### PR TITLE
Add tracked DEM provenance and QP101 highlight export

### DIFF
--- a/.AGENTS/AGENTS.md
+++ b/.AGENTS/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a Cargo workspace with two Rust crates and one Typst package. `rstim/` contains the simulator, CLI, code generators, QP101 export, and most circuit logic; key submodules live under `rstim/src/codegen/` and `rstim/src/sim/`. `rsinter/` builds analysis and reporting tools on top of `rstim`. Integration tests are organized by feature in `rstim/tests/` and `rsinter/tests/` with file names such as `cli_export_json.rs` or `dem_ir.rs`. `qp101-viz/` is a local Typst package: `lib.typ` is the entrypoint, `examples/` holds committed demos, and `checks/` holds renderer fixtures. Scratch material belongs in ignored paths like root `drafts/`, `qp101-viz/drafts/`, and `qp101-viz/draft_figs/`.
+
+## Build, Test, and Development Commands
+- `cargo build --workspace`: build both Rust crates.
+- `cargo test --workspace`: run the full Rust test suite.
+- `cargo test -p rstim --test qp101_highlights`: run one focused integration test file.
+- `cargo run -p rstim -- <subcommand>`: use the CLI locally, for example `cargo run -p rstim -- export_json --help`.
+- `cargo run -p rstim --example stim_parity_showcase`: reproduce the parity showcase from the README.
+- `make -C qp101-viz`: compile all committed Typst examples to PDFs.
+- `typst compile --root qp101-viz qp101-viz/examples/<file>.typ /tmp/out.pdf`: smoke-test one visualization example.
+
+## Coding Style & Naming Conventions
+Use Rust 2024 defaults and keep code `rustfmt`-clean with 4-space indentation. Prefer `snake_case` for functions, modules, files, and tests; use `CamelCase` for types. Name tests after behavior, not implementation, for example `qp101_export_marks_unambiguous_observable_symptom_highlights`. Keep CLI- and feature-specific tests in matching files (`cli_detect.rs`, `tracked_dem.rs`). In `qp101-viz`, keep `.typ` example names kebab-case and paired `.qp101.json` fixtures stable.
+
+## Testing Guidelines
+Every behavior change should update or add an integration test in the owning crate. Start with the narrowest useful command, then widen to crate- or workspace-level checks. For visualization work, compile at least one touched Typst example or check before claiming success. Do not commit scratch fixtures from ignored directories.
+
+## Commit & Pull Request Guidelines
+Recent commits use short imperative subjects, sometimes with prefixes such as `feat:`, `fix:`, or `docs:`. Follow that pattern and keep commits scoped to one subsystem when possible; avoid mixing `rstim` logic changes with `qp101-viz` asset churn unless they are directly linked. Pull requests should summarize behavior changes, list the exact verification commands run, and include a screenshot or generated PNG/PDF when renderer output changes.

--- a/.AGENTS/AGENTS.md
+++ b/.AGENTS/AGENTS.md
@@ -3,6 +3,9 @@
 ## Project Structure & Module Organization
 This repository is a Cargo workspace with two Rust crates and one Typst package. `rstim/` contains the simulator, CLI, code generators, QP101 export, and most circuit logic; key submodules live under `rstim/src/codegen/` and `rstim/src/sim/`. `rsinter/` builds analysis and reporting tools on top of `rstim`. Integration tests are organized by feature in `rstim/tests/` and `rsinter/tests/` with file names such as `cli_export_json.rs` or `dem_ir.rs`. `qp101-viz/` is a local Typst package: `lib.typ` is the entrypoint, `examples/` holds committed demos, and `checks/` holds renderer fixtures. Scratch material belongs in ignored paths like root `drafts/`, `qp101-viz/drafts/`, and `qp101-viz/draft_figs/`.
 
+## Agent Rules
+Use `.AGENTS/rules/visualization-update-flow.md` for the end-to-end sync process when QP101 export changes affect docs, fixtures, and Typst rendering. Use `.AGENTS/rules/QP101-ZY.md` for the narrower rule that treats `rstim/doc/QP101-ZY.md` as the format contract and lists the exact files that must be kept in sync with it.
+
 ## Build, Test, and Development Commands
 - `cargo build --workspace`: build both Rust crates.
 - `cargo test --workspace`: run the full Rust test suite.

--- a/.AGENTS/rules/QP101-ZY.md
+++ b/.AGENTS/rules/QP101-ZY.md
@@ -1,0 +1,42 @@
+# QP101-ZY Maintenance Rule
+
+## Purpose
+
+`rstim/doc/QP101-ZY.md` is the repository’s format contract for QP101-ZY JSON output. Exported JSON, tests, fixtures, and visualization code must stay aligned with it.
+
+## When `rstim/doc/QP101-ZY.md` must be updated
+
+- A top-level field is added, removed, or renamed
+- An `operations` `type` or field name changes
+- `annotations`, `style`, or `context` changes shape
+- The JSON structure for `detector`, `observable_include`, `noise`, or `repeat` changes
+- Field semantics change even if the field names stay the same
+
+## Required update order
+
+1. Change `rstim/src/qp101.rs`
+2. Update `rstim/doc/QP101-ZY.md`
+3. Update Rust tests and fixtures
+4. Update `qp101-viz`
+
+Do not skip step 2. The Typst package and committed examples should derive from the documented format, not from guesswork.
+
+## Matching Typst package update points
+
+When QP101-ZY output changes, review these files first:
+
+- `qp101-viz/lib.typ`
+- `qp101-viz/README.md`
+- `qp101-viz/examples/*.qp101.json`
+- `qp101-viz/checks/*.qp101.json`
+
+`lib.typ` is the primary renderer sync point. Examples and checks prove that the new format still renders correctly.
+
+## Pre-commit verification
+
+```sh
+cargo test -p rstim --test qp101_export --test qp101_fixtures --test cli_export_json
+typst compile --root qp101-viz qp101-viz/examples/<example>.typ /tmp/out.pdf
+```
+
+If the renderer output changed, include an updated PNG or PDF in the PR or review notes.

--- a/.AGENTS/rules/visualization-update-flow.md
+++ b/.AGENTS/rules/visualization-update-flow.md
@@ -1,0 +1,57 @@
+# Visualization Update Flow
+
+## Scope
+
+Follow this process whenever `rstim export_json` changes the QP101-ZY JSON shape or semantics.
+
+## 1. Update Rust output first
+
+- Core exporter: `rstim/src/qp101.rs`
+- CLI export path: `rstim/src/cli.rs`
+- Provenance and highlight metadata when relevant: `rstim/src/dem_provenance.rs`
+
+Stabilize the emitted JSON before touching docs, fixtures, or Typst rendering.
+
+## 2. Update the JSON format documentation
+
+- The format reference lives in `rstim/doc/QP101-ZY.md`.
+- Update it for any added, removed, renamed, or reinterpreted field.
+- Do not update tests and examples without updating the format document.
+
+## 3. Update Rust tests and fixtures
+
+- Structure tests: `rstim/tests/qp101_export.rs`
+- CLI export tests: `rstim/tests/cli_export_json.rs`
+- Fixture parity tests: `rstim/tests/qp101_fixtures.rs`
+- Stored fixtures: `rstim/tests/fixtures/qp101/`
+
+If the JSON changes, tests and fixtures must move together.
+
+## 4. Update the Typst visualization package
+
+- Renderer entrypoint: `qp101-viz/lib.typ`
+- Package docs: `qp101-viz/README.md`
+- Committed examples: `qp101-viz/examples/`
+- Render checks: `qp101-viz/checks/`
+
+Any change to `type`, `annotations`, `raw_targets`, `target_slots`, `context`, `detector`, or `observable_include` requires a review of the corresponding field reads in `qp101-viz/lib.typ`.
+
+## 5. Minimum verification
+
+Run:
+
+```sh
+cargo test -p rstim --test qp101_export --test qp101_fixtures --test cli_export_json
+```
+
+Then compile at least one affected Typst example:
+
+```sh
+typst compile --root qp101-viz qp101-viz/examples/<example>.typ /tmp/out.pdf
+```
+
+If renderer behavior changed, also run:
+
+```sh
+make -C qp101-viz
+```

--- a/docs/superpowers/plans/2026-04-02-dem-provenance-tracking-plan.md
+++ b/docs/superpowers/plans/2026-04-02-dem-provenance-tracking-plan.md
@@ -1,0 +1,853 @@
+# DEM Provenance Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in tracked DEM analysis path that preserves exact circuit-source provenance through merge and decomposition, and export DEM-origin query results as QP101 JSON highlights.
+
+**Architecture:** Keep the existing `DetectorErrorModel` and default `circuit_to_dem` path unchanged. Introduce a tracked analysis result with its own source table and bidirectional indices, teach the analyzer and decomposition pipeline to carry provenance in opt-in mode, then expose the queried origins through a QP101 `extensions.rstim_query_highlights` payload and an explicit CLI flag on `export_json`.
+
+**Tech Stack:** Rust, `serde` / `serde_json`, existing `clap` CLI, existing `rstim` DEM analyzer and QP101 exporter, Rust integration tests via `cargo test`
+
+---
+
+## File Structure
+
+- Create: `rstim/src/dem_provenance.rs`
+  - Own tracked data structures shared by analysis and export: `SourceId`, `DemErrorId`, `SourceBranch`, `TrackedSource`, `TrackedErrorTerm`, `TrackedDemResult`, highlight-export structs, and small helper methods for reverse-index construction.
+- Modify: `rstim/src/lib.rs`
+  - Re-export the new provenance module.
+- Modify: `rstim/src/error_analyzer.rs`
+  - Add tracked analyzer entry points, recursive repeat-aware traversal, tracked source emission helpers, tracked merge support, and tracked decomposition support.
+- Modify: `rstim/src/qp101.rs`
+  - Add a helper that exports a base QP101 document plus `extensions.rstim_query_highlights`.
+- Modify: `rstim/src/cli.rs`
+  - Add an explicit `--highlight_dem_error <INDEX>` flag to `export_json` and route that path through tracked analysis.
+- Create: `rstim/tests/tracked_dem.rs`
+  - Focused provenance tests for source emission, repeat tracking, merge behavior, and reverse indices.
+- Create: `rstim/tests/qp101_highlights.rs`
+  - JSON-shape tests for highlight extension payloads.
+- Modify: `rstim/tests/cli_export_json.rs`
+  - CLI tests for the explicit export flag and invalid query handling.
+- Modify: `rstim/doc/QP101-ZY.md`
+  - Document the `extensions.rstim_query_highlights` extension after the implementation stabilizes.
+
+### Task 1: Add Tracked Provenance Core Types
+
+**Files:**
+- Create: `rstim/src/dem_provenance.rs`
+- Modify: `rstim/src/lib.rs`
+- Test: `rstim/tests/tracked_dem.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a focused serialization and index-construction test to `rstim/tests/tracked_dem.rs`:
+
+```rust
+use rstim::dem::DemTarget;
+use rstim::dem_provenance::{
+    SourceBranch, TrackedDemResult, TrackedErrorTerm, TrackedSource,
+};
+
+#[test]
+fn tracked_result_builds_reverse_indices() {
+    let sources = vec![
+        TrackedSource {
+            source_id: 0,
+            op_path: vec![3, 1],
+            repeat_iterations: vec![2],
+            instr_name: "DEPOLARIZE1".to_string(),
+            target_slots: vec![0],
+            target_qubits: vec![5],
+            branch: SourceBranch::Y,
+            probability_fragment: 0.125,
+        },
+        TrackedSource {
+            source_id: 1,
+            op_path: vec![3, 1],
+            repeat_iterations: vec![2],
+            instr_name: "DEPOLARIZE1".to_string(),
+            target_slots: vec![1],
+            target_qubits: vec![7],
+            branch: SourceBranch::X,
+            probability_fragment: 0.125,
+        },
+    ];
+    let dem_terms = vec![
+        TrackedErrorTerm {
+            probability: 0.2,
+            targets: vec![DemTarget::Detector(0)],
+            source_ids: vec![0],
+        },
+        TrackedErrorTerm {
+            probability: 0.3,
+            targets: vec![DemTarget::Detector(1)],
+            source_ids: vec![0, 1],
+        },
+    ];
+
+    let result = TrackedDemResult::from_terms_and_sources(sources, dem_terms);
+
+    assert_eq!(result.dem_error_to_sources[0], vec![0]);
+    assert_eq!(result.dem_error_to_sources[1], vec![0, 1]);
+    assert_eq!(result.source_to_dem_errors[0], vec![0, 1]);
+    assert_eq!(result.source_to_dem_errors[1], vec![1]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rstim tracked_result_builds_reverse_indices --test tracked_dem`
+
+Expected: FAIL with an unresolved import for `rstim::dem_provenance` or missing types such as `TrackedDemResult`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `rstim/src/dem_provenance.rs` with the initial tracked types and reverse-index builder:
+
+```rust
+use crate::dem::{DemTarget, DetectorErrorModel};
+use serde::{Deserialize, Serialize};
+
+pub type SourceId = usize;
+pub type DemErrorId = usize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SourceBranch {
+    X,
+    Y,
+    Z,
+    XX,
+    XY,
+    XZ,
+    YX,
+    YY,
+    YZ,
+    ZX,
+    ZY,
+    ZZ,
+    MeasurementFlip,
+    CorrelatedBranch { index: usize },
+    Custom { label: String },
+}
+
+impl SourceBranch {
+    pub fn label(&self) -> String {
+        match self {
+            SourceBranch::X => "X".to_string(),
+            SourceBranch::Y => "Y".to_string(),
+            SourceBranch::Z => "Z".to_string(),
+            SourceBranch::XX => "XX".to_string(),
+            SourceBranch::XY => "XY".to_string(),
+            SourceBranch::XZ => "XZ".to_string(),
+            SourceBranch::YX => "YX".to_string(),
+            SourceBranch::YY => "YY".to_string(),
+            SourceBranch::YZ => "YZ".to_string(),
+            SourceBranch::ZX => "ZX".to_string(),
+            SourceBranch::ZY => "ZY".to_string(),
+            SourceBranch::ZZ => "ZZ".to_string(),
+            SourceBranch::MeasurementFlip => "M".to_string(),
+            SourceBranch::CorrelatedBranch { index } => format!("E{index}"),
+            SourceBranch::Custom { label } => label.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TrackedSource {
+    pub source_id: SourceId,
+    pub op_path: Vec<usize>,
+    pub repeat_iterations: Vec<u64>,
+    pub instr_name: String,
+    pub target_slots: Vec<usize>,
+    pub target_qubits: Vec<u32>,
+    pub branch: SourceBranch,
+    pub probability_fragment: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackedErrorTerm {
+    pub probability: f64,
+    pub targets: Vec<DemTarget>,
+    pub source_ids: Vec<SourceId>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackedDemResult {
+    pub dem: DetectorErrorModel,
+    pub sources: Vec<TrackedSource>,
+    pub dem_error_to_sources: Vec<Vec<SourceId>>,
+    pub source_to_dem_errors: Vec<Vec<DemErrorId>>,
+}
+
+impl TrackedDemResult {
+    pub fn from_terms_and_sources(
+        sources: Vec<TrackedSource>,
+        terms: Vec<TrackedErrorTerm>,
+    ) -> Self {
+        let mut dem = DetectorErrorModel::new();
+        let mut dem_error_to_sources = Vec::with_capacity(terms.len());
+        for term in terms {
+            dem.add_error(term.probability, term.targets);
+            dem_error_to_sources.push(term.source_ids);
+        }
+        let mut source_to_dem_errors = vec![Vec::new(); sources.len()];
+        for (dem_error_id, source_ids) in dem_error_to_sources.iter().enumerate() {
+            for &source_id in source_ids {
+                source_to_dem_errors[source_id].push(dem_error_id);
+            }
+        }
+        Self {
+            dem,
+            sources,
+            dem_error_to_sources,
+            source_to_dem_errors,
+        }
+    }
+}
+```
+
+Expose the module from `rstim/src/lib.rs`:
+
+```rust
+pub mod dem_provenance;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rstim tracked_result_builds_reverse_indices --test tracked_dem`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rstim/src/dem_provenance.rs rstim/src/lib.rs rstim/tests/tracked_dem.rs
+git commit -m "feat: add tracked DEM provenance core types"
+```
+
+### Task 2: Add Repeat-Aware Tracked Traversal And Source Emission
+
+**Files:**
+- Modify: `rstim/src/error_analyzer.rs`
+- Test: `rstim/tests/tracked_dem.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `rstim/tests/tracked_dem.rs` with a repeat-aware single-source test:
+
+```rust
+use rstim::error_analyzer::ErrorAnalyzer;
+use rstim::parser::parse_lines;
+
+#[test]
+fn tracked_dem_records_repeat_iteration_target_slot_and_branch() {
+    let circuit = parse_lines(
+        "REPEAT 2 {\n  DEPOLARIZE1(0.3) 5 7\n  TICK\n}\nM 5 7\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+    let source = tracked
+        .sources
+        .iter()
+        .find(|source| {
+            source.repeat_iterations == vec![1]
+                && source.target_slots == vec![1]
+                && source.branch.label() == "Y"
+        })
+        .unwrap();
+
+    assert_eq!(source.op_path, vec![0, 0]);
+    assert_eq!(source.target_qubits, vec![7]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rstim tracked_dem_records_repeat_iteration_target_slot_and_branch --test tracked_dem`
+
+Expected: FAIL because `ErrorAnalyzer::circuit_to_tracked_dem` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `rstim/src/error_analyzer.rs`, add tracked entry points and a repeat-aware recursive traversal context instead of using the flatten-first path:
+
+```rust
+use crate::dem_provenance::{SourceBranch, SourceId, TrackedDemResult, TrackedErrorTerm, TrackedSource};
+
+#[derive(Debug, Clone, Default)]
+struct TrackingContext {
+    op_path: Vec<usize>,
+    repeat_iterations: Vec<u64>,
+}
+
+impl ErrorAnalyzer {
+    pub fn circuit_to_tracked_dem(instrs: &[StimInstr]) -> Result<TrackedDemResult, String> {
+        Self::circuit_to_tracked_dem_with_options(instrs, AnalyzeOptions::default())
+    }
+
+    pub fn circuit_to_tracked_dem_with_options(
+        instrs: &[StimInstr],
+        options: AnalyzeOptions,
+    ) -> Result<TrackedDemResult, String> {
+        let mut analyzer = Self::new_tracked(instrs, options)?;
+        analyzer.undo_circuit_tracked(instrs, &mut TrackingContext::default())?;
+        analyzer.finish_tracked_result()
+    }
+
+    fn undo_circuit_tracked(
+        &mut self,
+        instrs: &[StimInstr],
+        ctx: &mut TrackingContext,
+    ) -> Result<(), String> {
+        for (op_index, instr) in instrs.iter().enumerate().rev() {
+            ctx.op_path.push(op_index);
+            match instr {
+                StimInstr::Repeat { count, body } => {
+                    for iter in (0..*count).rev() {
+                        ctx.repeat_iterations.push(iter);
+                        self.undo_circuit_tracked(body, ctx)?;
+                        ctx.repeat_iterations.pop();
+                    }
+                }
+                StimInstr::Op { name, args, targets, .. } => {
+                    self.undo_op_tracked(name, args, targets, ctx)?;
+                }
+            }
+            ctx.op_path.pop();
+        }
+        Ok(())
+    }
+
+    fn emit_tracked_source(
+        &mut self,
+        ctx: &TrackingContext,
+        instr_name: &str,
+        target_slots: Vec<usize>,
+        target_qubits: Vec<u32>,
+        branch: SourceBranch,
+        probability_fragment: f64,
+        targets: Vec<DemTarget>,
+    ) {
+        let source_id = self.tracked_sources.len();
+        self.tracked_sources.push(TrackedSource {
+            source_id,
+            op_path: ctx.op_path.iter().rev().copied().collect(),
+            repeat_iterations: ctx.repeat_iterations.iter().rev().copied().collect(),
+            instr_name: instr_name.to_string(),
+            target_slots,
+            target_qubits,
+            branch,
+            probability_fragment,
+        });
+        self.tracked_terms.push(TrackedErrorTerm {
+            probability: probability_fragment,
+            targets,
+            source_ids: vec![source_id],
+        });
+    }
+}
+```
+
+Wire `DEPOLARIZE1` and measurement noise through this helper first. Keep the old non-tracked emission path intact.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rstim tracked_dem_records_repeat_iteration_target_slot_and_branch --test tracked_dem`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rstim/src/error_analyzer.rs rstim/tests/tracked_dem.rs
+git commit -m "feat: add repeat-aware tracked DEM traversal"
+```
+
+### Task 3: Preserve Provenance Through Merge And Canonicalization
+
+**Files:**
+- Modify: `rstim/src/error_analyzer.rs`
+- Test: `rstim/tests/tracked_dem.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a merge-precision test:
+
+```rust
+#[test]
+fn tracked_dem_merge_keeps_exact_source_union() {
+    let circuit = parse_lines(
+        "R 0\nX_ERROR(0.1) 0\nX_ERROR(0.2) 0\nM 0\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    assert_eq!(tracked.dem.instructions().len(), 1);
+    assert_eq!(tracked.dem_error_to_sources.len(), 1);
+    assert_eq!(tracked.dem_error_to_sources[0].len(), 2);
+    assert_eq!(tracked.source_to_dem_errors[0], vec![0]);
+    assert_eq!(tracked.source_to_dem_errors[1], vec![0]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rstim tracked_dem_merge_keeps_exact_source_union --test tracked_dem`
+
+Expected: FAIL because the tracked path still emits duplicate final terms instead of a merged provenance set.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Teach the tracked finalizer in `rstim/src/error_analyzer.rs` to merge terms by canonicalized target set while unioning source ids:
+
+```rust
+use std::collections::BTreeMap;
+
+fn merge_tracked_terms(terms: Vec<TrackedErrorTerm>) -> Vec<TrackedErrorTerm> {
+    let mut merged: BTreeMap<Vec<DemTarget>, (f64, Vec<SourceId>)> = BTreeMap::new();
+    for term in terms.into_iter().rev() {
+        if term.probability <= 0.0 || term.targets.is_empty() {
+            continue;
+        }
+        let key = canonicalize_error_targets(&term.targets);
+        merged
+            .entry(key)
+            .and_modify(|(existing_prob, existing_sources)| {
+                *existing_prob = *existing_prob + term.probability
+                    - 2.0 * *existing_prob * term.probability;
+                for source_id in &term.source_ids {
+                    if !existing_sources.contains(source_id) {
+                        existing_sources.push(*source_id);
+                    }
+                }
+                existing_sources.sort_unstable();
+            })
+            .or_insert_with(|| {
+                let mut source_ids = term.source_ids;
+                source_ids.sort_unstable();
+                source_ids.dedup();
+                (term.probability, source_ids)
+            });
+    }
+
+    merged
+        .into_iter()
+        .map(|(targets, (probability, source_ids))| TrackedErrorTerm {
+            probability,
+            targets,
+            source_ids,
+        })
+        .collect()
+}
+```
+
+Use this helper inside `finish_tracked_result()` before constructing `TrackedDemResult`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rstim tracked_dem_merge_keeps_exact_source_union --test tracked_dem`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rstim/src/error_analyzer.rs rstim/tests/tracked_dem.rs
+git commit -m "feat: preserve provenance through DEM merge"
+```
+
+### Task 4: Preserve Provenance Through Decomposition
+
+**Files:**
+- Modify: `rstim/src/error_analyzer.rs`
+- Test: `rstim/tests/tracked_dem.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a decomposition-specific provenance test:
+
+```rust
+#[test]
+fn tracked_dem_decomposition_keeps_reverse_links() {
+    let circuit = parse_lines(
+        "R 0 1 2\nX_ERROR(0.1) 0\nCX 0 1\nCX 1 2\nM 0 1 2\nDETECTOR rec[-3]\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem_decomposed(&circuit).unwrap();
+
+    let dem_ids = &tracked.source_to_dem_errors[0];
+    assert!(!dem_ids.is_empty());
+    for &dem_id in dem_ids {
+        assert!(tracked.dem_error_to_sources[dem_id].contains(&0));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rstim tracked_dem_decomposition_keeps_reverse_links --test tracked_dem`
+
+Expected: FAIL because the tracked decomposed API does not exist or decomposition drops provenance.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add tracked decomposed entry points and a tracked decomposition helper in `rstim/src/error_analyzer.rs`:
+
+```rust
+impl ErrorAnalyzer {
+    pub fn circuit_to_tracked_dem_decomposed(
+        instrs: &[StimInstr],
+    ) -> Result<TrackedDemResult, String> {
+        let mut tracked = Self::circuit_to_tracked_dem(instrs)?;
+        decompose_tracked_terms(&mut tracked)?;
+        Ok(tracked)
+    }
+}
+
+fn decompose_tracked_terms(tracked: &mut TrackedDemResult) -> Result<(), String> {
+    let mut rewritten_terms = Vec::new();
+    for (dem_error_id, instr) in tracked.dem.instructions().iter().enumerate() {
+        let DemInstruction::Error { probability, targets } = instr else {
+            continue;
+        };
+        let rewritten_targets = rewrite_targets_to_graphlike(targets)?;
+        rewritten_terms.push(TrackedErrorTerm {
+            probability: *probability,
+            targets: rewritten_targets,
+            source_ids: tracked.dem_error_to_sources[dem_error_id].clone(),
+        });
+    }
+    let merged_terms = merge_tracked_terms(rewritten_terms);
+    let sources = tracked.sources.clone();
+    *tracked = TrackedDemResult::from_terms_and_sources(sources, merged_terms);
+    Ok(())
+}
+```
+
+Reuse the same target-rewrite logic as the existing `decompose_errors`, but keep `source_ids` attached to each term throughout the rewrite and re-merge.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rstim tracked_dem_decomposition_keeps_reverse_links --test tracked_dem`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rstim/src/error_analyzer.rs rstim/tests/tracked_dem.rs
+git commit -m "feat: preserve provenance through DEM decomposition"
+```
+
+### Task 5: Export Highlighted QP101 Documents
+
+**Files:**
+- Modify: `rstim/src/dem_provenance.rs`
+- Modify: `rstim/src/qp101.rs`
+- Test: `rstim/tests/qp101_highlights.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rstim/tests/qp101_highlights.rs` with an export-shape test:
+
+```rust
+use rstim::error_analyzer::ErrorAnalyzer;
+use rstim::parser::parse_lines;
+use rstim::qp101::export_qp101_with_highlighted_dem_error;
+
+#[test]
+fn qp101_export_includes_dem_origin_highlights() {
+    let circuit = parse_lines(
+        "REPEAT 2 {\n  DEPOLARIZE1(0.3) 5 7\n}\nM 5 7\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    let doc = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 0).unwrap();
+    let value = serde_json::to_value(doc).unwrap();
+
+    assert_eq!(value["extensions"]["rstim_query_highlights"]["query"]["kind"], "dem_error_origin");
+    assert_eq!(value["extensions"]["rstim_query_highlights"]["highlights"][0]["target_slots"], serde_json::json!([0]));
+    assert!(value["extensions"]["rstim_query_highlights"]["highlights"][0]["repeat_iterations"].is_array());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rstim qp101_export_includes_dem_origin_highlights --test qp101_highlights`
+
+Expected: FAIL with missing `export_qp101_with_highlighted_dem_error`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add highlight-export structs to `rstim/src/dem_provenance.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HighlightRecord {
+    pub op_path: Vec<usize>,
+    pub repeat_iterations: Vec<u64>,
+    pub target_slots: Vec<usize>,
+    pub target_qubits: Vec<u32>,
+    pub branch: String,
+    pub label: String,
+}
+
+impl HighlightRecord {
+    pub fn from_source(source: &TrackedSource) -> Self {
+        let label = source.branch.label();
+        Self {
+            op_path: source.op_path.clone(),
+            repeat_iterations: source.repeat_iterations.clone(),
+            target_slots: source.target_slots.clone(),
+            target_qubits: source.target_qubits.clone(),
+            branch: label.clone(),
+            label,
+        }
+    }
+}
+```
+
+Add the export helper to `rstim/src/qp101.rs`:
+
+```rust
+use crate::dem_provenance::{HighlightRecord, TrackedDemResult};
+use serde_json::json;
+
+pub fn export_qp101_with_highlighted_dem_error(
+    instrs: &[StimInstr],
+    tracked: &TrackedDemResult,
+    dem_error_index: usize,
+) -> Result<Qp101Document, String> {
+    let source_ids = tracked
+        .dem_error_to_sources
+        .get(dem_error_index)
+        .ok_or_else(|| format!("DEM error index out of range: {dem_error_index}"))?;
+
+    let mut highlights = Vec::new();
+    for &source_id in source_ids {
+        highlights.push(HighlightRecord::from_source(&tracked.sources[source_id]));
+    }
+
+    let mut doc = export_qp101(instrs)?;
+    doc.extensions = Some(json!({
+        "rstim_query_highlights": {
+            "version": "1",
+            "query": {
+                "kind": "dem_error_origin",
+                "dem_error_index": dem_error_index,
+            },
+            "highlights": highlights,
+        }
+    }));
+    Ok(doc)
+}
+```
+
+Add a small dedup pass over `highlights` keyed by `op_path`, `repeat_iterations`, `target_slots`, and `branch` before writing them into the document.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rstim qp101_export_includes_dem_origin_highlights --test qp101_highlights`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rstim/src/dem_provenance.rs rstim/src/qp101.rs rstim/tests/qp101_highlights.rs
+git commit -m "feat: export DEM-origin highlights in QP101"
+```
+
+### Task 6: Add Explicit CLI Query Export
+
+**Files:**
+- Modify: `rstim/src/cli.rs`
+- Modify: `rstim/tests/cli_export_json.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `rstim/tests/cli_export_json.rs`:
+
+```rust
+#[test]
+fn export_json_can_highlight_dem_error_origins() {
+    let output = run_export_json_with_stdin(
+        &["--highlight_dem_error", "0"],
+        "REPEAT 2 {\n  DEPOLARIZE1(0.3) 5 7\n}\nM 5 7\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        value["extensions"]["rstim_query_highlights"]["query"]["dem_error_index"],
+        0
+    );
+}
+
+#[test]
+fn export_json_rejects_invalid_highlight_dem_error_index() {
+    let output = run_export_json_with_stdin(
+        &["--highlight_dem_error", "99"],
+        "X_ERROR(0.1) 0\nM 0\nDETECTOR rec[-1]\n",
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("DEM error index out of range"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rstim --test cli_export_json export_json_can_highlight_dem_error_origins`
+
+Expected: FAIL because `export_json` does not accept `--highlight_dem_error`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `rstim/src/cli.rs`, extend the command shape and export path:
+
+```rust
+#[command(name = "export_json")]
+ExportJson {
+    #[arg(long = "in")]
+    r#in: Option<String>,
+    #[arg(long)]
+    out: Option<String>,
+    #[arg(long, default_value = "pretty")]
+    format: String,
+    #[arg(long = "highlight_dem_error")]
+    highlight_dem_error: Option<usize>,
+},
+```
+
+Update the runner:
+
+```rust
+fn run_export_json(
+    text: &str,
+    format: JsonOutputFormat,
+    highlight_dem_error: Option<usize>,
+    w: &mut dyn Write,
+) -> Result<(), String> {
+    let instrs = parse_lines(text)?;
+    let doc = if let Some(dem_error_index) = highlight_dem_error {
+        let tracked = crate::error_analyzer::ErrorAnalyzer::circuit_to_tracked_dem(&instrs)?;
+        crate::qp101::export_qp101_with_highlighted_dem_error(
+            &instrs,
+            &tracked,
+            dem_error_index,
+        )?
+    } else {
+        crate::qp101::export_qp101(&instrs)?
+    };
+
+    match format {
+        JsonOutputFormat::Pretty => serde_json::to_writer_pretty(&mut *w, &doc)
+            .map_err(|e| format!("write error: {e}"))?,
+        JsonOutputFormat::Compact => serde_json::to_writer(&mut *w, &doc)
+            .map_err(|e| format!("write error: {e}"))?,
+    }
+    w.write_all(b"\n").map_err(|e| format!("write error: {e}"))?;
+    Ok(())
+}
+```
+
+Keep the default path byte-for-byte equivalent when `highlight_dem_error` is `None`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rstim --test cli_export_json export_json_can_highlight_dem_error_origins export_json_rejects_invalid_highlight_dem_error_index`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rstim/src/cli.rs rstim/tests/cli_export_json.rs
+git commit -m "feat: add CLI export for DEM-origin highlights"
+```
+
+### Task 7: Update The QP101 Extension Documentation
+
+**Files:**
+- Modify: `rstim/doc/QP101-ZY.md`
+- Test: none
+
+- [ ] **Step 1: Write the doc diff**
+
+Add a new subsection under the top-level `extensions` discussion in `rstim/doc/QP101-ZY.md`:
+
+```markdown
+## rstim Query Highlight Extension
+
+`rstim` may attach query-specific visualization metadata under
+`extensions.rstim_query_highlights`.
+
+This extension is not part of the generic QP101 core schema. It preserves
+query results such as "which circuit-side noise sources produced DEM error
+line N" without mutating the base circuit structure.
+
+Example:
+
+~~~json
+{
+  "extensions": {
+    "rstim_query_highlights": {
+      "version": "1",
+      "query": {
+        "kind": "dem_error_origin",
+        "dem_error_index": 17
+      },
+      "highlights": [
+        {
+          "op_path": [12, 3, 5],
+          "repeat_iterations": [4, 2],
+          "target_slots": [1],
+          "target_qubits": [5],
+          "branch": "Y",
+          "label": "Y"
+        }
+      ]
+    }
+  }
+}
+~~~
+```
+
+- [ ] **Step 2: Review the rendered section for consistency**
+
+Run: `sed -n '1,260p' rstim/doc/QP101-ZY.md`
+
+Expected: the new extension section uses `target_slots`, matches the implementation, and does not redefine the QP101 core schema.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rstim/doc/QP101-ZY.md
+git commit -m "docs: describe rstim query highlight extension"
+```
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - tracked core types: Tasks 1-2
+  - merge and decomposition preservation: Tasks 3-4
+  - QP101 highlight export: Task 5
+  - explicit opt-in CLI path: Task 6
+  - extension documentation: Task 7
+- Placeholder scan:
+  - no placeholder markers remain
+  - every code-writing step includes concrete code blocks
+  - every verification step includes an exact command and expected result
+- Type consistency:
+  - `target_slots` is used consistently in tracked types, JSON export, and docs
+  - `SourceBranch::label()` is the single display-label source
+  - `export_qp101_with_highlighted_dem_error(...)` remains the only QP101 helper that injects query metadata

--- a/docs/superpowers/specs/2026-04-02-dem-provenance-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-02-dem-provenance-tracking-design.md
@@ -1,0 +1,381 @@
+# DEM Provenance Tracking Design
+
+Date: 2026-04-02
+Status: Proposed
+Scope: `rstim`
+
+## Summary
+
+This design adds an opt-in provenance-tracking analysis path to `rstim` so users can query the precise relationship between circuit-side error sources and final DEM error lines in both directions:
+
+- given a circuit noise source, find the final DEM error lines it contributes to
+- given a DEM error line, find the exact circuit-side noise sources that produced it
+
+The tracked path must preserve provenance through:
+
+- nested `REPEAT` structure and concrete repeat iterations
+- per-instruction target slots
+- per-source branch identity such as `X`, `Y`, `Z`, `XY`, `ZZ`, measurement flips, and correlated-error branches
+- DEM target canonicalization
+- graphlike decomposition and post-decomposition merging
+
+The default DEM generation path remains unchanged and does not pay the runtime or memory cost of provenance tracking.
+
+## Goals
+
+- Preserve exact many-to-many provenance between circuit-side error sources and final DEM error lines.
+- Support source precision at the level of repeat instance, instruction position, target slot, and branch label.
+- Export query results as a QP101 document with additional highlight metadata suitable for downstream visualization.
+- Keep the existing `circuit_to_dem` and `export_json` behavior unchanged unless the tracked path is explicitly requested.
+
+## Non-Goals
+
+- Do not add provenance storage to the default `DetectorErrorModel`.
+- Do not require parser text spans or source line numbers in the first version.
+- Do not solve per-component provenance inside a single final DEM line beyond the line-level mapping.
+- Do not redesign the generic QP101 core schema for all tools; the query payload is an `rstim` extension.
+
+## Current State
+
+The current implementation in [`rstim/src/error_analyzer.rs`](/Users/nzy/rcode/rstim/rstim/src/error_analyzer.rs) loses source information in two places:
+
+1. Raw circuit-side errors are collected as bare `(probability, targets)` tuples and then merged by canonicalized target set before the final `DetectorErrorModel` is built.
+2. `decompose_errors` rewrites non-graphlike error targets and then merges again, without preserving any circuit-side identity.
+
+As a result, `rstim` can currently support DEM-side explanation based on final DEM lines, but it cannot answer precise source-to-DEM questions after merges and decompositions.
+
+## Requirements
+
+### Functional Requirements
+
+- The tracked path must preserve exact source identity from emission to final DEM output.
+- Each tracked source must distinguish:
+  - static operation path inside nested `REPEAT` bodies
+  - dynamic repeat iteration path
+  - target slot
+  - branch label
+- Queries must support:
+  - `dem_error -> [source]`
+  - `source -> [dem_error]`
+- Query export must produce a QP101 JSON document whose base circuit content matches the normal export, with added highlight metadata for the queried sources.
+
+### Performance Requirements
+
+- Provenance tracking must be opt-in.
+- The default DEM generation path must remain lightweight and should not allocate provenance structures.
+- The tracked path may consume additional memory proportional to the number of emitted raw error sources and final merged provenance links.
+
+## Recommended Architecture
+
+Add a separate tracked-analysis pipeline instead of extending the default pipeline in place.
+
+### Public API Shape
+
+Keep the current API:
+
+- `ErrorAnalyzer::circuit_to_dem(...) -> Result<DetectorErrorModel, String>`
+
+Add tracked variants:
+
+- `ErrorAnalyzer::circuit_to_tracked_dem(...) -> Result<TrackedDemResult, String>`
+- `ErrorAnalyzer::circuit_to_tracked_dem_with_options(...) -> Result<TrackedDemResult, String>`
+- query-oriented helper APIs as needed for exporting highlight JSON
+
+The tracked result owns:
+
+- the final `DetectorErrorModel`
+- the tracked source table
+- the forward and reverse provenance indices
+
+### Core Types
+
+#### `TrackedSource`
+
+Represents one precise circuit-side error source. This is finer-grained than a `StimInstr`.
+
+Required fields:
+
+- `source_id`
+- `op_path: Vec<usize>`
+- `repeat_iterations: Vec<u64>`
+- `instr_name: String`
+- `target_slots: Vec<usize>`
+- `target_qubits: Vec<u32>`
+- `branch: SourceBranch`
+- `probability_fragment: f64`
+
+Optional fields may be added later for debugging, such as raw DEM targets or parser spans.
+
+#### `SourceBranch`
+
+Internal enum describing the branch identity of a source.
+
+The first version should cover at least:
+
+- `X`
+- `Y`
+- `Z`
+- two-qubit Pauli branches such as `XX`, `XY`, `XZ`, `YX`, `YY`, `YZ`, `ZX`, `ZY`, `ZZ`
+- `MeasurementFlip`
+- `CorrelatedBranch { index }`
+- `Custom { label }`
+
+#### `TrackedErrorTerm`
+
+Tracked version of the current internal `(probability, targets)` item.
+
+Required fields:
+
+- `probability: f64`
+- `targets: Vec<DemTarget>`
+- `source_ids: Vec<SourceId>`
+
+Semantics:
+
+- This is an intermediate analyzer artifact.
+- It represents one current DEM-side error term together with the exact set of circuit-side sources that flow into it.
+
+#### `TrackedDemResult`
+
+Required fields:
+
+- `dem: DetectorErrorModel`
+- `sources: Vec<TrackedSource>`
+- `dem_error_to_sources: Vec<Vec<SourceId>>`
+- `source_to_dem_errors: Vec<Vec<DemErrorId>>`
+
+The `dem_error_to_sources` table indexes only final `error(...)` instructions, not detector annotations or other DEM instructions.
+
+## Traversal Strategy
+
+Tracked mode must not depend on the current flatten-first path for `REPEAT`.
+
+### Why flattening is insufficient
+
+The tracked feature must return both:
+
+- the static operation location inside nested `REPEAT` bodies
+- the dynamic repeat instance path for the concrete source occurrence
+
+Flattening preserves neither cleanly. It replaces hierarchical structure with a linear stream, which makes it impossible to recover a stable `repeat[outer] -> repeat[inner] -> operation` identity for downstream visualization.
+
+### Tracked traversal model
+
+Use a recursive traversal that maintains:
+
+- `op_path`: array indices through nested `operations` and `repeat.body`
+- `repeat_iterations`: the concrete iteration chosen at each nested `REPEAT`
+
+Every source emitted during analysis captures both vectors.
+
+## Source Emission Rules
+
+All source creation must flow through shared tracked helpers. The tracked path must not directly append bare `(probability, targets)` tuples.
+
+### Emission invariant
+
+At the moment a raw circuit-side source is emitted:
+
+1. create one `TrackedSource`
+2. assign a stable `source_id`
+3. create one or more `TrackedErrorTerm` values whose `source_ids` initially contain only that `source_id`
+
+This is the only stage where new provenance identities are created. Later stages only transform or merge existing provenance.
+
+### Target-slot precision
+
+For operations with multiple targets, tracked emission must record the exact target slots that caused the source.
+
+Examples:
+
+- `DEPOLARIZE1(p) 3 5` can emit separate sources for slot `[0]` and slot `[1]`
+- `PAULI_CHANNEL_2(...) 4 7` records the slot pair `[0, 1]` associated with the two-qubit branch
+- measurement noise records the measurement site that produced the source
+
+### Branch precision
+
+Operations that expand into multiple branches must produce source records with explicit `SourceBranch` values.
+
+Examples:
+
+- `DEPOLARIZE1` emits `X`, `Y`, `Z`
+- `DEPOLARIZE2` emits two-qubit Pauli branches
+- correlated error blocks can emit `CorrelatedBranch { index }`
+
+## Merging And Canonicalization
+
+The tracked path keeps the current probability semantics for merged DEM targets, but it must also preserve source identity.
+
+### Raw merge
+
+Current merge key:
+
+- canonicalized `Vec<DemTarget>`
+
+Tracked merge value:
+
+- merged probability
+- union of `source_ids`
+
+If multiple independent circuit-side sources end up with the same target set, the final merged DEM line records all of them in its provenance set.
+
+### Canonicalization rule
+
+Target canonicalization continues to normalize ordering and separator layout exactly as it does today. Provenance is not part of the key; it is carried in the merge value.
+
+## Decomposition Strategy
+
+`decompose_errors` must gain a tracked equivalent or an internal tracked mode.
+
+### Required semantics
+
+When a non-graphlike term is rewritten into graphlike components:
+
+- the rewritten term inherits the original term's `source_ids`
+- no new `source_id` values are created during decomposition
+- later merge steps union provenance sets when rewritten targets collapse to the same final DEM line
+
+This preserves exact line-level many-to-many provenance.
+
+### Precision boundary
+
+The first version guarantees exact mapping at the final DEM error-line level:
+
+- exact `source -> final DEM lines`
+- exact `final DEM line -> sources`
+
+It does not guarantee separate provenance for each `^`-separated component inside a single final DEM line. This is acceptable for the intended visualization workflow because the rendering only needs to highlight circuit-side source locations for a queried DEM line.
+
+## QP101 Highlight Export
+
+The base QP101 document remains structurally identical to the normal export. Query results are attached through a top-level extension block.
+
+### Recommended extension shape
+
+Add highlight metadata under:
+
+- `extensions.rstim_query_highlights`
+
+Recommended structure:
+
+```json
+{
+  "extensions": {
+    "rstim_query_highlights": {
+      "version": "1",
+      "query": {
+        "kind": "dem_error_origin",
+        "dem_error_index": 17
+      },
+      "highlights": [
+        {
+          "op_path": [12, 3, 5],
+          "repeat_iterations": [4, 2],
+          "target_slots": [1],
+          "target_qubits": [5],
+          "branch": "Y",
+          "label": "Y"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Field semantics
+
+- `op_path`
+  - static path to the operation within nested `operations` and `repeat.body` arrays
+- `repeat_iterations`
+  - dynamic repeat instance path for the matched occurrence
+- `target_slots`
+  - precise slot indices inside the matched operation's target list
+- `target_qubits`
+  - direct qubit indices needed by downstream rendering
+- `branch`
+  - source branch label, serialized from `SourceBranch`
+- `label`
+  - renderer-facing display label; initially identical to `branch`
+
+### Why highlights live in `extensions`
+
+This metadata is query-specific, not part of the core circuit definition. It also includes dynamic repeat-instance identity, which does not belong inside the static QP101 operation tree. The QP101 document already reserves `extensions` for non-core auxiliary data, so this is the least invasive and most composable location.
+
+## Query Model
+
+The first version should support at least:
+
+- query by final DEM error index to produce a highlighted QP101 document
+- internal reverse lookup from source id to DEM error ids
+
+For a `dem_error_index` query:
+
+1. build tracked analysis result
+2. resolve `dem_error_index -> [source_id]`
+3. convert each source into one highlight record
+4. export the base QP101 document
+5. inject `extensions.rstim_query_highlights`
+
+If multiple source ids map to the same:
+
+- `op_path`
+- `repeat_iterations`
+- `target_slots`
+- `branch`
+
+they may be coalesced into one exported highlight record.
+
+## Error Handling
+
+- Invalid DEM error indices must return a clear error.
+- If tracked decomposition fails, the tracked API returns the same class of decomposition error as the normal path, with enough context to identify the failing term.
+- If a query requests highlight export but the tracked analysis result is unavailable, the export path must fail instead of silently emitting incomplete metadata.
+
+## Performance Trade-Offs
+
+Tracked mode adds overhead from:
+
+- source allocation for every emitted raw error source
+- provenance-set unions during merge
+- provenance propagation during decomposition
+- reverse-index construction for final query support
+
+This is acceptable only because the feature is explicitly opt-in. The default path must remain the recommended path for users who only need the final DEM.
+
+## Testing Strategy
+
+### Unit Tests
+
+- source emission preserves `target_slots` for multi-target noise instructions
+- source emission preserves branch identity for `DEPOLARIZE1`, `DEPOLARIZE2`, and correlated blocks
+- tracked traversal preserves `repeat_iterations` for nested repeats
+
+### Provenance Correctness Tests
+
+- multiple sources merged into one final DEM line produce an exact union of source ids
+- one source that decomposes into multiple final DEM lines produces exact reverse links
+- canonicalization does not change the resolved source set
+
+### Export Tests
+
+- highlighted QP101 JSON preserves the original circuit structure
+- extension payload includes `op_path`, `repeat_iterations`, `target_slots`, and `branch`
+- a representative repeat-containing circuit exports the correct repeat-instance highlight records
+
+## Rollout Plan
+
+Implement in this order:
+
+1. add tracked core data structures and tracked source emission helpers
+2. add tracked recursive traversal that preserves repeat identity
+3. add tracked merge support
+4. add tracked decomposition support
+5. add query API and QP101 highlight export
+6. add unit and integration coverage for merge, decomposition, and repeat-aware export
+
+## Open Decisions Resolved By This Design
+
+- Provenance tracking is opt-in, not default.
+- Source precision includes repeat iterations, target slots, and branch labels.
+- The first exported JSON form is a highlighted QP101 document, not a separate draw-only format.
+- Query-specific metadata lives in `extensions`, not inside core QP101 operations.

--- a/qp101-viz/.gitignore
+++ b/qp101-viz/.gitignore
@@ -1,0 +1,5 @@
+/.worktrees/
+drafts/
+.DS_Store
+draft_figs/
+examples/circuits/

--- a/qp101-viz/Makefile
+++ b/qp101-viz/Makefile
@@ -1,0 +1,23 @@
+TYPST ?= typst
+ROOT ?= .
+EXAMPLE_DIR ?= examples
+OUT_DIR ?= draft_figs
+
+EXAMPLE_SRCS := $(wildcard $(EXAMPLE_DIR)/*.typ)
+PDFS := $(patsubst $(EXAMPLE_DIR)/%.typ,$(OUT_DIR)/%.pdf,$(EXAMPLE_SRCS))
+
+.PHONY: all list clean
+
+all: $(PDFS)
+
+list:
+	@printf '%s\n' $(PDFS)
+
+$(OUT_DIR):
+	@mkdir -p $(OUT_DIR)
+
+$(OUT_DIR)/%.pdf: $(EXAMPLE_DIR)/%.typ lib.typ typst.toml | $(OUT_DIR)
+	$(TYPST) compile --root $(ROOT) $< $@
+
+clean:
+	rm -f $(PDFS)

--- a/qp101-viz/README.md
+++ b/qp101-viz/README.md
@@ -1,0 +1,79 @@
+# qp101-viz
+
+`qp101-viz` is a local Typst package prototype for rendering QP101-ZY circuit JSON as a timeline view.
+
+## Scope
+
+This first prototype focuses on:
+
+- reading QP101-ZY JSON directly with `json(...)`
+- rendering the ordered `operations` stream as a quill-based quantum circuit
+- preserving `repeat`, `tick`, detectors, observables, and noise as distinct visual events
+- assigning renderer-only global measurement anchors such as `m1`, `m2`, `m3`, ... in expanded visual order
+- resolving `detector` and `observable_include` `rec[-k]` sources into those measurement anchors when possible
+
+It does not yet implement a geometry-based layout renderer. The schema and renderer shape are designed so that a future coordinate/layout view can consume the same JSON.
+
+## Public API
+
+- `timeline-theme(...)`
+- `qp101-timeline(doc, theme: timeline-theme())`
+- `qp101-timeline-file(path, theme: timeline-theme())`
+
+## Example
+
+```typst
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+#set page(width: auto, height: auto, margin: 10pt)
+
+#qp101-timeline-file(
+  "examples/repeat-detector.qp101.json",
+  theme: timeline-theme(step_width: 5.6em),
+)
+```
+
+## Repository Layout
+
+- `examples/` keeps a small set of human-facing rendered demos.
+- examples that are meant to render after copying the package are self-contained and read JSON from files bundled inside `examples/`.
+- `checks/` holds metadata/query fixtures used to verify renderer behavior.
+
+## Notes
+
+- `repeat` blocks are expanded for display and rendered as dashed grouped regions labeled `repeat xN`.
+- repeated iterations are separated with dashed slice markers inside the grouped region.
+- `tick` stays explicit as a dedicated separator moment.
+- the visible circuit now only uses real qubit wires labeled `q0`, `q1`, ...
+- `qubit_coords` and `shift_coords` stay available in the JSON model but are intentionally hidden from the timeline view.
+- the main gate track is drawn with Typst's `quill` package, following the same broad rendering model as the `yao-rs/visualization` reference.
+- `R` and `RX` are rendered as lightweight reset boxes.
+- `X_ERROR`, `Z_ERROR`, and `DEPOLARIZE1` render as compact single-qubit noise boxes with short labels such as `XE`, `ZE`, and `D1`, even when one op targets many qubits.
+- `DEPOLARIZE2` renders as connected two-box noise gates, and each rendered pair carries its own parameter note above it.
+- `M`, `MX`, and `MR` are rendered as compact measurement boxes with plain-text anchors such as `m1` above the gate.
+- measurement-producing gates currently recognized for semantic anchors are `M`, `MX`, and `MR`.
+- measurement and detector/observable operators reserve extra horizontal space for their labels so dense timelines do not collide as easily.
+- circuit-top measurement and Stim-style operator labels now share a single theme clearance value so they stay above the wire instead of drifting into gate bodies.
+- `detector` and `observable_include` render inline on the circuit in a Stim-like single-wire box style.
+- detector boxes use `DETECTOR` with a top label such as `D0 = m2*m1`.
+- observable boxes use `OBS_INCLUDE(k)` with a top label such as `L0 *= m7`.
+- detector and observable host wires follow Stim's rule: use the minimum resolved measurement-source qubit, otherwise fall back to the best available source qubit, otherwise `q0`.
+- detector and `observable_include` display resolved anchors instead of raw `rec[-k]` when the referenced measurements exist in the current expanded history.
+- detector and observable source text now lists each resolved anchor explicitly instead of compressing consecutive runs into `m7-m8` style ranges.
+- non-`rec` sources remain textual, and unresolved `rec[...]` sources stay explicit as raw `rec[...]`.
+- operation-local `annotations` now render per-target query markers on matched noise boxes, using `target_slots` plus `context.repeat_iterations` to disambiguate repeated and multi-source inputs.
+
+## Verification
+
+Previously verified locally with `typst 0.14.2` by compiling and querying:
+
+- `examples/timeline.typ`
+- `examples/rstim-fixture.typ`
+- `examples/anchor-basic.typ`
+- `checks/repeat-groups.typ`
+- `checks/stim-operator-host-render.typ`
+- local `examples/circuits/` renders such as `steane_x_basis_with_flags.json` and `surface_code_d3_with_flags.json` when those ignored local fixtures are available in the workspace
+- query-based fixtures for:
+  - measurement-history structure
+  - wire layout and hidden metadata
+  - detector / observable promotion into the main track
+  - detector / observable source resolution

--- a/qp101-viz/checks/anchor-basic-bottom.typ
+++ b/qp101-viz/checks/anchor-basic-bottom.typ
@@ -1,0 +1,6 @@
+#import "../lib.typ": collect-render-model, render-bottom-entry
+
+#let doc = json("../examples/anchor-basic.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+
+#metadata(render-bottom-entry(model.moments.at(0).bottom.at(0), model.measurements)) <bottom>

--- a/qp101-viz/checks/anchor-basic-labels.typ
+++ b/qp101-viz/checks/anchor-basic-labels.typ
@@ -1,0 +1,10 @@
+#import "../lib.typ": collect-render-model, measurement-gate-labels, timeline-theme
+
+#let doc = json("../examples/anchor-basic.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+#let target = model.moments.at(0).main.at(0).measurement_targets.at(0)
+
+#metadata(measurement-gate-labels(target, timeline-theme())) <labels>
+#let label_content = repr(measurement-gate-labels(target, timeline-theme()).at(0).content)
+#assert.eq(label_content, "styled(child: [m1], ..)")
+#metadata(label_content) <label-content>

--- a/qp101-viz/checks/anchor-forward-bottom.typ
+++ b/qp101-viz/checks/anchor-forward-bottom.typ
@@ -1,0 +1,6 @@
+#import "../lib.typ": collect-render-model, render-bottom-entry
+
+#let doc = json("anchor-forward.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+
+#metadata(render-bottom-entry(model.moments.at(0).bottom.at(0), model.measurements)) <bottom>

--- a/qp101-viz/checks/anchor-forward.qp101.json
+++ b/qp101-viz/checks/anchor-forward.qp101.json
@@ -1,0 +1,13 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 1,
+  "operations": [
+    { "type": "gate", "gate": "M", "targets": [0] },
+    {
+      "type": "detector",
+      "sources": [{ "kind": "rec", "offset": 0 }]
+    },
+    { "type": "gate", "gate": "M", "targets": [0] }
+  ]
+}

--- a/qp101-viz/checks/anchor-interleaved-bottom.typ
+++ b/qp101-viz/checks/anchor-interleaved-bottom.typ
@@ -1,0 +1,6 @@
+#import "../lib.typ": collect-render-model, render-bottom-entry
+
+#let doc = json("anchor-interleaved.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+
+#metadata(model.moments.at(0).bottom.map(entry => render-bottom-entry(entry, model.measurements))) <bottoms>

--- a/qp101-viz/checks/anchor-interleaved-model.typ
+++ b/qp101-viz/checks/anchor-interleaved-model.typ
@@ -1,0 +1,8 @@
+#import "../lib.typ": collect-render-model
+
+#let doc = json("anchor-interleaved.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+
+#metadata(model.moments.at(0).main) <main>
+#metadata(model.moments.at(0).bottom) <bottom>
+#metadata(model.measurements) <measurements>

--- a/qp101-viz/checks/anchor-interleaved.qp101.json
+++ b/qp101-viz/checks/anchor-interleaved.qp101.json
@@ -1,0 +1,18 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 1,
+  "operations": [
+    { "type": "gate", "gate": "M", "targets": [0] },
+    {
+      "type": "detector",
+      "sources": [{ "kind": "rec", "offset": -1 }]
+    },
+    { "type": "gate", "gate": "M", "targets": [0] },
+    {
+      "type": "observable_include",
+      "index": 0,
+      "sources": [{ "kind": "rec", "offset": -1 }]
+    }
+  ]
+}

--- a/qp101-viz/checks/anchor-repeat-bottom.typ
+++ b/qp101-viz/checks/anchor-repeat-bottom.typ
@@ -1,0 +1,15 @@
+#import "../lib.typ": collect-render-model, render-bottom-entry
+
+#let doc = json("../examples/anchor-repeat.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+#let labels = {
+  let out = ()
+  for moment in model.moments {
+    for entry in moment.bottom {
+      out.push(render-bottom-entry(entry, model.measurements))
+    }
+  }
+  out
+}
+
+#metadata(labels) <bottoms>

--- a/qp101-viz/checks/highlight-render.typ
+++ b/qp101-viz/checks/highlight-render.typ
@@ -1,0 +1,81 @@
+#import "@preview/quill:0.7.2": tequila
+#import "../lib.typ": collect-render-model, render-main-op, timeline-theme
+
+#let theme = timeline-theme()
+
+#let gate-label-texts(gate) = gate.labels.map(label => repr(label.content))
+#let gate-fill(gate) = repr(gate.fill)
+
+#let single_doc = json("../examples/depolarize1-single-highlight.qp101.json")
+#let single_model = collect-render-model(single_doc.at("operations", default: ()))
+#let single_built = tequila.build(
+  n: single_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(single_model.moments.at(0).main.at(1), theme),
+)
+#let single_detector_built = tequila.build(
+  n: single_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(single_model.moments.at(0).main.at(3), theme),
+)
+
+#let repeat_doc = json("../examples/repeat-highlight.qp101.json")
+#let repeat_model = collect-render-model(repeat_doc.at("operations", default: ()))
+#let repeat_iter0_built = tequila.build(
+  n: repeat_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(repeat_model.moments.at(0).main.at(0), theme),
+)
+#let repeat_iter1_built = tequila.build(
+  n: repeat_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(repeat_model.moments.at(2).main.at(0), theme),
+)
+
+#let multi_doc = json("../examples/multi-source-highlight.qp101.json")
+#let multi_model = collect-render-model(multi_doc.at("operations", default: ()))
+#let multi_first_built = tequila.build(
+  n: multi_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(multi_model.moments.at(0).main.at(1), theme),
+)
+#let multi_second_built = tequila.build(
+  n: multi_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(multi_model.moments.at(0).main.at(2), theme),
+)
+#let multi_detector_built = tequila.build(
+  n: multi_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(multi_model.moments.at(0).main.at(4), theme),
+)
+
+#let rendered = (
+  single: gate-label-texts(single_built.at(1)),
+  single_detector: gate-label-texts(single_detector_built.at(1)),
+  single_detector_fill: gate-fill(single_detector_built.at(1)),
+  repeat_iter0_slot0: gate-label-texts(repeat_iter0_built.at(1)),
+  repeat_iter0_slot1: gate-label-texts(repeat_iter0_built.at(2)),
+  repeat_iter1_slot0: gate-label-texts(repeat_iter1_built.at(1)),
+  repeat_iter1_slot1: gate-label-texts(repeat_iter1_built.at(2)),
+  multi_first: gate-label-texts(multi_first_built.at(1)),
+  multi_second: gate-label-texts(multi_second_built.at(1)),
+  multi_detector: gate-label-texts(multi_detector_built.at(1)),
+  multi_detector_fill: gate-fill(multi_detector_built.at(1)),
+)
+
+#assert.eq(rendered.single.len(), 2)
+#assert.eq(rendered.single_detector.len(), 1)
+#assert.eq(rendered.single_detector_fill, "rgb(\"#dbeafe\")")
+#assert.eq(rendered.repeat_iter0_slot0.len(), 1)
+#assert.eq(rendered.repeat_iter0_slot1.len(), 3)
+#assert.eq(rendered.repeat_iter0_slot1.at(2), "styled(child: [repeat[0]], ..)")
+#assert.eq(rendered.repeat_iter1_slot0.len(), 1)
+#assert.eq(rendered.repeat_iter1_slot1.len(), 3)
+#assert.eq(rendered.repeat_iter1_slot1.at(2), "styled(child: [repeat[1]], ..)")
+#assert.eq(rendered.multi_first.len(), 2)
+#assert.eq(rendered.multi_second.len(), 2)
+#assert.eq(rendered.multi_detector.len(), 1)
+#assert.eq(rendered.multi_detector_fill, "rgb(\"#dbeafe\")")
+
+#metadata(rendered) <highlight-rendered>

--- a/qp101-viz/checks/mr-box.qp101.json
+++ b/qp101-viz/checks/mr-box.qp101.json
@@ -1,0 +1,12 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 1,
+  "operations": [
+    { "type": "gate", "gate": "MR", "targets": [0] },
+    {
+      "type": "detector",
+      "sources": [{ "kind": "rec", "offset": -1 }]
+    }
+  ]
+}

--- a/qp101-viz/checks/mr-box.typ
+++ b/qp101-viz/checks/mr-box.typ
@@ -1,0 +1,21 @@
+#import "@preview/quill:0.7.2": tequila
+#import "../lib.typ": collect-render-model, render-main-op, timeline-theme
+
+#let doc = json("mr-box.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+#let theme = timeline-theme()
+
+#metadata(tequila.build(
+  n: doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(model.moments.at(0).main.at(0), theme),
+)) <mr-box-built>
+
+#let expectation = (
+  gate_content: "MR",
+  draw_function: "draw-boxed-gate",
+  anchor_text: "m1",
+  width_should_be_reserved: true,
+  failure_hint: "MR should render as a boxed MR gate with its own reserved width instead of a meter glyph with a floating R label",
+)
+#metadata(expectation) <mr-box-expectation>

--- a/qp101-viz/checks/noise-render-render.typ
+++ b/qp101-viz/checks/noise-render-render.typ
@@ -1,0 +1,8 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+#qp101-timeline-file(
+  "checks/noise-render.qp101.json",
+  theme: timeline-theme(step_width: 5.6em),
+)

--- a/qp101-viz/checks/noise-render.qp101.json
+++ b/qp101-viz/checks/noise-render.qp101.json
@@ -1,0 +1,36 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 6,
+  "operations": [
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [0.001],
+      "raw_targets": [{ "kind": "qubit", "index": 0 }]
+    },
+    { "type": "tick" },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [0.001],
+      "raw_targets": [
+        { "kind": "qubit", "index": 0 },
+        { "kind": "qubit", "index": 2 },
+        { "kind": "qubit", "index": 4 }
+      ]
+    },
+    { "type": "tick" },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE2",
+      "params": [0.001],
+      "raw_targets": [
+        { "kind": "qubit", "index": 0 },
+        { "kind": "qubit", "index": 1 },
+        { "kind": "qubit", "index": 4 },
+        { "kind": "qubit", "index": 3 }
+      ]
+    }
+  ]
+}

--- a/qp101-viz/checks/noise-render.typ
+++ b/qp101-viz/checks/noise-render.typ
@@ -1,0 +1,62 @@
+#import "@preview/quill:0.7.2": tequila
+#import "../lib.typ": collect-render-model, noise-render-spec, render-main-op, timeline-theme
+
+#let doc = json("noise-render.qp101.json")
+#let ops = doc.at("operations", default: ())
+#let model = collect-render-model(ops)
+#let theme = timeline-theme()
+
+#metadata((
+  x_error: noise-render-spec(ops.at(0)),
+  depolarize1: noise-render-spec(ops.at(2)),
+  depolarize2: noise-render-spec(ops.at(4)),
+)) <noise-render-spec>
+
+#assert.eq(noise-render-spec(ops.at(0)).note, "0.001")
+#assert.eq(noise-render-spec(ops.at(2)).note, "0.001")
+#assert.eq(noise-render-spec(ops.at(4)).note, "0.001")
+
+#let single = render-main-op(model.moments.at(0).main.at(0), theme)
+#let batched = render-main-op(model.moments.at(2).main.at(0), theme)
+#let paired = render-main-op(model.moments.at(4).main.at(0), theme)
+#let single_built = tequila.build(n: doc.at("num_qubits"), append-wire: true, ..single)
+#let batched_built = tequila.build(n: doc.at("num_qubits"), append-wire: true, ..batched)
+#let paired_built = tequila.build(n: doc.at("num_qubits"), append-wire: true, ..paired)
+
+#metadata((
+  single: (
+    count: single.len(),
+    qubits: single.map(op => op.first().qubit),
+    spans: single.map(op => op.first().n),
+    supplement_counts: single.map(op => op.first().supplements.len()),
+    note_counts: single_built.slice(1).map(op => op.labels.len()),
+    note_reprs: single_built.slice(1).map(op => op.labels.map(label => repr(label.content))),
+  ),
+  batched: (
+    count: batched.len(),
+    qubits: batched.map(op => op.first().qubit),
+    spans: batched.map(op => op.first().n),
+    supplement_counts: batched.map(op => op.first().supplements.len()),
+    note_counts: batched_built.slice(1).map(op => op.labels.len()),
+    note_reprs: batched_built.slice(1).map(op => op.labels.map(label => repr(label.content))),
+  ),
+  paired: (
+    count: paired.len(),
+    lead_qubits: paired.map(op => op.first().qubit),
+    spans: paired.map(op => op.first().n),
+    supplement_counts: paired.map(op => op.first().supplements.len()),
+    note_counts: paired_built.slice(1).map(op => op.labels.len()),
+    note_reprs: paired_built.slice(1).map(op => op.labels.map(label => repr(label.content))),
+  ),
+)) <noise-render-structure>
+
+#assert.eq(single_built.slice(1).map(op => op.labels.len()), (1,))
+#assert.eq(batched_built.slice(1).map(op => op.labels.len()), (1, 1, 1))
+#assert.eq(
+  batched_built.slice(1).map(op => repr(op.labels.at(0).content)),
+  ("styled(child: [0.001], ..)", "styled(child: [0.001], ..)", "styled(child: [0.001], ..)"),
+)
+#assert.eq(
+  paired_built.slice(1).filter(op => op.labels.len() > 0).map(op => repr(op.labels.at(0).content)),
+  ("styled(child: [0.001], ..)", "styled(child: [0.001], ..)"),
+)

--- a/qp101-viz/checks/operator-spacing.typ
+++ b/qp101-viz/checks/operator-spacing.typ
@@ -1,0 +1,22 @@
+#import "@preview/quill:0.7.2": tequila
+#import "../lib.typ": collect-render-model, render-main-op, timeline-theme
+
+#let doc = json("stim-operator-host.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+#let theme = timeline-theme()
+
+#let detector = model.moments.at(0).main.at(6)
+#let observable = model.moments.at(0).main.at(8)
+
+#metadata(tequila.build(n: doc.at("num_qubits"), append-wire: true, ..render-main-op(detector, theme))) <operator-spacing-detector>
+#metadata(tequila.build(n: doc.at("num_qubits"), append-wire: true, ..render-main-op(observable, theme))) <operator-spacing-observable>
+
+#let expectation = (
+  detector_width_should_be_reserved: true,
+  observable_width_should_be_reserved: true,
+  detector_source: "D0 = m2*m1",
+  observable_source: "L0 *= m7",
+  source_label_dy: "-0.15em",
+  failure_hint: "Stim-style operators should reserve enough width for their top source text so labels do not overlap adjacent columns",
+)
+#metadata(expectation) <operator-spacing-expectation>

--- a/qp101-viz/checks/repeat-groups.typ
+++ b/qp101-viz/checks/repeat-groups.typ
@@ -1,0 +1,6 @@
+#import "../lib.typ": collect-render-model
+
+#let doc = json("../examples/repeat-detector.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+
+#metadata(model.at("repeat_groups", default: ())) <repeat-groups>

--- a/qp101-viz/checks/stim-operator-forward.qp101.json
+++ b/qp101-viz/checks/stim-operator-forward.qp101.json
@@ -1,0 +1,18 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 1,
+  "operations": [
+    {
+      "type": "detector",
+      "sources": [
+        { "kind": "rec", "offset": 0 }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [0]
+    }
+  ]
+}

--- a/qp101-viz/checks/stim-operator-forward.typ
+++ b/qp101-viz/checks/stim-operator-forward.typ
@@ -1,0 +1,24 @@
+#import "../lib.typ": collect-render-model
+
+#let doc = json("stim-operator-forward.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+
+#metadata(model) <stim-operator-forward-model>
+
+#let expectation = (
+  main_entries: (
+    (
+      kind: "detector",
+      host_wire: "q0",
+      label: "DETECTOR",
+      source: "D0 = rec[0]",
+      unresolved: true,
+    ),
+  ),
+  bottom_expectations: (
+    should_be_empty: true,
+    failure_hint: "Forward detector text should be removed from moment.bottom once promoted",
+  ),
+  failure_hint: "Forward rec[0] detector should be promoted but keep unresolved source text",
+)
+#metadata(expectation) <stim-operator-forward-expectation>

--- a/qp101-viz/checks/stim-operator-host-render.typ
+++ b/qp101-viz/checks/stim-operator-host-render.typ
@@ -1,0 +1,8 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+#qp101-timeline-file(
+  "checks/stim-operator-host.qp101.json",
+  theme: timeline-theme(step_width: 5.6em),
+)

--- a/qp101-viz/checks/stim-operator-host.qp101.json
+++ b/qp101-viz/checks/stim-operator-host.qp101.json
@@ -1,0 +1,28 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 2,
+  "operations": [
+    { "type": "gate", "gate": "M", "targets": [0] },
+    { "type": "gate", "gate": "M", "targets": [1] },
+    { "type": "gate", "gate": "M", "targets": [1] },
+    { "type": "gate", "gate": "M", "targets": [1] },
+    { "type": "gate", "gate": "M", "targets": [1] },
+    { "type": "gate", "gate": "M", "targets": [1] },
+    {
+      "type": "detector",
+      "sources": [
+        { "kind": "rec", "offset": -5 },
+        { "kind": "rec", "offset": -6 }
+      ]
+    },
+    { "type": "gate", "gate": "M", "targets": [1] },
+    {
+      "type": "observable_include",
+      "index": 0,
+      "sources": [
+        { "kind": "rec", "offset": -1 }
+      ]
+    }
+  ]
+}

--- a/qp101-viz/checks/stim-operator-host.typ
+++ b/qp101-viz/checks/stim-operator-host.typ
@@ -1,0 +1,29 @@
+#import "../lib.typ": collect-render-model
+
+#let doc = json("stim-operator-host.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+
+#metadata(model) <stim-operator-host-model>
+
+#let expectation = (
+  main_entries: (
+    (
+      kind: "detector",
+      host_wire: "q0",
+      label: "DETECTOR",
+      source: "D0 = m2*m1",
+    ),
+    (
+      kind: "observable_include",
+      host_wire: "q1",
+      label: "OBS_INCLUDE(0)",
+      source: "L0 *= m7",
+    ),
+  ),
+  bottom_expectations: (
+    should_be_empty: true,
+    failure_hint: "Detector/observable text should disappear from moment.bottom once promoted",
+  ),
+  failure_hint: "Should promote detector/observable into moment.main with Stim-style host/text",
+)
+#metadata(expectation) <stim-operator-host-expectation>

--- a/qp101-viz/checks/stim-operator-no-range.qp101.json
+++ b/qp101-viz/checks/stim-operator-no-range.qp101.json
@@ -1,0 +1,18 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 3,
+  "operations": [
+    { "type": "gate", "gate": "M", "targets": [0] },
+    { "type": "gate", "gate": "M", "targets": [1] },
+    { "type": "gate", "gate": "M", "targets": [2] },
+    {
+      "type": "detector",
+      "sources": [
+        { "kind": "rec", "offset": -3 },
+        { "kind": "rec", "offset": -2 },
+        { "kind": "rec", "offset": -1 }
+      ]
+    }
+  ]
+}

--- a/qp101-viz/checks/stim-operator-no-range.typ
+++ b/qp101-viz/checks/stim-operator-no-range.typ
@@ -1,0 +1,12 @@
+#import "../lib.typ": collect-render-model
+
+#let doc = json("stim-operator-no-range.qp101.json")
+#let model = collect-render-model(doc.at("operations", default: ()))
+
+#metadata(model) <stim-operator-no-range-model>
+
+#let expectation = (
+  detector_source: "D0 = m1*m2*m3",
+  failure_hint: "Stim-style detector source text should list each anchor explicitly instead of compressing runs into m1-m3 style ranges",
+)
+#metadata(expectation) <stim-operator-no-range-expectation>

--- a/qp101-viz/checks/top-label-clearance.typ
+++ b/qp101-viz/checks/top-label-clearance.typ
@@ -1,0 +1,27 @@
+#import "@preview/quill:0.7.2": tequila
+#import "../lib.typ": collect-render-model, measurement-gate-labels, render-main-op, timeline-theme
+
+#let theme = timeline-theme()
+
+#let measurement_doc = json("../examples/anchor-basic.qp101.json")
+#let measurement_model = collect-render-model(measurement_doc.at("operations", default: ()))
+#let measurement_target = measurement_model.moments.at(0).main.at(0).measurement_targets.at(0)
+#let measurement_built = tequila.build(
+  n: measurement_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(measurement_model.moments.at(0).main.at(0), theme),
+)
+
+#let stim_doc = json("stim-operator-host.qp101.json")
+#let stim_model = collect-render-model(stim_doc.at("operations", default: ()))
+#let detector_built = tequila.build(
+  n: stim_doc.at("num_qubits"),
+  append-wire: true,
+  ..render-main-op(stim_model.moments.at(0).main.at(6), theme),
+)
+
+#metadata((
+  measurement_anchor_dy: measurement_built.at(1).labels.at(0).dy,
+  measurement_badge_dy: measurement-gate-labels(measurement_target, theme).at(0).dy,
+  detector_source_dy: detector_built.at(1).labels.at(0).dy,
+)) <top-label-dy>

--- a/qp101-viz/checks/wire-layout.qp101.json
+++ b/qp101-viz/checks/wire-layout.qp101.json
@@ -1,0 +1,10 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 2,
+  "operations": [
+    { "type": "qubit_coords", "targets": [0], "coords": [1.0, 2.0] },
+    { "type": "shift_coords", "delta": [0.5, 0.25] },
+    { "type": "gate", "gate": "M", "targets": [0] }
+  ]
+}

--- a/qp101-viz/checks/wire-layout.typ
+++ b/qp101-viz/checks/wire-layout.typ
@@ -1,0 +1,14 @@
+#import "../lib.typ": collect-render-model, wire-label-items, timeline-theme
+
+#let doc = json("wire-layout.qp101.json")
+
+#metadata(collect-render-model(doc.at("operations", default: ()))) <wire-layout-model>
+#metadata(wire-label-items(doc.at("num_qubits"), 0, doc.at("num_qubits") + 1, timeline-theme())) <wire-layout-labels>
+
+#let expectation = (
+  labels: ("q0", "q1"),
+  main_wire_count: 2,
+  first_moment_top_should_be_empty: true,
+  failure_hint: "Timeline should only expose q0/q1 wires and should hide qubit_coords/shift_coords from visible moments",
+)
+#metadata(expectation) <wire-layout-expectation>

--- a/qp101-viz/docs/plans/2026-03-30-noise-gate-rendering-design.md
+++ b/qp101-viz/docs/plans/2026-03-30-noise-gate-rendering-design.md
@@ -1,0 +1,88 @@
+# Noise Gate Rendering Design
+
+Date: 2026-03-30
+
+## Context
+
+The current timeline renderer treats every `noise` operation as a generic multi-qubit gate. In practice, this causes three visible problems:
+
+- `X_ERROR` and `DEPOLARIZE1` are rendered as large boxes spanning multiple wires, even though they are single-qubit noise channels.
+- `DEPOLARIZE2` is rendered as one large spanning box instead of a two-qubit connected gate.
+- Full gate names plus parameters, such as `DEPOLARIZE1(0.001)`, make noise gates visually wider than necessary.
+
+The JSON samples in this repository already preserve enough semantic information to render these operations correctly. The main issue is in the renderer, not in the schema.
+
+## JSON Design Assessment
+
+The current JSON design is acceptable and should remain unchanged.
+
+- `gate` preserves the canonical operation name.
+- `params` preserves the physical parameter values.
+- `raw_targets` preserves the source-level target references.
+- optional `display.label` already exists as a presentation override and can remain as an escape hatch.
+
+The renderer should own the mapping from canonical gate name to visual form. That keeps the schema semantic and avoids polluting circuit data with display-only abbreviations.
+
+## Rendering Semantics
+
+Noise gates should be classified by renderer-side policy before drawing:
+
+- `X_ERROR`, `Z_ERROR`, `DEPOLARIZE1`: single-qubit noise
+- `DEPOLARIZE2`: two-qubit noise
+- unknown noise gates: fallback to the current generic multi-qubit rendering
+
+Single-qubit noise should render as one compact box per target qubit in the same moment. This applies both to one-target ops and to batched ops where a single JSON operation references many qubits.
+
+Two-qubit noise should render as a pair of compact boxes connected by a vertical line. If a future `DEPOLARIZE2` op contains an even-length target list, the renderer should expand it pairwise in order. Odd or malformed target sets should fall back to the generic rendering instead of guessing.
+
+## Labels And Notes
+
+Default short labels should be provided by the renderer:
+
+- `X_ERROR` -> `XE`
+- `DEPOLARIZE1` -> `D1`
+- `DEPOLARIZE2` -> `D2`
+
+These are presentation defaults only. If `display.label` is present, it should continue to override the default.
+
+Noise parameters should not remain inside the gate body. Instead, the renderer should place a compact note such as `p=0.001` above the rendered noise group. For batched single-qubit noise and paired two-qubit noise, the parameter note should appear once per logical group, attached to the topmost rendered gate.
+
+## Implementation Structure
+
+The change should stay localized to `lib.typ` by extracting dedicated noise helpers:
+
+- `noise-short-label(op)`
+- `noise-note-label(op)`
+- `noise-qubit-groups(op)`
+- `render-noise-op(op, theme)`
+
+`render-main-op` should delegate all `type == "noise"` operations to `render-noise-op`.
+
+This keeps policy separate from drawing and avoids expanding the existing generic gate path further.
+
+## Error Handling
+
+The renderer should remain tolerant of malformed or unfamiliar data.
+
+- If a supposed single-qubit noise op cannot resolve clean qubit targets, use the current generic fallback.
+- If `DEPOLARIZE2` does not resolve to clean pairs, use the current generic fallback.
+- Unknown noise gate kinds should keep the current behavior.
+
+The goal is to improve common known cases without reducing compatibility.
+
+## Verification Plan
+
+Verification should include both metadata-style checks and visual compilation.
+
+Add targeted checks to cover:
+
+- single `X_ERROR` renders as a single boxed gate with short label
+- batched `X_ERROR` and `DEPOLARIZE1` render as multiple single-wire gates in one moment
+- `DEPOLARIZE2` renders as a two-wire connected structure rather than a spanning multigate
+- parameter notes appear once above the rendered noise group
+
+Then recompile representative examples, especially the circuit demos that currently show the issue, to confirm the updated appearance is correct.
+
+## Out Of Scope
+
+This change does not redesign the timeline layout system, change the JSON schema, or introduce a geometry-based renderer. It only fixes noise gate semantics and presentation within the existing timeline view.

--- a/qp101-viz/docs/plans/2026-03-30-noise-gate-rendering-implementation.md
+++ b/qp101-viz/docs/plans/2026-03-30-noise-gate-rendering-implementation.md
@@ -1,0 +1,478 @@
+# Noise Gate Rendering Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Render known noise gates with correct arity-aware shapes and compact labels/parameter notes without changing the QP101 JSON schema.
+
+**Architecture:** Add a renderer-side noise classification layer in `lib.typ` so `render-main-op` delegates noise ops to dedicated helpers. Keep `noise` JSON untouched, derive singleton and pair groups from `raw_targets`, and verify behavior with focused Typst query fixtures plus representative circuit compilations.
+
+**Tech Stack:** Typst 0.14.x, Quill 0.7.2, local JSON fixtures under `checks/` and `examples/circuits/`
+
+---
+
+### Task 1: Add Noise Semantic Fixtures And Helper Functions
+
+**Files:**
+- Create: `checks/noise-render.qp101.json`
+- Create: `checks/noise-render.typ`
+- Modify: `lib.typ`
+- Test: `checks/noise-render.typ`
+
+**Step 1: Write the failing test**
+
+Create `checks/noise-render.qp101.json`:
+
+```json
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 5,
+  "operations": [
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [0.001],
+      "raw_targets": [
+        { "kind": "qubit", "index": 0 }
+      ]
+    },
+    { "type": "tick" },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [0.001],
+      "raw_targets": [
+        { "kind": "qubit", "index": 0 },
+        { "kind": "qubit", "index": 2 },
+        { "kind": "qubit", "index": 4 }
+      ]
+    },
+    { "type": "tick" },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE2",
+      "params": [0.001],
+      "raw_targets": [
+        { "kind": "qubit", "index": 1 },
+        { "kind": "qubit", "index": 3 }
+      ]
+    }
+  ]
+}
+```
+
+Create `checks/noise-render.typ`:
+
+```typ
+#import "../lib.typ": collect-render-model, noise-render-spec, render-main-op, timeline-theme
+
+#let doc = json("noise-render.qp101.json")
+#let ops = doc.at("operations", default: ())
+#let model = collect-render-model(ops)
+#let theme = timeline-theme()
+
+#metadata((
+  x_error: noise-render-spec(ops.at(0)),
+  depolarize1: noise-render-spec(ops.at(2)),
+  depolarize2: noise-render-spec(ops.at(4)),
+)) <noise-render-spec>
+
+#let single = render-main-op(model.moments.at(0).main.at(0), theme)
+#let batched = render-main-op(model.moments.at(2).main.at(0), theme)
+#let paired = render-main-op(model.moments.at(4).main.at(0), theme)
+
+#metadata((
+  single: (
+    count: single.len(),
+    qubits: single.map(op => op.first().qubit),
+    spans: single.map(op => op.first().n),
+    supplement_counts: single.map(op => op.first().supplements.len()),
+  ),
+  batched: (
+    count: batched.len(),
+    qubits: batched.map(op => op.first().qubit),
+    spans: batched.map(op => op.first().n),
+    supplement_counts: batched.map(op => op.first().supplements.len()),
+  ),
+  paired: (
+    count: paired.len(),
+    lead_qubit: paired.first().first().qubit,
+    span: paired.first().first().n,
+    supplement_count: paired.first().first().supplements.len(),
+  ),
+)) <noise-render-structure>
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+typst query checks/noise-render.typ "<noise-render-spec>" --one
+```
+
+Expected: FAIL because `noise-render-spec` is not defined/exported yet.
+
+**Step 3: Write minimal implementation**
+
+Add semantic helpers near the existing gate-label helpers in `lib.typ`:
+
+```typ
+#let noise-target-qubits(op) = shifted-qubits(qubits-from-refs(op.at("raw_targets", default: ())))
+
+#let noise-short-label(op) = {
+  let display = op.at("display", default: none)
+  if display != none and display.at("label", default: none) != none {
+    return display.at("label")
+  }
+
+  let gate = op.at("gate", default: "")
+  if gate == "X_ERROR" { return "XE" }
+  if gate == "Z_ERROR" { return "ZE" }
+  if gate == "DEPOLARIZE1" { return "D1" }
+  if gate == "DEPOLARIZE2" { return "D2" }
+  gate
+}
+
+#let noise-note-label(op) = {
+  let params = op.at("params", default: ())
+  if params.len() == 0 {
+    return none
+  }
+  "p=" + params.map(v => fmt-num(v)).join(", ")
+}
+
+#let noise-policy(op) = {
+  let gate = op.at("gate", default: "")
+  if gate == "X_ERROR" or gate == "Z_ERROR" or gate == "DEPOLARIZE1" {
+    return "single"
+  }
+  if gate == "DEPOLARIZE2" {
+    return "pair"
+  }
+  "fallback"
+}
+
+#let noise-qubit-groups(op) = {
+  let qubits = noise-target-qubits(op)
+  let policy = noise-policy(op)
+
+  if policy == "single" {
+    return qubits.map(q => (q,))
+  }
+  if policy == "pair" and calc.rem(qubits.len(), 2) == 0 {
+    let groups = ()
+    for pair in range(calc.floor(qubits.len() / 2)) {
+      let i = pair * 2
+      groups.push((qubits.at(i), qubits.at(i + 1)))
+    }
+    return groups
+  }
+  ()
+}
+
+#let noise-render-spec(op) = (
+  policy: noise-policy(op),
+  short_label: noise-short-label(op),
+  note: noise-note-label(op),
+  groups: noise-qubit-groups(op),
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+typst query checks/noise-render.typ "<noise-render-spec>" --one
+```
+
+Expected: JSON metadata showing:
+- `x_error.policy = "single"` and `x_error.short_label = "XE"`
+- `depolarize1.policy = "single"` and `depolarize1.short_label = "D1"`
+- `depolarize2.policy = "pair"` and `depolarize2.short_label = "D2"`
+- all three notes equal `p=0.001`
+
+**Step 5: Commit**
+
+```bash
+git add checks/noise-render.qp101.json checks/noise-render.typ lib.typ
+git commit -m "feat: add noise render spec helpers"
+```
+
+### Task 2: Render Single-Qubit Noise As Compact Boxes
+
+**Files:**
+- Modify: `lib.typ`
+- Test: `checks/noise-render.typ`
+
+**Step 1: Write the failing test**
+
+Run:
+
+```bash
+typst query checks/noise-render.typ "<noise-render-structure>" --one
+```
+
+Expected: FAIL semantically because current structure still reports one rendered op for the batched `DEPOLARIZE1` noise moment instead of three single-wire ops.
+
+**Step 2: Run test to verify it fails**
+
+Inspect the output and confirm that:
+- `single.count` is not yet guaranteed to be `1` through the new noise path
+- `batched.count` is currently `1` instead of `3`
+
+**Step 3: Write minimal implementation**
+
+Add compact noise-box helpers and wire them into a dedicated renderer path:
+
+```typ
+#let noise-note-label-entry(note, theme) = {
+  if note == none {
+    return ()
+  }
+  (
+    (
+      content: text(size: theme.note_font_size - 1pt, fill: theme.note_color)[#note],
+      pos: top,
+      dy: top-label-clearance(theme),
+    ),
+  )
+}
+
+#let noise-box-constructor(label, theme, note: none, target: none) = (x: auto, y: auto) => gate(
+  text(size: theme.note_font_size, fill: theme.color)[#label],
+  x: x,
+  y: y,
+  fill: theme.noise_fill,
+  stroke: .6pt + theme.note_color,
+  width: reserved-gate-width((
+    estimated-text-width(label, theme.note_font_size, padding: 0.7em),
+  ), minimum: 1.9em),
+  label: noise-note-label-entry(note, theme),
+  multi: if target == none { none } else {(
+    target: target,
+    num-qubits: calc.abs(target) + 1,
+    wire-count: 1,
+    wire-stroke: auto,
+    label: none,
+    extent: auto,
+    size-all-wires: false,
+    inputs: none,
+    outputs: none,
+    wire-label: (),
+    pass-through: (),
+  )},
+)
+
+#let noise-single-op(qubit, label, theme, note: none) = (
+  (
+    qubit: qubit,
+    n: 1,
+    supplements: (),
+    constructor: noise-box-constructor(label, theme, note: note),
+  ),
+)
+
+#let render-noise-op(op, theme) = {
+  let spec = noise-render-spec(op)
+  if spec.policy == "single" and spec.groups.len() > 0 {
+    let ops = ()
+    for (index, group) in spec.groups.enumerate() {
+      let note = if index == 0 { spec.note } else { none }
+      ops.push(noise-single-op(group.first(), spec.short_label, theme, note: note))
+    }
+    return ops
+  }
+
+  let qubits = noise-target-qubits(op)
+  let gate = generic-gate(qubits, gate-label(op), theme, fill: theme.noise_fill)
+  if gate == none { return () }
+  (gate,)
+}
+```
+
+Then replace the current inline `kind == "noise"` branch in `render-main-op` with:
+
+```typ
+if kind == "noise" {
+  return render-noise-op(op, theme)
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+typst query checks/noise-render.typ "<noise-render-structure>" --one
+```
+
+Expected: metadata showing:
+- `single.count = 1`, `single.qubits = (0,)`, `single.spans = (1,)`
+- `batched.count = 3`, `batched.qubits = (0, 2, 4)`, `batched.spans = (1, 1, 1)`
+- each single/batched entry has `supplement_counts = (0, ...)`
+
+**Step 5: Commit**
+
+```bash
+git add lib.typ checks/noise-render.typ
+git commit -m "feat: render single-qubit noise as compact boxes"
+```
+
+### Task 3: Render DEPOLARIZE2 As A Paired Two-Box Gate
+
+**Files:**
+- Create: `checks/noise-render-render.typ`
+- Modify: `lib.typ`
+- Test: `checks/noise-render.typ`
+- Test: `checks/noise-render-render.typ`
+
+**Step 1: Write the failing test**
+
+Create `checks/noise-render-render.typ`:
+
+```typ
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+#qp101-timeline-file(
+  "checks/noise-render.qp101.json",
+  theme: timeline-theme(step_width: 5.6em),
+)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+typst query checks/noise-render.typ "<noise-render-structure>" --one
+```
+
+Expected: FAIL semantically because `paired` is still reported as the old generic spanning gate instead of one lead op with one supplement.
+
+**Step 3: Write minimal implementation**
+
+Extend `render-noise-op` with a paired-gate helper:
+
+```typ
+#let noise-pair-op(q1, q2, label, theme, note: none) = {
+  let upper = calc.min(q1, q2)
+  let lower = calc.max(q1, q2)
+  (
+    (
+      qubit: upper,
+      n: lower - upper + 1,
+      supplements: (
+        (
+          lower,
+          noise-box-constructor(label, theme),
+        ),
+      ),
+      constructor: noise-box-constructor(
+        label,
+        theme,
+        note: note,
+        target: lower - upper,
+      ),
+    ),
+  )
+}
+```
+
+Then update `render-noise-op`:
+
+```typ
+if spec.policy == "pair" and spec.groups.len() > 0 {
+  let ops = ()
+  for (index, group) in spec.groups.enumerate() {
+    let note = if index == 0 { spec.note } else { none }
+    ops.push(noise-pair-op(group.at(0), group.at(1), spec.short_label, theme, note: note))
+  }
+  return ops
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+typst query checks/noise-render.typ "<noise-render-structure>" --one
+typst compile checks/noise-render-render.typ /tmp/qp101-viz-noise-render.pdf
+```
+
+Expected:
+- `paired.count = 1`
+- `paired.lead_qubit = 1`
+- `paired.span = 3`
+- `paired.supplement_count = 1`
+- PDF compile succeeds and visually shows `D2` as two boxes connected by a vertical line, with one `p=0.001` note above the upper box
+
+**Step 5: Commit**
+
+```bash
+git add lib.typ checks/noise-render.typ checks/noise-render-render.typ
+git commit -m "feat: render depolarize2 as paired noise gate"
+```
+
+### Task 4: Verify Real Examples And Update Documentation
+
+**Files:**
+- Modify: `README.md`
+- Test: `checks/noise-render.typ`
+- Test: `checks/noise-render-render.typ`
+- Test: `examples/circuits/render.typ`
+
+**Step 1: Write the failing test**
+
+Add a short renderer note to `README.md` once the behavior exists:
+
+```md
+- `X_ERROR`, `Z_ERROR`, and `DEPOLARIZE1` render as compact short-label single-qubit noise boxes, even when a single op targets many qubits.
+- `DEPOLARIZE2` renders as a two-box connected noise gate with one parameter note above the pair.
+```
+
+**Step 2: Run test to verify it fails**
+
+Run the full verification set before the README edit is applied:
+
+```bash
+typst query checks/noise-render.typ "<noise-render-spec>" --one
+typst query checks/noise-render.typ "<noise-render-structure>" --one
+typst compile checks/noise-render-render.typ /tmp/qp101-viz-noise-render.pdf
+typst compile --input source=examples/circuits/steane_x_basis_with_flags.json examples/circuits/render.typ /tmp/qp101-viz-steane-noise.pdf
+typst compile --input source=examples/circuits/surface_code_d3_with_flags.json examples/circuits/render.typ /tmp/qp101-viz-surface-noise.pdf
+```
+
+Expected: all Typst commands succeed and the two example PDFs show:
+- `XE` and `D1` as compact single-wire noise boxes
+- `D2` as paired two-box gates
+- one `p=0.001` note above each logical noise group
+
+**Step 3: Write minimal implementation**
+
+Update the `README.md` notes section with the new rendering rules and keep the wording presentation-focused rather than schema-focused.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+typst query checks/noise-render.typ "<noise-render-spec>" --one
+typst query checks/noise-render.typ "<noise-render-structure>" --one
+typst compile checks/noise-render-render.typ /tmp/qp101-viz-noise-render.pdf
+typst compile --input source=examples/circuits/steane_x_basis_with_flags.json examples/circuits/render.typ /tmp/qp101-viz-steane-noise.pdf
+typst compile --input source=examples/circuits/surface_code_d3_with_flags.json examples/circuits/render.typ /tmp/qp101-viz-surface-noise.pdf
+```
+
+Expected: all commands succeed with the updated README committed alongside the rendering changes.
+
+**Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document noise gate rendering rules"
+```

--- a/qp101-viz/examples/anchor-basic.qp101.json
+++ b/qp101-viz/examples/anchor-basic.qp101.json
@@ -1,0 +1,12 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 1,
+  "operations": [
+    { "type": "gate", "gate": "M", "targets": [0] },
+    {
+      "type": "detector",
+      "sources": [{ "kind": "rec", "offset": -1 }]
+    }
+  ]
+}

--- a/qp101-viz/examples/anchor-basic.typ
+++ b/qp101-viz/examples/anchor-basic.typ
@@ -1,0 +1,5 @@
+#import "../lib.typ": qp101-timeline-file
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+#qp101-timeline-file("examples/anchor-basic.qp101.json")

--- a/qp101-viz/examples/anchor-repeat.qp101.json
+++ b/qp101-viz/examples/anchor-repeat.qp101.json
@@ -1,0 +1,31 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 1,
+  "operations": [
+    {
+      "type": "repeat",
+      "count": 3,
+      "body": [
+        { "type": "gate", "gate": "M", "targets": [0] },
+        { "type": "gate", "gate": "M", "targets": [0] },
+        {
+          "type": "detector",
+          "sources": [
+            { "kind": "rec", "offset": -1 },
+            { "kind": "rec", "offset": -2 }
+          ]
+        },
+        { "type": "tick" }
+      ]
+    },
+    {
+      "type": "observable_include",
+      "index": 0,
+      "sources": [
+        { "kind": "rec", "offset": -1 },
+        { "kind": "rec", "offset": -2 }
+      ]
+    }
+  ]
+}

--- a/qp101-viz/examples/anchor-repeat.typ
+++ b/qp101-viz/examples/anchor-repeat.typ
@@ -1,0 +1,8 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+#qp101-timeline-file(
+  "examples/anchor-repeat.qp101.json",
+  theme: timeline-theme(step_width: 5.8em),
+)

--- a/qp101-viz/examples/basic.qp101.json
+++ b/qp101-viz/examples/basic.qp101.json
@@ -1,0 +1,14 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 2,
+  "operations": [
+    { "type": "gate", "gate": "H", "targets": [0] },
+    { "type": "gate", "gate": "X", "targets": [1], "controls": [0], "control_configs": [true] },
+    { "type": "tick" },
+    { "type": "gate", "gate": "M", "targets": [0, 1] }
+  ],
+  "metadata": {
+    "source": "basic-example"
+  }
+}

--- a/qp101-viz/examples/depolarize1-single-highlight.qp101.json
+++ b/qp101-viz/examples/depolarize1-single-highlight.qp101.json
@@ -1,0 +1,129 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 1,
+  "operations": [
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.3
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "target_slots": [
+            0
+          ],
+          "label": "X",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-origin",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 0,
+            "op_path": [
+              1
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": [],
+            "source_branch": "X",
+            "target_qubits": [
+              0
+            ]
+          }
+        },
+        {
+          "kind": "marker",
+          "target_slots": [
+            0
+          ],
+          "label": "Y",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-origin",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 0,
+            "op_path": [
+              1
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": [],
+            "source_branch": "Y",
+            "target_qubits": [
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "label": "D0",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-symptom",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 0,
+            "detector_index": 0,
+            "op_path": [
+              3
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": []
+          }
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "framework": "rstim"
+  }
+}

--- a/qp101-viz/examples/depolarize1-single-highlight.typ
+++ b/qp101-viz/examples/depolarize1-single-highlight.typ
@@ -1,0 +1,7 @@
+#import "../lib.typ": qp101-timeline-file
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= depolarize1 single highlight
+
+#qp101-timeline-file("examples/depolarize1-single-highlight.qp101.json")

--- a/qp101-viz/examples/multi-source-highlight.qp101.json
+++ b/qp101-viz/examples/multi-source-highlight.qp101.json
@@ -1,0 +1,144 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 1,
+  "operations": [
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.1
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "target_slots": [
+            0
+          ],
+          "label": "X",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-origin",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 0,
+            "op_path": [
+              1
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": [],
+            "source_branch": "X",
+            "target_qubits": [
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.2
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "target_slots": [
+            0
+          ],
+          "label": "X",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-origin",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 0,
+            "op_path": [
+              2
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": [],
+            "source_branch": "X",
+            "target_qubits": [
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "label": "D0",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-symptom",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 0,
+            "detector_index": 0,
+            "op_path": [
+              4
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": []
+          }
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "framework": "rstim"
+  }
+}

--- a/qp101-viz/examples/multi-source-highlight.typ
+++ b/qp101-viz/examples/multi-source-highlight.typ
@@ -1,0 +1,7 @@
+#import "../lib.typ": qp101-timeline-file
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= multi-source highlight
+
+#qp101-timeline-file("examples/multi-source-highlight.qp101.json")

--- a/qp101-viz/examples/repeat-detector.qp101.json
+++ b/qp101-viz/examples/repeat-detector.qp101.json
@@ -1,0 +1,38 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 3,
+  "operations": [
+    { "type": "qubit_coords", "coords": [0.0, 0.0], "targets": [0] },
+    { "type": "qubit_coords", "coords": [1.0, 0.0], "targets": [1] },
+    { "type": "qubit_coords", "coords": [2.0, 0.0], "targets": [2] },
+    { "type": "tick" },
+    {
+      "type": "repeat",
+      "count": 2,
+      "body": [
+        { "type": "gate", "gate": "CX", "targets": [0, 1] },
+        { "type": "gate", "gate": "CX", "targets": [1, 2] },
+        { "type": "tick" },
+        { "type": "gate", "gate": "M", "targets": [1] },
+        {
+          "type": "detector",
+          "coords": [1.0, 0.0, 0.0],
+          "sources": [
+            { "kind": "rec", "offset": -1 }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "observable_include",
+      "index": 0,
+      "sources": [
+        { "kind": "rec", "offset": -1 }
+      ]
+    }
+  ],
+  "metadata": {
+    "framework": "rstim"
+  }
+}

--- a/qp101-viz/examples/repeat-highlight.qp101.json
+++ b/qp101-viz/examples/repeat-highlight.qp101.json
@@ -1,0 +1,218 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 8,
+  "operations": [
+    {
+      "type": "repeat",
+      "count": 2,
+      "body": [
+        {
+          "type": "noise",
+          "gate": "DEPOLARIZE1",
+          "params": [
+            0.3
+          ],
+          "raw_targets": [
+            {
+              "kind": "qubit",
+              "index": 5
+            },
+            {
+              "kind": "qubit",
+              "index": 7
+            }
+          ],
+          "annotations": [
+            {
+              "kind": "marker",
+              "target_slots": [
+                1
+              ],
+              "label": "X",
+              "text": "repeat[1]",
+              "style": {
+                "preset": "danger",
+                "color": "red",
+                "highlight": true
+              },
+              "tags": [
+                "dem-origin",
+                "query-result"
+              ],
+              "context": {
+                "dem_error_index": 1,
+                "op_path": [
+                  0,
+                  0
+                ],
+                "query_kind": "dem_error_origin",
+                "repeat_iterations": [
+                  1
+                ],
+                "source_branch": "X",
+                "target_qubits": [
+                  7
+                ]
+              }
+            },
+            {
+              "kind": "marker",
+              "target_slots": [
+                1
+              ],
+              "label": "Y",
+              "text": "repeat[1]",
+              "style": {
+                "preset": "danger",
+                "color": "red",
+                "highlight": true
+              },
+              "tags": [
+                "dem-origin",
+                "query-result"
+              ],
+              "context": {
+                "dem_error_index": 1,
+                "op_path": [
+                  0,
+                  0
+                ],
+                "query_kind": "dem_error_origin",
+                "repeat_iterations": [
+                  1
+                ],
+                "source_branch": "Y",
+                "target_qubits": [
+                  7
+                ]
+              }
+            },
+            {
+              "kind": "marker",
+              "target_slots": [
+                1
+              ],
+              "label": "X",
+              "text": "repeat[0]",
+              "style": {
+                "preset": "danger",
+                "color": "red",
+                "highlight": true
+              },
+              "tags": [
+                "dem-origin",
+                "query-result"
+              ],
+              "context": {
+                "dem_error_index": 1,
+                "op_path": [
+                  0,
+                  0
+                ],
+                "query_kind": "dem_error_origin",
+                "repeat_iterations": [
+                  0
+                ],
+                "source_branch": "X",
+                "target_qubits": [
+                  7
+                ]
+              }
+            },
+            {
+              "kind": "marker",
+              "target_slots": [
+                1
+              ],
+              "label": "Y",
+              "text": "repeat[0]",
+              "style": {
+                "preset": "danger",
+                "color": "red",
+                "highlight": true
+              },
+              "tags": [
+                "dem-origin",
+                "query-result"
+              ],
+              "context": {
+                "dem_error_index": 1,
+                "op_path": [
+                  0,
+                  0
+                ],
+                "query_kind": "dem_error_origin",
+                "repeat_iterations": [
+                  0
+                ],
+                "source_branch": "Y",
+                "target_qubits": [
+                  7
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "tick"
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        5,
+        7
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "label": "D1",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-symptom",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 1,
+            "detector_index": 1,
+            "op_path": [
+              3
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": []
+          }
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "framework": "rstim"
+  }
+}

--- a/qp101-viz/examples/repeat-highlight.typ
+++ b/qp101-viz/examples/repeat-highlight.typ
@@ -1,0 +1,10 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= repeat highlight
+
+#qp101-timeline-file(
+  "examples/repeat-highlight.qp101.json",
+  theme: timeline-theme(step_width: 5.8em),
+)

--- a/qp101-viz/examples/repetition_code_memory_d3_r3.qp101.json
+++ b/qp101-viz/examples/repetition_code_memory_d3_r3.qp101.json
@@ -1,0 +1,462 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 5,
+  "operations": [
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        0.0,
+        0.0
+      ],
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        2.0,
+        0.0
+      ],
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        4.0,
+        0.0
+      ],
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        1.0,
+        0.0
+      ],
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        3.0,
+        0.0
+      ],
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        0,
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        1,
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        1,
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        2,
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        3.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        }
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        0,
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        1,
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        1,
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        2,
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        1.0,
+        0.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -4
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        3.0,
+        0.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -3
+        }
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        0,
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        1,
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        1,
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        2,
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        1.0,
+        0.0,
+        2.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -4
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        3.0,
+        0.0,
+        2.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -3
+        }
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        1.0,
+        0.0,
+        3.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -5
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        3.0,
+        0.0,
+        3.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -4
+        }
+      ]
+    },
+    {
+      "type": "observable_include",
+      "index": 0,
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "framework": "rstim"
+  }
+}

--- a/qp101-viz/examples/rstim-fixture.typ
+++ b/qp101-viz/examples/rstim-fixture.typ
@@ -1,0 +1,10 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= rstim repetition_code_memory_d3_r3
+
+#qp101-timeline-file(
+  "examples/repetition_code_memory_d3_r3.qp101.json",
+  theme: timeline-theme(step_width: 4.8em, lane_width: 5.6em, font_size: 7pt),
+)

--- a/qp101-viz/examples/surface-code-rotated-memory-x-d3-r3-round1.qp101.json
+++ b/qp101-viz/examples/surface-code-rotated-memory-x-d3-r3-round1.qp101.json
@@ -1,0 +1,345 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 17,
+  "operations": [
+    {
+      "type": "qubit_coords",
+      "coords": [0.0, 4.0],
+      "targets": [0]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [1.0, 1.0],
+      "targets": [1]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [1.0, 3.0],
+      "targets": [2]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [1.0, 5.0],
+      "targets": [3]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [2.0, 0.0],
+      "targets": [4]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [2.0, 2.0],
+      "targets": [5]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [2.0, 4.0],
+      "targets": [6]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [3.0, 1.0],
+      "targets": [7]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [3.0, 3.0],
+      "targets": [8]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [3.0, 5.0],
+      "targets": [9]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [4.0, 2.0],
+      "targets": [10]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [4.0, 4.0],
+      "targets": [11]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [4.0, 6.0],
+      "targets": [12]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [5.0, 1.0],
+      "targets": [13]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [5.0, 3.0],
+      "targets": [14]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [5.0, 5.0],
+      "targets": [15]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [6.0, 2.0],
+      "targets": [16]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [1]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [2]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [3]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [7]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [8]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [9]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [13]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [14]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [15]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [0]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [4]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [5]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [6]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [10]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [11]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [12]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [16]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [4]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [6]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [10]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [12]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [4, 7, 6, 9, 10, 14, 3, 0, 8, 5, 15, 11]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [4, 1, 6, 3, 10, 8, 2, 0, 7, 5, 14, 11]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [6, 8, 10, 13, 12, 15, 2, 5, 9, 11, 14, 16]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [6, 2, 10, 7, 12, 9, 1, 5, 8, 11, 13, 16]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [4]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [6]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [10]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [12]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [0]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [4]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [5]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [6]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [10]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [11]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [12]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [16]
+    },
+    {
+      "type": "detector",
+      "coords": [2.0, 0.0, 0.0],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -7
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [2.0, 4.0, 0.0],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -5
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [4.0, 2.0, 0.0],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -4
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [4.0, 6.0, 0.0],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        }
+      ]
+    },
+    {
+      "type": "shift_coords",
+      "delta": [0.0, 0.0, 1.0]
+    },
+    {
+      "type": "tick"
+    }
+  ]
+}

--- a/qp101-viz/examples/surface-code-rotated-memory-x-d3-r3-round1.typ
+++ b/qp101-viz/examples/surface-code-rotated-memory-x-d3-r3-round1.typ
@@ -1,0 +1,16 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= rotated surface code memory X, first measurement round
+
+#qp101-timeline-file(
+  "examples/surface-code-rotated-memory-x-d3-r3-round1.qp101.json",
+  theme: timeline-theme(
+    step_width: 4.8em,
+    font_size: 7pt,
+    note_font_size: 6.2pt,
+    row_spacing: 12pt,
+    gate_padding: 0.28em,
+  ),
+)

--- a/qp101-viz/examples/surface-code-rotated-memory-x-d3-r3.typ
+++ b/qp101-viz/examples/surface-code-rotated-memory-x-d3-r3.typ
@@ -1,0 +1,16 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= rotated surface code memory X, d=3, r=3
+
+#qp101-timeline-file(
+  "examples/surface_code_rotated_memory_x_d3_r3.qp101.json",
+  theme: timeline-theme(
+    step_width: 4.2em,
+    font_size: 6.6pt,
+    note_font_size: 6pt,
+    row_spacing: 12pt,
+    gate_padding: 0.28em,
+  ),
+)

--- a/qp101-viz/examples/surface-code-rotated-memory-z-d3-r5-supported-noise-dem-error-136.typ
+++ b/qp101-viz/examples/surface-code-rotated-memory-z-d3-r5-supported-noise-dem-error-136.typ
@@ -1,0 +1,16 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= rotated surface code memory Z, d=3, r=5, dem error 136
+
+#qp101-timeline-file(
+  "examples/surface_code_rotated_memory_z_d3_r5_supported_noise_dem_error_136.qp101.json",
+  theme: timeline-theme(
+    step_width: 4.2em,
+    font_size: 6.6pt,
+    note_font_size: 6pt,
+    row_spacing: 12pt,
+    gate_padding: 0.28em,
+  ),
+)

--- a/qp101-viz/examples/surface-code-rotated-memory-z-d3-r5-supported-noise-dem-error-137.typ
+++ b/qp101-viz/examples/surface-code-rotated-memory-z-d3-r5-supported-noise-dem-error-137.typ
@@ -2,10 +2,10 @@
 
 #set page(width: auto, height: auto, margin: 10pt)
 
-= rotated surface code memory Z, d=3, r=5, dem error 136
+= rotated surface code memory Z, d=3, r=5, dem error 137
 
 #qp101-timeline-file(
-  "examples/surface_code_rotated_memory_z_d3_r5_supported_noise_dem_error_136.qp101.json",
+  "examples/surface_code_rotated_memory_z_d3_r5_supported_noise_dem_error_137.qp101.json",
   theme: timeline-theme(
     step_width: 4.2em,
     font_size: 6.6pt,

--- a/qp101-viz/examples/surface_code_rotated_memory_x_d3_r3.qp101.json
+++ b/qp101-viz/examples/surface_code_rotated_memory_x_d3_r3.qp101.json
@@ -1,0 +1,1462 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 17,
+  "operations": [
+    {
+      "type": "qubit_coords",
+      "coords": [
+        0.0,
+        4.0
+      ],
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        1.0,
+        1.0
+      ],
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        1.0,
+        3.0
+      ],
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        1.0,
+        5.0
+      ],
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        2.0,
+        0.0
+      ],
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        2.0,
+        2.0
+      ],
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        2.0,
+        4.0
+      ],
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        3.0,
+        1.0
+      ],
+      "targets": [
+        7
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        3.0,
+        3.0
+      ],
+      "targets": [
+        8
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        3.0,
+        5.0
+      ],
+      "targets": [
+        9
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        4.0,
+        2.0
+      ],
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        4.0,
+        4.0
+      ],
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        4.0,
+        6.0
+      ],
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        5.0,
+        1.0
+      ],
+      "targets": [
+        13
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        5.0,
+        3.0
+      ],
+      "targets": [
+        14
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        5.0,
+        5.0
+      ],
+      "targets": [
+        15
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        6.0,
+        2.0
+      ],
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        7
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        8
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        9
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        13
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        14
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "RX",
+      "targets": [
+        15
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        7,
+        6,
+        9,
+        10,
+        14,
+        3,
+        0,
+        8,
+        5,
+        15,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        1,
+        6,
+        3,
+        10,
+        8,
+        2,
+        0,
+        7,
+        5,
+        14,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        8,
+        10,
+        13,
+        12,
+        15,
+        2,
+        5,
+        9,
+        11,
+        14,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        2,
+        10,
+        7,
+        12,
+        9,
+        1,
+        5,
+        8,
+        11,
+        13,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -7
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -5
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -4
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        6.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        }
+      ]
+    },
+    {
+      "type": "shift_coords",
+      "delta": [
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        7,
+        6,
+        9,
+        10,
+        14,
+        3,
+        0,
+        8,
+        5,
+        15,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        1,
+        6,
+        3,
+        10,
+        8,
+        2,
+        0,
+        7,
+        5,
+        14,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        8,
+        10,
+        13,
+        12,
+        15,
+        2,
+        5,
+        9,
+        11,
+        14,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        2,
+        10,
+        7,
+        12,
+        9,
+        1,
+        5,
+        8,
+        11,
+        13,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        0.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -16
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -7
+        },
+        {
+          "kind": "rec",
+          "offset": -15
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -14
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -13
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -4
+        },
+        {
+          "kind": "rec",
+          "offset": -12
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -11
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        6.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -10
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        6.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -9
+        }
+      ]
+    },
+    {
+      "type": "shift_coords",
+      "delta": [
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        7,
+        6,
+        9,
+        10,
+        14,
+        3,
+        0,
+        8,
+        5,
+        15,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        1,
+        6,
+        3,
+        10,
+        8,
+        2,
+        0,
+        7,
+        5,
+        14,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        8,
+        10,
+        13,
+        12,
+        15,
+        2,
+        5,
+        9,
+        11,
+        14,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        2,
+        10,
+        7,
+        12,
+        9,
+        1,
+        5,
+        8,
+        11,
+        13,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        0.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -16
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -7
+        },
+        {
+          "kind": "rec",
+          "offset": -15
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -14
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -13
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -4
+        },
+        {
+          "kind": "rec",
+          "offset": -12
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -11
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        6.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -10
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        6.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -9
+        }
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        7
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        8
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        9
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        13
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        14
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MX",
+      "targets": [
+        15
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        0.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -16
+        },
+        {
+          "kind": "rec",
+          "offset": -9
+        },
+        {
+          "kind": "rec",
+          "offset": -6
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        4.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -14
+        },
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -7
+        },
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -4
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        2.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -13
+        },
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -2
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        6.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -11
+        },
+        {
+          "kind": "rec",
+          "offset": -4
+        },
+        {
+          "kind": "rec",
+          "offset": -1
+        }
+      ]
+    },
+    {
+      "type": "observable_include",
+      "index": 0,
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -9
+        },
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -7
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "framework": "rstim"
+  }
+}

--- a/qp101-viz/examples/surface_code_rotated_memory_z_d3_r5_supported_noise_dem_error_136.qp101.json
+++ b/qp101-viz/examples/surface_code_rotated_memory_z_d3_r5_supported_noise_dem_error_136.qp101.json
@@ -1,0 +1,3098 @@
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 17,
+  "operations": [
+    {
+      "type": "qubit_coords",
+      "coords": [
+        0.0,
+        4.0
+      ],
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        1.0,
+        1.0
+      ],
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        1.0,
+        3.0
+      ],
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        1.0,
+        5.0
+      ],
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        2.0,
+        0.0
+      ],
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        2.0,
+        2.0
+      ],
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        2.0,
+        4.0
+      ],
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        3.0,
+        1.0
+      ],
+      "targets": [
+        7
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        3.0,
+        3.0
+      ],
+      "targets": [
+        8
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        3.0,
+        5.0
+      ],
+      "targets": [
+        9
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        4.0,
+        2.0
+      ],
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        4.0,
+        4.0
+      ],
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        4.0,
+        6.0
+      ],
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        5.0,
+        1.0
+      ],
+      "targets": [
+        13
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        5.0,
+        3.0
+      ],
+      "targets": [
+        14
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        5.0,
+        5.0
+      ],
+      "targets": [
+        15
+      ]
+    },
+    {
+      "type": "qubit_coords",
+      "coords": [
+        6.0,
+        2.0
+      ],
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        7
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        8
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        9
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        13
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        14
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        15
+      ]
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "R",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        },
+        {
+          "kind": "qubit",
+          "index": 4
+        },
+        {
+          "kind": "qubit",
+          "index": 5
+        },
+        {
+          "kind": "qubit",
+          "index": 6
+        },
+        {
+          "kind": "qubit",
+          "index": 10
+        },
+        {
+          "kind": "qubit",
+          "index": 11
+        },
+        {
+          "kind": "qubit",
+          "index": 12
+        },
+        {
+          "kind": "qubit",
+          "index": 16
+        }
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        7,
+        6,
+        9,
+        10,
+        14,
+        3,
+        0,
+        8,
+        5,
+        15,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        1,
+        6,
+        3,
+        10,
+        8,
+        2,
+        0,
+        7,
+        5,
+        14,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        8,
+        10,
+        13,
+        12,
+        15,
+        2,
+        5,
+        9,
+        11,
+        14,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        2,
+        10,
+        7,
+        12,
+        9,
+        1,
+        5,
+        8,
+        11,
+        13,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        },
+        {
+          "kind": "qubit",
+          "index": 4
+        },
+        {
+          "kind": "qubit",
+          "index": 5
+        },
+        {
+          "kind": "qubit",
+          "index": 6
+        },
+        {
+          "kind": "qubit",
+          "index": 10
+        },
+        {
+          "kind": "qubit",
+          "index": 11
+        },
+        {
+          "kind": "qubit",
+          "index": 12
+        },
+        {
+          "kind": "qubit",
+          "index": 16
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        0.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -8
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -6
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        6.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        }
+      ]
+    },
+    {
+      "type": "shift_coords",
+      "delta": [
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        7,
+        6,
+        9,
+        10,
+        14,
+        3,
+        0,
+        8,
+        5,
+        15,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        1,
+        6,
+        3,
+        10,
+        8,
+        2,
+        0,
+        7,
+        5,
+        14,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        8,
+        10,
+        13,
+        12,
+        15,
+        2,
+        5,
+        9,
+        11,
+        14,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        2,
+        10,
+        7,
+        12,
+        9,
+        1,
+        5,
+        8,
+        11,
+        13,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        },
+        {
+          "kind": "qubit",
+          "index": 4
+        },
+        {
+          "kind": "qubit",
+          "index": 5
+        },
+        {
+          "kind": "qubit",
+          "index": 6
+        },
+        {
+          "kind": "qubit",
+          "index": 10
+        },
+        {
+          "kind": "qubit",
+          "index": 11
+        },
+        {
+          "kind": "qubit",
+          "index": 12
+        },
+        {
+          "kind": "qubit",
+          "index": 16
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        0.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -16
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -7
+        },
+        {
+          "kind": "rec",
+          "offset": -15
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -14
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -13
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -4
+        },
+        {
+          "kind": "rec",
+          "offset": -12
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -11
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        6.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -10
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        6.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -9
+        }
+      ]
+    },
+    {
+      "type": "shift_coords",
+      "delta": [
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        7,
+        6,
+        9,
+        10,
+        14,
+        3,
+        0,
+        8,
+        5,
+        15,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        1,
+        6,
+        3,
+        10,
+        8,
+        2,
+        0,
+        7,
+        5,
+        14,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        8,
+        10,
+        13,
+        12,
+        15,
+        2,
+        5,
+        9,
+        11,
+        14,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        2,
+        10,
+        7,
+        12,
+        9,
+        1,
+        5,
+        8,
+        11,
+        13,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        },
+        {
+          "kind": "qubit",
+          "index": 4
+        },
+        {
+          "kind": "qubit",
+          "index": 5
+        },
+        {
+          "kind": "qubit",
+          "index": 6
+        },
+        {
+          "kind": "qubit",
+          "index": 10
+        },
+        {
+          "kind": "qubit",
+          "index": 11
+        },
+        {
+          "kind": "qubit",
+          "index": 12
+        },
+        {
+          "kind": "qubit",
+          "index": 16
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        0.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -16
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -7
+        },
+        {
+          "kind": "rec",
+          "offset": -15
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -14
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -13
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -4
+        },
+        {
+          "kind": "rec",
+          "offset": -12
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -11
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        6.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -10
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        6.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -9
+        }
+      ]
+    },
+    {
+      "type": "shift_coords",
+      "delta": [
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        7,
+        6,
+        9,
+        10,
+        14,
+        3,
+        0,
+        8,
+        5,
+        15,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        1,
+        6,
+        3,
+        10,
+        8,
+        2,
+        0,
+        7,
+        5,
+        14,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        8,
+        10,
+        13,
+        12,
+        15,
+        2,
+        5,
+        9,
+        11,
+        14,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        2,
+        10,
+        7,
+        12,
+        9,
+        1,
+        5,
+        8,
+        11,
+        13,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        },
+        {
+          "kind": "qubit",
+          "index": 4
+        },
+        {
+          "kind": "qubit",
+          "index": 5
+        },
+        {
+          "kind": "qubit",
+          "index": 6
+        },
+        {
+          "kind": "qubit",
+          "index": 10
+        },
+        {
+          "kind": "qubit",
+          "index": 11
+        },
+        {
+          "kind": "qubit",
+          "index": 12
+        },
+        {
+          "kind": "qubit",
+          "index": 16
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        0.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -16
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -7
+        },
+        {
+          "kind": "rec",
+          "offset": -15
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -14
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -13
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -4
+        },
+        {
+          "kind": "rec",
+          "offset": -12
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -11
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        6.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -10
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        6.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -9
+        }
+      ]
+    },
+    {
+      "type": "shift_coords",
+      "delta": [
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        7,
+        6,
+        9,
+        10,
+        14,
+        3,
+        0,
+        8,
+        5,
+        15,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        4,
+        1,
+        6,
+        3,
+        10,
+        8,
+        2,
+        0,
+        7,
+        5,
+        14,
+        11
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        8,
+        10,
+        13,
+        12,
+        15,
+        2,
+        5,
+        9,
+        11,
+        14,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "gate",
+      "gate": "CX",
+      "targets": [
+        6,
+        2,
+        10,
+        7,
+        12,
+        9,
+        1,
+        5,
+        8,
+        11,
+        13,
+        16
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "DEPOLARIZE1",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "target_slots": [
+            7
+          ],
+          "label": "X",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-origin",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 136,
+            "op_path": [
+              203
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": [],
+            "source_branch": "X",
+            "target_qubits": [
+              14
+            ]
+          }
+        },
+        {
+          "kind": "marker",
+          "target_slots": [
+            7
+          ],
+          "label": "Y",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-origin",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 136,
+            "op_path": [
+              203
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": [],
+            "source_branch": "Y",
+            "target_qubits": [
+              14
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "H",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 0
+        },
+        {
+          "kind": "qubit",
+          "index": 4
+        },
+        {
+          "kind": "qubit",
+          "index": 5
+        },
+        {
+          "kind": "qubit",
+          "index": 6
+        },
+        {
+          "kind": "qubit",
+          "index": 10
+        },
+        {
+          "kind": "qubit",
+          "index": 11
+        },
+        {
+          "kind": "qubit",
+          "index": 12
+        },
+        {
+          "kind": "qubit",
+          "index": 16
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        0
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        4
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        5
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        6
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        10
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        11
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        12
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "MR",
+      "targets": [
+        16
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        0.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -16
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        0.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -7
+        },
+        {
+          "kind": "rec",
+          "offset": -15
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -14
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -13
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -4
+        },
+        {
+          "kind": "rec",
+          "offset": -12
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        4.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -11
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        6.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -10
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        6.0,
+        2.0,
+        0.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -1
+        },
+        {
+          "kind": "rec",
+          "offset": -9
+        }
+      ]
+    },
+    {
+      "type": "tick"
+    },
+    {
+      "type": "noise",
+      "gate": "X_ERROR",
+      "params": [
+        0.001
+      ],
+      "raw_targets": [
+        {
+          "kind": "qubit",
+          "index": 1
+        },
+        {
+          "kind": "qubit",
+          "index": 2
+        },
+        {
+          "kind": "qubit",
+          "index": 3
+        },
+        {
+          "kind": "qubit",
+          "index": 7
+        },
+        {
+          "kind": "qubit",
+          "index": 8
+        },
+        {
+          "kind": "qubit",
+          "index": 9
+        },
+        {
+          "kind": "qubit",
+          "index": 13
+        },
+        {
+          "kind": "qubit",
+          "index": 14
+        },
+        {
+          "kind": "qubit",
+          "index": 15
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "target_slots": [
+            7
+          ],
+          "label": "X",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-origin",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 136,
+            "op_path": [
+              227
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": [],
+            "source_branch": "X",
+            "target_qubits": [
+              14
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        1
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        2
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        3
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        7
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        8
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        9
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        13
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        14
+      ]
+    },
+    {
+      "type": "gate",
+      "gate": "M",
+      "targets": [
+        15
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        0.0,
+        4.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -17
+        },
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -7
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        2.0,
+        2.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -15
+        },
+        {
+          "kind": "rec",
+          "offset": -9
+        },
+        {
+          "kind": "rec",
+          "offset": -8
+        },
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -5
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        4.0,
+        4.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -12
+        },
+        {
+          "kind": "rec",
+          "offset": -5
+        },
+        {
+          "kind": "rec",
+          "offset": -4
+        },
+        {
+          "kind": "rec",
+          "offset": -2
+        },
+        {
+          "kind": "rec",
+          "offset": -1
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "label": "D38",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-symptom",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 136,
+            "detector_index": 38,
+            "op_path": [
+              239
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "detector",
+      "coords": [
+        6.0,
+        2.0,
+        1.0
+      ],
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -10
+        },
+        {
+          "kind": "rec",
+          "offset": -3
+        },
+        {
+          "kind": "rec",
+          "offset": -2
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "label": "D39",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-symptom",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 136,
+            "detector_index": 39,
+            "op_path": [
+              240
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "observable_include",
+      "index": 0,
+      "sources": [
+        {
+          "kind": "rec",
+          "offset": -9
+        },
+        {
+          "kind": "rec",
+          "offset": -6
+        },
+        {
+          "kind": "rec",
+          "offset": -3
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "framework": "rstim"
+  }
+}

--- a/qp101-viz/examples/surface_code_rotated_memory_z_d3_r5_supported_noise_dem_error_137.qp101.json
+++ b/qp101-viz/examples/surface_code_rotated_memory_z_d3_r5_supported_noise_dem_error_137.qp101.json
@@ -2453,7 +2453,7 @@
         {
           "kind": "marker",
           "target_slots": [
-            7
+            6
           ],
           "label": "X",
           "style": {
@@ -2466,7 +2466,7 @@
             "query-result"
           ],
           "context": {
-            "dem_error_index": 136,
+            "dem_error_index": 137,
             "op_path": [
               203
             ],
@@ -2474,14 +2474,14 @@
             "repeat_iterations": [],
             "source_branch": "X",
             "target_qubits": [
-              14
+              13
             ]
           }
         },
         {
           "kind": "marker",
           "target_slots": [
-            7
+            6
           ],
           "label": "Y",
           "style": {
@@ -2494,7 +2494,7 @@
             "query-result"
           ],
           "context": {
-            "dem_error_index": 136,
+            "dem_error_index": 137,
             "op_path": [
               203
             ],
@@ -2502,7 +2502,7 @@
             "repeat_iterations": [],
             "source_branch": "Y",
             "target_qubits": [
-              14
+              13
             ]
           }
         }
@@ -2831,7 +2831,7 @@
         {
           "kind": "marker",
           "target_slots": [
-            7
+            6
           ],
           "label": "X",
           "style": {
@@ -2844,7 +2844,7 @@
             "query-result"
           ],
           "context": {
-            "dem_error_index": 136,
+            "dem_error_index": 137,
             "op_path": [
               227
             ],
@@ -2852,7 +2852,7 @@
             "repeat_iterations": [],
             "source_branch": "X",
             "target_qubits": [
-              14
+              13
             ]
           }
         }
@@ -3001,30 +3001,6 @@
           "kind": "rec",
           "offset": -1
         }
-      ],
-      "annotations": [
-        {
-          "kind": "marker",
-          "label": "D38",
-          "style": {
-            "preset": "danger",
-            "color": "red",
-            "highlight": true
-          },
-          "tags": [
-            "dem-symptom",
-            "query-result"
-          ],
-          "context": {
-            "dem_error_index": 136,
-            "detector_index": 38,
-            "op_path": [
-              239
-            ],
-            "query_kind": "dem_error_origin",
-            "repeat_iterations": []
-          }
-        }
       ]
     },
     {
@@ -3062,7 +3038,7 @@
             "query-result"
           ],
           "context": {
-            "dem_error_index": 136,
+            "dem_error_index": 137,
             "detector_index": 39,
             "op_path": [
               240
@@ -3088,6 +3064,30 @@
         {
           "kind": "rec",
           "offset": -3
+        }
+      ],
+      "annotations": [
+        {
+          "kind": "marker",
+          "label": "L0",
+          "style": {
+            "preset": "danger",
+            "color": "red",
+            "highlight": true
+          },
+          "tags": [
+            "dem-symptom",
+            "query-result"
+          ],
+          "context": {
+            "dem_error_index": 137,
+            "observable_index": 0,
+            "op_path": [
+              241
+            ],
+            "query_kind": "dem_error_origin",
+            "repeat_iterations": []
+          }
         }
       ]
     }

--- a/qp101-viz/examples/timeline.typ
+++ b/qp101-viz/examples/timeline.typ
@@ -1,0 +1,14 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= Basic
+
+#qp101-timeline-file("examples/basic.qp101.json")
+
+= Repeat And Detector
+
+#qp101-timeline-file(
+  "examples/repeat-detector.qp101.json",
+  theme: timeline-theme(step_width: 5.8em),
+)

--- a/qp101-viz/lib.typ
+++ b/qp101-viz/lib.typ
@@ -1,0 +1,1417 @@
+#import "@preview/quill:0.7.2": *
+
+#let timeline-theme(
+  step_width: 5.2em,
+  lane_width: 6.5em,
+  font_size: 8pt,
+  note_font_size: 7pt,
+  wire: .75pt + rgb("#2f3540"),
+  color: rgb("#20262e"),
+  scale: 100%,
+  row_spacing: 14pt,
+  column_spacing: auto,
+  gate_padding: .35em,
+  gate_fill: white,
+  noise_fill: rgb("#ffe4d6"),
+  note_color: rgb("#4b5563"),
+  top_label_clearance: -0.15em,
+  circuit_padding: (top: 1.2em, bottom: 1.2em, left: 0.4em, right: 0.6em),
+) = {
+  let resolved_column_spacing = if column_spacing == auto {
+    step_width / 3
+  } else {
+    column_spacing
+  }
+  (
+    step_width: step_width,
+    lane_width: lane_width,
+    font_size: font_size,
+    note_font_size: note_font_size,
+    wire: wire,
+    color: color,
+    scale: scale,
+    row_spacing: row_spacing,
+    column_spacing: resolved_column_spacing,
+    gate_padding: gate_padding,
+    gate_fill: gate_fill,
+    noise_fill: noise_fill,
+    note_color: note_color,
+    top_label_clearance: top_label_clearance,
+    circuit_padding: circuit_padding,
+  )
+}
+
+#let round3(x) = calc.round(x, digits: 3)
+
+#let fmt-num(x) = str(round3(x))
+
+#let fmt-vec(xs) = {
+  if xs.len() == 0 {
+    return "()"
+  }
+  "(" + xs.map(v => fmt-num(v)).join(", ") + ")"
+}
+
+#let contains-int(xs, needle) = {
+  for x in xs {
+    if x == needle {
+      return true
+    }
+  }
+  false
+}
+
+#let unique-ints(xs) = {
+  let out = ()
+  for x in xs {
+    if not contains-int(out, x) {
+      out.push(x)
+    }
+  }
+  out
+}
+
+#let int-tuples-equal(xs, ys) = {
+  if xs.len() != ys.len() {
+    return false
+  }
+  for i in range(xs.len()) {
+    if xs.at(i) != ys.at(i) {
+      return false
+    }
+  }
+  true
+}
+
+#let shifted-qubits(xs) = xs
+
+#let qubits-from-refs(refs) = {
+  let out = ()
+  for ref in refs {
+    let kind = ref.at("kind", default: "")
+    if kind == "qubit" {
+      out.push(ref.at("index"))
+    } else if kind == "pauli" {
+      out.push(ref.at("qubit"))
+    }
+  }
+  unique-ints(out)
+}
+
+#let render-ref(ref) = {
+  let kind = ref.at("kind", default: "")
+  if kind == "qubit" {
+    let prefix = if ref.at("inverted", default: false) { "!" } else { "" }
+    return prefix + "q" + str(ref.at("index"))
+  }
+  if kind == "rec" {
+    return "rec[" + str(ref.at("offset")) + "]"
+  }
+  if kind == "pauli" {
+    let prefix = if ref.at("inverted", default: false) { "!" } else { "" }
+    return prefix + ref.at("basis") + str(ref.at("qubit"))
+  }
+  if kind == "combiner" {
+    return "*"
+  }
+  if kind == "sweep" {
+    return "sweep[" + str(ref.at("index")) + "]"
+  }
+  "?"
+}
+
+#let render-refs(refs) = {
+  if refs.len() == 0 {
+    return "-"
+  }
+  refs.map(render-ref).join(" ")
+}
+
+#let measurement-by-index(measurements, measurement_index) = {
+  for measurement in measurements {
+    if measurement.measurement_index == measurement_index {
+      return measurement
+    }
+  }
+  none
+}
+
+#let resolve-source(ref, measurements, measurement_count) = {
+  let kind = ref.at("kind", default: "")
+  if kind == "rec" {
+    let offset = ref.at("offset", default: 0)
+    let resolved_index = measurement_count + offset + 1
+    if offset >= 0 or resolved_index <= 0 or resolved_index > measurement_count {
+      return (
+        kind: "text",
+        text: "unresolved " + render-ref(ref),
+      )
+    }
+    let measurement = measurement-by-index(measurements, resolved_index)
+    if measurement == none {
+      return (
+        kind: "text",
+        text: "unresolved " + render-ref(ref),
+      )
+    }
+    return (
+      kind: "anchor",
+      index: measurement.measurement_index,
+      text: measurement.anchor,
+    )
+  }
+  (
+    kind: "text",
+    text: render-ref(ref),
+  )
+}
+
+#let resolve-stim-source(ref, measurements, measurement_count) = {
+  let kind = ref.at("kind", default: "")
+  if kind == "rec" {
+    let offset = ref.at("offset", default: 0)
+    let resolved_index = measurement_count + offset + 1
+    if offset >= 0 or resolved_index <= 0 or resolved_index > measurement_count {
+      return (
+        kind: "text",
+        text: render-ref(ref),
+        unresolved: true,
+      )
+    }
+    let measurement = measurement-by-index(measurements, resolved_index)
+    if measurement == none {
+      return (
+        kind: "text",
+        text: render-ref(ref),
+        unresolved: true,
+      )
+    }
+    return (
+      kind: "anchor",
+      index: measurement.measurement_index,
+      text: measurement.anchor,
+      qubit: measurement.qubit,
+      unresolved: false,
+    )
+  }
+  (
+    kind: "text",
+    text: render-ref(ref),
+    unresolved: false,
+  )
+}
+
+#let compress-anchor-run(run) = {
+  if run.len() >= 2 {
+    return (run.first().text + "-" + run.last().text,)
+  }
+  run.map(item => item.text)
+}
+
+#let render-resolved-refs(refs, measurements, measurement_count) = {
+  if refs.len() == 0 {
+    return "-"
+  }
+  let resolved = refs.map(ref => resolve-source(ref, measurements, measurement_count))
+  let out = ()
+  let anchor_run = ()
+
+  for item in resolved {
+    if item.kind == "anchor" {
+      if anchor_run.len() == 0 {
+        anchor_run.push(item)
+      } else if item.index == anchor_run.last().index + 1 {
+        anchor_run.push(item)
+      } else {
+        for text in compress-anchor-run(anchor_run) {
+          out.push(text)
+        }
+        anchor_run = (item,)
+      }
+    } else {
+      if anchor_run.len() > 0 {
+        for text in compress-anchor-run(anchor_run) {
+          out.push(text)
+        }
+        anchor_run = ()
+      }
+      out.push(item.text)
+    }
+  }
+
+  if anchor_run.len() > 0 {
+    for text in compress-anchor-run(anchor_run) {
+      out.push(text)
+    }
+  }
+
+  out.join(" ")
+}
+
+#let stim-source-pieces(refs, measurements, measurement_count) = {
+  if refs.len() == 0 {
+    return ("-",)
+  }
+  refs.map(ref => resolve-stim-source(ref, measurements, measurement_count).text)
+}
+
+#let stim-source-text(refs, measurements, measurement_count) = {
+  stim-source-pieces(refs, measurements, measurement_count).join("*")
+}
+
+#let stim-source-unresolved(refs, measurements, measurement_count) = {
+  for ref in refs {
+    if resolve-stim-source(ref, measurements, measurement_count).at("unresolved", default: false) {
+      return true
+    }
+  }
+  false
+}
+
+#let stim-source-host-qubit(refs, measurements, measurement_count) = {
+  let candidates = ()
+  for ref in refs {
+    let resolved = resolve-stim-source(ref, measurements, measurement_count)
+    if resolved.kind == "anchor" {
+      candidates.push(resolved.qubit)
+    }
+  }
+  if candidates.len() > 0 {
+    return candidates.sorted().first()
+  }
+
+  let fallbacks = qubits-from-refs(refs).sorted()
+  if fallbacks.len() > 0 {
+    return fallbacks.first()
+  }
+
+  0
+}
+
+#let contains-text(xs, needle) = {
+  for x in xs {
+    if x == needle {
+      return true
+    }
+  }
+  false
+}
+
+#let op-annotations(op) = op.at("annotations", default: ())
+
+#let annotation-repeat-iterations(annotation) = {
+  let annotation_context = annotation.at("context", default: none)
+  if annotation_context == none {
+    return none
+  }
+  annotation_context.at("repeat_iterations", default: none)
+}
+
+#let annotation-matches-entry(annotation, entry) = {
+  if annotation.at("kind", default: "") != "marker" {
+    return false
+  }
+  let repeat_iterations = annotation-repeat-iterations(annotation)
+  if repeat_iterations == none {
+    return true
+  }
+  int-tuples-equal(repeat_iterations, entry.at("repeat_iterations", default: ()))
+}
+
+#let annotation-tags(annotation) = annotation.at("tags", default: ())
+
+#let annotation-display-style(annotation) = {
+  let tags = annotation-tags(annotation)
+  if contains-text(tags, "dem-symptom") {
+    return (
+      preset: "info",
+      color: "blue",
+      highlight: true,
+    )
+  }
+  annotation.at("style", default: none)
+}
+
+#let entry-annotations(entry) = {
+  let out = ()
+  for annotation in op-annotations(entry.op) {
+    if annotation-matches-entry(annotation, entry) {
+      out.push(annotation)
+    }
+  }
+  out
+}
+
+#let marker-info-for-slot(entry_annotations, target_slot) = {
+  let labels = ()
+  let texts = ()
+  let style = none
+  for annotation in entry_annotations {
+    if contains-int(annotation.at("target_slots", default: ()), target_slot) {
+      if style == none {
+        style = annotation-display-style(annotation)
+      }
+      let label = annotation.at("label", default: none)
+      if label != none {
+        labels.push(label)
+      }
+      let text_value = annotation.at("text", default: none)
+      if text_value != none and not contains-text(texts, text_value) {
+        texts.push(text_value)
+      }
+    }
+  }
+  if labels.len() == 0 and texts.len() == 0 {
+    return none
+  }
+  (
+    label: if labels.len() == 0 { none } else { labels.join(" ") },
+    text: if texts.len() == 0 { none } else { texts.join(" · ") },
+    style: style,
+  )
+}
+
+#let operation-marker-info(entry_annotations) = {
+  let labels = ()
+  let texts = ()
+  let style = none
+  for annotation in entry_annotations {
+    let target_slots = annotation.at("target_slots", default: ())
+    if target_slots.len() == 0 {
+      if style == none {
+        style = annotation-display-style(annotation)
+      }
+      let label = annotation.at("label", default: none)
+      if label != none {
+        labels.push(label)
+      }
+      let text_value = annotation.at("text", default: none)
+      if text_value != none and not contains-text(texts, text_value) {
+        texts.push(text_value)
+      }
+    }
+  }
+  if labels.len() == 0 and texts.len() == 0 {
+    return none
+  }
+  (
+    label: if labels.len() == 0 { none } else { labels.join(" ") },
+    text: if texts.len() == 0 { none } else { texts.join(" · ") },
+    style: style,
+  )
+}
+
+#let highlight-palette(style) = {
+  if style != none {
+    let preset = style.at("preset", default: "")
+    let color = style.at("color", default: "")
+    if preset == "danger" or color == "red" {
+      return (
+        fill: rgb("#fee2e2"),
+        stroke: rgb("#dc2626"),
+        text: rgb("#991b1b"),
+      )
+    }
+    if preset == "info" or color == "blue" {
+      return (
+        fill: rgb("#dbeafe"),
+        stroke: rgb("#2563eb"),
+        text: rgb("#1d4ed8"),
+      )
+    }
+  }
+  (
+    fill: rgb("#fff3bf"),
+    stroke: rgb("#b45309"),
+    text: rgb("#7c2d12"),
+  )
+}
+
+#let highlight-label-badge(text_value, theme, style: none) = {
+  let palette = highlight-palette(style)
+  box(
+  inset: (x: 0.18em, y: 0.03em),
+  radius: 0.22em,
+  fill: palette.fill,
+  stroke: .45pt + palette.stroke,
+  text(size: theme.note_font_size - 1pt, fill: palette.text)[#text_value],
+)
+}
+
+#let highlight-label-entry(text_value, theme, style: none) = (
+  content: highlight-label-badge(text_value, theme, style: style),
+  pos: top + right,
+  dx: -0.1em,
+  dy: theme.top_label_clearance,
+)
+
+#let highlight-text-entry(text_value, theme, style: none) = {
+  let palette = highlight-palette(style)
+  (
+    content: text(size: theme.note_font_size - 1pt, fill: palette.text)[#text_value],
+    pos: top + right,
+    dx: 1.35em,
+    dy: theme.top_label_clearance,
+  )
+}
+
+#let operation-marker-labels(marker, theme) = {
+  let labels = ()
+  if marker != none and marker.label != none {
+    labels.push(highlight-label-entry(marker.label, theme, style: marker.style))
+  }
+  if marker != none and marker.text != none {
+    labels.push(highlight-text-entry(marker.text, theme, style: marker.style))
+  }
+  labels
+}
+
+#let ref-target-qubit(ref) = {
+  let kind = ref.at("kind", default: "")
+  if kind == "qubit" {
+    return ref.at("index")
+  }
+  if kind == "pauli" {
+    return ref.at("qubit")
+  }
+  none
+}
+
+#let noise-target-slots(op) = {
+  let out = ()
+  for (slot, ref) in op.at("raw_targets", default: ()).enumerate() {
+    let qubit = ref-target-qubit(ref)
+    if qubit != none {
+      out.push((slot: slot, qubit: qubit))
+    }
+  }
+  out
+}
+
+#let noise-target-qubits(op) = shifted-qubits(qubits-from-refs(op.at("raw_targets", default: ())))
+
+#let noise-short-label(op) = {
+  let display = op.at("display", default: none)
+  if display != none {
+    let label = display.at("label", default: none)
+    if label != none {
+      return label
+    }
+  }
+
+  let gate = op.at("gate", default: "")
+  if gate == "X_ERROR" {
+    return "XE"
+  }
+  if gate == "Z_ERROR" {
+    return "ZE"
+  }
+  if gate == "DEPOLARIZE1" {
+    return "D1"
+  }
+  if gate == "DEPOLARIZE2" {
+    return "D2"
+  }
+  gate
+}
+
+#let noise-note-label(op) = {
+  let params = op.at("params", default: ())
+  if params.len() == 0 {
+    return none
+  }
+  params.map(v => fmt-num(v)).join(", ")
+}
+
+#let noise-policy(op) = {
+  let gate = op.at("gate", default: "")
+  if gate == "X_ERROR" or gate == "Z_ERROR" or gate == "DEPOLARIZE1" {
+    return "single"
+  }
+  if gate == "DEPOLARIZE2" {
+    return "pair"
+  }
+  "fallback"
+}
+
+#let noise-qubit-groups(op) = {
+  let targets = noise-target-slots(op)
+  let policy = noise-policy(op)
+
+  if policy == "single" {
+    return targets.map(target => (target.qubit,))
+  }
+  if policy == "pair" and calc.rem(targets.len(), 2) == 0 {
+    let groups = ()
+    for pair in range(calc.floor(targets.len() / 2)) {
+      let i = pair * 2
+      groups.push((targets.at(i).qubit, targets.at(i + 1).qubit))
+    }
+    return groups
+  }
+  ()
+}
+
+#let noise-render-spec(op) = (
+  policy: noise-policy(op),
+  short_label: noise-short-label(op),
+  note: noise-note-label(op),
+  groups: noise-qubit-groups(op),
+)
+
+#let gate-label(op) = {
+  let display = op.at("display", default: none)
+  if display != none {
+    let label = display.at("label", default: none)
+    if label != none {
+      return label
+    }
+  }
+  let gate = op.at("gate")
+  let params = op.at("params", default: ())
+  if params.len() == 0 {
+    return gate
+  }
+  gate + "(" + params.map(v => fmt-num(v)).join(", ") + ")"
+}
+
+#let gate-qubits(op) = {
+  let out = ()
+  for q in op.at("targets", default: ()) {
+    out.push(q)
+  }
+  for q in op.at("controls", default: ()) {
+    out.push(q)
+  }
+  let raw = op.at("raw_targets", default: none)
+  if raw != none {
+    for q in qubits-from-refs(raw) {
+      out.push(q)
+    }
+  }
+  unique-ints(out)
+}
+
+#let span-pass-through(qubits) = {
+  let sorted = unique-ints(qubits).sorted()
+  if sorted.len() < 2 {
+    return ()
+  }
+  let start = sorted.first()
+  let last = sorted.last()
+  let holes = ()
+  for q in range(start + 1, last) {
+    if not contains-int(sorted, q) {
+      holes.push(q - start)
+    }
+  }
+  holes
+}
+
+#let empty-moment() = (top: (), main: (), bottom: ())
+
+#let moment-empty(moment) = moment.top.len() == 0 and moment.main.len() == 0 and moment.bottom.len() == 0
+
+#let moment-add-top(moment, text) = (
+  top: moment.top + (text,),
+  main: moment.main,
+  bottom: moment.bottom,
+)
+
+#let moment-add-main(moment, op) = (
+  top: moment.top,
+  main: moment.main + (op,),
+  bottom: moment.bottom,
+)
+
+#let moment-add-bottom(moment, text) = (
+  top: moment.top,
+  main: moment.main,
+  bottom: moment.bottom + (text,),
+)
+
+#let main-entry(op, measurement_targets: none, op_path: (), repeat_iterations: ()) = (
+  kind: "gate",
+  op: op,
+  measurement_targets: measurement_targets,
+  op_path: op_path,
+  repeat_iterations: repeat_iterations,
+)
+
+#let repeat-group-entry(count, start_moment_index, end_moment_index, iteration_starts) = (
+  label: "repeat x" + str(count),
+  count: count,
+  start_moment_index: start_moment_index,
+  end_moment_index: end_moment_index,
+  iteration_starts: iteration_starts,
+)
+
+#let stim-operator-entry(
+  op,
+  measurements,
+  measurement_count,
+  detector_index: none,
+  op_path: (),
+  repeat_iterations: (),
+) = {
+  let kind = op.at("type", default: "")
+  let sources = op.at("sources", default: ())
+  let source_text = stim-source-text(sources, measurements, measurement_count)
+
+  (
+    op: op,
+    kind: kind,
+    host_qubit: stim-source-host-qubit(sources, measurements, measurement_count),
+    label: if kind == "detector" {
+      "DETECTOR"
+    } else {
+      "OBS_INCLUDE(" + str(op.at("index")) + ")"
+    },
+    source: if kind == "detector" {
+      "D" + str(detector_index) + " = " + source_text
+    } else {
+      "L" + str(op.at("index")) + " *= " + source_text
+    },
+    unresolved: stim-source-unresolved(sources, measurements, measurement_count),
+    index: if kind == "detector" { detector_index } else { op.at("index") },
+    coords: op.at("coords", default: ()),
+    measurement_count: measurement_count,
+    sources: sources,
+    op_path: op_path,
+    repeat_iterations: repeat_iterations,
+  )
+}
+
+#let measurement-targets(op) = {
+  if op.at("type", default: "") != "gate" {
+    return none
+  }
+  let gate = op.at("gate", default: "")
+  if gate != "M" and gate != "MX" and gate != "MR" {
+    return none
+  }
+  let out = ()
+  for (target_index, qubit) in op.at("targets", default: ()).enumerate() {
+    out.push((
+      target_index: target_index,
+      qubit: qubit,
+      gate: gate,
+    ))
+  }
+  out
+}
+
+#let bottom-entry(op, measurement_count) = {
+  let kind = op.at("type", default: "")
+  if kind == "detector" {
+    return (
+      kind: kind,
+      sources: op.at("sources", default: ()),
+      coords: op.at("coords", default: ()),
+      measurement_count: measurement_count,
+    )
+  }
+  if kind == "observable_include" {
+    return (
+      kind: kind,
+      index: op.at("index"),
+      sources: op.at("sources", default: ()),
+      measurement_count: measurement_count,
+    )
+  }
+  none
+}
+
+#let render-bottom-entry(entry, measurements) = {
+  if entry.kind == "detector" {
+    let suffix = if entry.coords.len() == 0 { "" } else { " @ " + fmt-vec(entry.coords) }
+    return "det " + render-resolved-refs(entry.sources, measurements, entry.measurement_count) + suffix
+  }
+  if entry.kind == "observable_include" {
+    return "obs[" + str(entry.index) + "] " + render-resolved-refs(entry.sources, measurements, entry.measurement_count)
+  }
+  "?"
+}
+
+#let collect-render-model-from(
+  ops,
+  moment_base: 0,
+  starting_measurement_index: 0,
+  starting_detector_index: 0,
+  op_path_prefix: (),
+  repeat_iterations: (),
+) = {
+  let moments = ()
+  let measurements = ()
+  let repeat_groups = ()
+  let current = empty-moment()
+  let measurement_index = starting_measurement_index
+  let detector_index = starting_detector_index
+
+  for (op_index, op) in ops.enumerate() {
+    let kind = op.at("type")
+    let op_path = op_path_prefix + (op_index,)
+    if kind == "tick" {
+      if not moment-empty(current) {
+        moments.push(current)
+        current = empty-moment()
+      }
+      moments.push((top: ("|",), main: (), bottom: ()))
+    } else if kind == "repeat" {
+      if not moment-empty(current) {
+        moments.push(current)
+        current = empty-moment()
+      }
+      let count = op.at("count")
+      let group_start = moment_base + moments.len()
+      let iteration_starts = ()
+      for i in range(count) {
+        iteration_starts.push(moment_base + moments.len())
+        let nested = collect-render-model-from(
+          op.at("body"),
+          moment_base: moment_base + moments.len(),
+          starting_measurement_index: measurement_index,
+          starting_detector_index: detector_index,
+          op_path_prefix: op_path,
+          repeat_iterations: repeat_iterations + (i,),
+        )
+        for nested_moment in nested.moments {
+          moments.push(nested_moment)
+        }
+        for measurement in nested.measurements {
+          measurements.push(measurement)
+        }
+        for repeat_group in nested.repeat_groups {
+          repeat_groups.push(repeat_group)
+        }
+        measurement_index = nested.next_measurement_index
+        detector_index = nested.next_detector_index
+      }
+      let group_end = moment_base + moments.len() - 1
+      if group_start <= group_end {
+        repeat_groups.push(repeat-group-entry(count, group_start, group_end, iteration_starts))
+      }
+    } else if kind == "qubit_coords" {
+    } else if kind == "shift_coords" {
+    } else if kind == "detector" {
+      current = moment-add-main(
+        current,
+        stim-operator-entry(
+          op,
+          measurements,
+          measurement_index,
+          detector_index: detector_index,
+          op_path: op_path,
+          repeat_iterations: repeat_iterations,
+        ),
+      )
+      detector_index += 1
+    } else if kind == "observable_include" {
+      current = moment-add-main(
+        current,
+        stim-operator-entry(
+          op,
+          measurements,
+          measurement_index,
+          op_path: op_path,
+          repeat_iterations: repeat_iterations,
+        ),
+      )
+    } else if kind == "annotation" {
+      current = moment-add-top(current, op.at("kind") + ": " + op.at("text"))
+    } else {
+      let measurement_targets = measurement-targets(op)
+      if measurement_targets == none {
+        current = moment-add-main(
+          current,
+          main-entry(op, op_path: op_path, repeat_iterations: repeat_iterations),
+        )
+      } else {
+        let detailed_targets = ()
+        let current_moment_index = moment_base + moments.len()
+        for target in measurement_targets {
+          measurement_index += 1
+          let detail = (
+            measurement_index: measurement_index,
+            anchor: "m" + str(measurement_index),
+            moment_index: current_moment_index,
+            render_moment_index: current_moment_index,
+            target_index: target.target_index,
+            qubit: target.qubit,
+            gate: target.gate,
+          )
+          detailed_targets.push(detail)
+          measurements.push(detail)
+        }
+        current = moment-add-main(
+          current,
+          main-entry(
+            op,
+            measurement_targets: detailed_targets,
+            op_path: op_path,
+            repeat_iterations: repeat_iterations,
+          ),
+        )
+      }
+    }
+  }
+
+  if not moment-empty(current) {
+    moments.push(current)
+  }
+
+  (
+    moments: moments,
+    measurements: measurements,
+    repeat_groups: repeat_groups,
+    next_measurement_index: measurement_index,
+    next_detector_index: detector_index,
+  )
+}
+
+#let collect-render-model(ops) = {
+  let model = collect-render-model-from(ops)
+  (
+    moments: model.moments,
+    measurements: model.measurements,
+    repeat_groups: model.repeat_groups,
+  )
+}
+
+#let note-op(qubit, note_text, theme) = tequila.gate(
+  qubit,
+  text(size: theme.note_font_size, fill: theme.note_color)[#note_text],
+  fill: none,
+  stroke: none,
+)
+
+#let estimated-text-width(text_value, font_size, padding: 0em) = {
+  0.58em * calc.max(str(text_value).len(), 1) + padding
+}
+
+#let max-length(xs) = {
+  let out = xs.first()
+  for x in xs.slice(1) {
+    if x > out {
+      out = x
+    }
+  }
+  out
+}
+
+#let reserved-gate-width(widths, minimum: 1.8em) = {
+  max-length((minimum,) + widths)
+}
+
+#let top-label-clearance(theme) = theme.top_label_clearance
+
+#let measurement-anchor-label(target, theme) = (
+  content: text(size: theme.note_font_size - 1pt, fill: theme.note_color)[#target.anchor],
+  pos: top,
+  dy: top-label-clearance(theme),
+)
+
+#let measurement-gate-labels(target, theme) = ((measurement-anchor-label(target, theme)),)
+
+#let measurement-box-label(target) = {
+  if target.gate == "MX" {
+    return "MX"
+  }
+  if target.gate == "MR" {
+    return "MR"
+  }
+  "M"
+}
+
+#let measurement-box-width(target, theme) = reserved-gate-width((
+  estimated-text-width(measurement-box-label(target), theme.note_font_size, padding: 0.9em),
+  estimated-text-width(target.anchor, theme.note_font_size - 1pt, padding: 0.9em),
+), minimum: 2.2em)
+
+#let measurement-box-gate(target, theme) = tequila.gate(
+  target.qubit,
+  text(size: theme.note_font_size, fill: theme.note_color)[#measurement-box-label(target)],
+  fill: white,
+  stroke: .6pt + theme.note_color,
+  width: measurement-box-width(target, theme),
+  label: (measurement-anchor-label(target, theme),),
+)
+
+#let light-gate(qubit, label, theme) = tequila.gate(
+  qubit,
+  label,
+  fill: none,
+  stroke: .6pt + theme.note_color,
+)
+
+#let noise-note-entry(note, theme) = {
+  if note == none {
+    return ()
+  }
+  (
+    (
+      content: text(size: theme.note_font_size - 1pt, fill: theme.note_color)[#note],
+      pos: top,
+      dy: top-label-clearance(theme),
+    ),
+  )
+}
+
+#let noise-label-entries(note, marker, theme) = {
+  let labels = ()
+  if note != none {
+    labels.push((
+      content: text(size: theme.note_font_size - 1pt, fill: theme.note_color)[#note],
+      pos: top,
+      dy: top-label-clearance(theme),
+    ))
+  }
+  if marker != none and marker.label != none {
+    labels.push(highlight-label-entry(marker.label, theme, style: marker.style))
+  }
+  if marker != none and marker.text != none {
+    labels.push(highlight-text-entry(marker.text, theme, style: marker.style))
+  }
+  labels
+}
+
+#let operation-marker-fill(marker, fallback) = {
+  if marker == none or marker.style == none {
+    return fallback
+  }
+  highlight-palette(marker.style).fill
+}
+
+#let operation-marker-stroke(marker, fallback) = {
+  if marker == none or marker.style == none {
+    return fallback
+  }
+  .6pt + highlight-palette(marker.style).stroke
+}
+
+#let noise-box-width(label, theme) = reserved-gate-width((
+  estimated-text-width(label, theme.note_font_size, padding: 0.8em),
+), minimum: 1.9em)
+
+#let noise-box-gate(qubit, label, theme, note: none, marker: none) = tequila.gate(
+  qubit,
+  text(size: theme.note_font_size, fill: theme.color)[#label],
+  fill: theme.noise_fill,
+  stroke: .6pt + theme.note_color,
+  width: noise-box-width(label, theme),
+  label: noise-label-entries(note, marker, theme),
+)
+
+#let noise-box-constructor(label, theme, note: none, target: none, marker: none) = (x: auto, y: auto) => gate(
+  text(size: theme.note_font_size, fill: theme.color)[#label],
+  x: x,
+  y: y,
+  fill: theme.noise_fill,
+  stroke: .6pt + theme.note_color,
+  width: noise-box-width(label, theme),
+  label: noise-label-entries(note, marker, theme),
+  multi: if target == none {
+    none
+  } else {
+    (
+      target: target,
+      num-qubits: 1,
+      wire-count: 1,
+      wire-stroke: auto,
+      label: none,
+      extent: auto,
+      size-all-wires: false,
+      inputs: none,
+      outputs: none,
+      wire-label: (),
+      pass-through: (),
+    )
+  },
+)
+
+#let generic-gate(qubits, label, theme, fill: none) = {
+  let sorted = unique-ints(qubits).sorted()
+  if sorted.len() == 0 {
+    return none
+  }
+  if sorted.len() == 1 {
+    return tequila.gate(sorted.first(), label, fill: fill)
+  }
+  let first = sorted.first()
+  let last = sorted.last()
+  tequila.mqgate(
+    first,
+    n: last - first + 1,
+    label,
+    fill: fill,
+    pass-through: span-pass-through(sorted),
+  )
+}
+
+#let wire-label-items(num_qubits, top_wire, bottom_wire, theme) = {
+  let items = ()
+  for q in range(num_qubits) {
+    items.push(lstick(
+      text(size: theme.font_size, fill: theme.color)[#("q" + str(q))],
+      x: 0,
+      y: q,
+    ))
+  }
+  items
+}
+
+#let stim-operator-gate(entry, theme) = {
+  let operation_marker = operation-marker-info(entry-annotations(entry))
+  let is_symptom = operation_marker != none and operation_marker.style != none and operation_marker.style.at("color", default: "") == "blue"
+  tequila.gate(
+    entry.host_qubit,
+    text(size: theme.note_font_size, fill: theme.color)[#entry.label],
+    fill: operation-marker-fill(operation_marker, luma(235)),
+    stroke: operation-marker-stroke(operation_marker, .6pt + theme.color),
+    radius: 0pt,
+    width: reserved-gate-width((
+      estimated-text-width(entry.label, theme.note_font_size, padding: 0.9em),
+      estimated-text-width(entry.source, theme.note_font_size - 1pt, padding: 0.9em),
+    ), minimum: 3em),
+    label: (
+      (
+        content: text(size: theme.note_font_size - 1pt, fill: theme.note_color)[#entry.source],
+        pos: top,
+        dy: top-label-clearance(theme),
+      ),
+      ..if is_symptom { () } else { operation-marker-labels(operation_marker, theme) },
+    ),
+  )
+}
+
+#let render-noise-op(entry, theme) = {
+  let op = entry.op
+  let spec = noise-render-spec(op)
+  let matched_annotations = entry-annotations(entry)
+  let target_groups = noise-target-slots(op)
+
+  if spec.policy == "single" and target_groups.len() > 0 {
+    let ops = ()
+    for target in target_groups {
+      let note = spec.note
+      let marker = marker-info-for-slot(matched_annotations, target.slot)
+      ops.push(noise-box-gate(target.qubit, spec.short_label, theme, note: note, marker: marker))
+    }
+    return ops
+  }
+
+  if spec.policy == "pair" and calc.rem(target_groups.len(), 2) == 0 and target_groups.len() > 0 {
+    let ops = ()
+    for pair in range(calc.floor(target_groups.len() / 2)) {
+      let i = pair * 2
+      let group = (target_groups.at(i), target_groups.at(i + 1))
+      let sorted = group.map(target => target.qubit).sorted()
+      let upper = sorted.first()
+      let lower = sorted.last()
+      let note = spec.note
+      ops.push((
+        (
+          qubit: upper,
+          n: lower - upper + 1,
+          supplements: (
+            (lower, noise-box-constructor(spec.short_label, theme)),
+          ),
+          constructor: noise-box-constructor(
+            spec.short_label,
+            theme,
+            note: note,
+            target: lower - upper,
+          ),
+        ),
+      ))
+    }
+    return ops
+  }
+
+  let qubits = noise-target-qubits(op)
+  let gate = generic-gate(qubits, gate-label(op), theme, fill: theme.noise_fill)
+  if gate == none {
+    return ()
+  }
+  (gate,)
+}
+
+#let render-main-op(entry, theme) = {
+  if entry.kind == "detector" or entry.kind == "observable_include" {
+    return (stim-operator-gate(entry, theme),)
+  }
+
+  let op = entry.op
+  let kind = op.at("type")
+  let label = gate-label(op)
+
+  if kind == "noise" {
+    return render-noise-op(entry, theme)
+  }
+
+  let targets = shifted-qubits(op.at("targets", default: ()))
+  let controls = shifted-qubits(op.at("controls", default: ()))
+  let visible = shifted-qubits(gate-qubits(op))
+  let gate = op.at("gate")
+  let measurement_targets = entry.measurement_targets
+
+  if measurement_targets != none {
+    let ops = ()
+    for target in measurement_targets {
+      ops.push(measurement-box-gate(target, theme))
+    }
+    return ops
+  }
+
+  if gate == "R" {
+    return targets.map(t => light-gate(t, "R", theme))
+  }
+  if gate == "RX" {
+    return targets.map(t => light-gate(t, $R_x$, theme))
+  }
+  if gate == "H" {
+    return targets.map(t => tequila.h(t))
+  }
+  if gate == "X" and controls.len() == 0 {
+    return targets.map(t => tequila.x(t))
+  }
+  if gate == "Y" {
+    return targets.map(t => tequila.y(t))
+  }
+  if gate == "Z" and controls.len() == 0 {
+    return targets.map(t => tequila.z(t))
+  }
+  if gate == "S" {
+    return targets.map(t => tequila.s(t))
+  }
+  if gate == "T" {
+    return targets.map(t => tequila.t(t))
+  }
+
+  if controls.len() == 1 and targets.len() == 1 {
+    if gate == "X" {
+      return (tequila.cx(controls.first(), targets.first()),)
+    }
+    if gate == "Z" {
+      return (tequila.cz(controls.first(), targets.first()),)
+    }
+    return (tequila.ca(controls.first(), targets.first(), label, fill: theme.gate_fill),)
+  }
+
+  if controls.len() > 1 and targets.len() == 1 {
+    return (
+      tequila.multi-controlled-gate(
+        controls,
+        targets.first(),
+        gate.with(label, fill: theme.gate_fill),
+      ),
+    )
+  }
+
+  if gate == "S_DAG" and targets.len() == 1 {
+    return (tequila.sdg(targets.first()),)
+  }
+  if gate == "T" and targets.len() == 1 {
+    return (tequila.t(targets.first()),)
+  }
+  if gate == "T_DAG" and targets.len() == 1 {
+    return (tequila.tdg(targets.first()),)
+  }
+  if gate == "CX" and targets.len() == 2 {
+    return (tequila.cx(targets.at(0), targets.at(1)),)
+  }
+  if gate == "CX" and targets.len() > 2 and calc.rem(targets.len(), 2) == 0 {
+    let ops = ()
+    for pair in range(calc.floor(targets.len() / 2)) {
+      let i = pair * 2
+      ops.push(tequila.cx(targets.at(i), targets.at(i + 1)))
+    }
+    return ops
+  }
+  if gate == "CZ" and targets.len() == 2 {
+    return (tequila.cz(targets.at(0), targets.at(1)),)
+  }
+  if gate == "CZ" and targets.len() > 2 and calc.rem(targets.len(), 2) == 0 {
+    let ops = ()
+    for pair in range(calc.floor(targets.len() / 2)) {
+      let i = pair * 2
+      ops.push(tequila.cz(targets.at(i), targets.at(i + 1)))
+    }
+    return ops
+  }
+  if gate == "SWAP" and targets.len() == 2 {
+    return (tequila.swap(targets.at(0), targets.at(1)),)
+  }
+
+  let rendered = generic-gate(
+    if visible.len() == 0 { targets } else { visible },
+    label,
+    theme,
+    fill: theme.gate_fill,
+  )
+  if rendered == none {
+    return ()
+  }
+  (rendered,)
+}
+
+#let build-moment-ops(moment, measurements, top_wire, bottom_wire, theme) = {
+  let ops = ()
+  if moment.top == ("|",) and moment.main.len() == 0 and moment.bottom.len() == 0 {
+    if top_wire == bottom_wire {
+      ops.push(note-op(top_wire, "|", theme))
+    } else {
+      ops.push(tequila.barrier(start: top_wire, end: bottom_wire))
+    }
+    return ops
+  }
+  if moment.top.len() > 0 {
+    ops.push(note-op(top_wire, moment.top.join("  |  "), theme))
+  }
+  for op in moment.main {
+    for rendered in render-main-op(op, theme) {
+      ops.push(rendered)
+    }
+  }
+  if moment.bottom.len() > 0 {
+    ops.push(note-op(bottom_wire, moment.bottom.map(entry => render-bottom-entry(entry, measurements)).join("  |  "), theme))
+  }
+  ops
+}
+
+#let last-column(items) = calc.max(..items.map(item => item.x))
+
+#let repeat-group-label(group, theme) = (
+  content: box(
+    inset: (x: 0.22em, y: 0.04em),
+    radius: 0.18em,
+    fill: white,
+    text(size: theme.note_font_size, fill: theme.note_color)[#group.label],
+  ),
+  pos: top + left,
+  dx: 0.45em,
+  dy: 0.72em,
+)
+
+#let repeat-slice-label(text_value, theme) = (
+  content: text(size: theme.note_font_size - 1pt, fill: theme.note_color)[#text_value],
+  pos: top,
+  dy: 0.62em,
+)
+
+#let build-repeat-decorations(model, moment_spans, top_wire, total_wires, theme) = {
+  let items = ()
+
+  for group in model.repeat_groups {
+    let start_span = moment_spans.at(group.start_moment_index, default: none)
+    let end_span = moment_spans.at(group.end_moment_index, default: none)
+    if start_span == none or end_span == none {
+      continue
+    }
+
+    items.push(gategroup(
+      total_wires,
+      end_span.end - start_span.start + 1,
+      x: start_span.start,
+      y: top_wire,
+      z: "below",
+      padding: (
+        left: 0.2em,
+        right: 0.2em,
+        top: 0.9em,
+        bottom: 0.4em,
+      ),
+      stroke: (paint: luma(180), thickness: .6pt, dash: "dashed"),
+      fill: luma(248),
+      radius: 4pt,
+      label: (repeat-group-label(group, theme),),
+    ))
+
+    for (iteration_offset, moment_index) in group.iteration_starts.slice(1).enumerate() {
+      let span = moment_spans.at(moment_index, default: none)
+      if span == none {
+        continue
+      }
+      items.push(slice(
+        n: total_wires,
+        x: span.start,
+        y: top_wire,
+        z: "below",
+        stroke: (paint: luma(195), thickness: .55pt, dash: "dashed"),
+        label: (repeat-slice-label("iter " + str(iteration_offset + 2), theme),),
+      ))
+    }
+  }
+
+  items
+}
+
+#let qp101-timeline(doc, theme: timeline-theme()) = {
+  let model = collect-render-model(doc.at("operations", default: ()))
+  let moments = model.moments
+  let total_wires = doc.at("num_qubits")
+  let top_wire = 0
+  let bottom_wire = total_wires - 1
+
+  let items = ()
+  let moment_spans = ()
+  let next_x = 1
+
+  for label in wire-label-items(doc.at("num_qubits"), top_wire, bottom_wire, theme) {
+    items.push(label)
+  }
+
+  for moment in moments {
+    let start_x = next_x
+    let ops = build-moment-ops(moment, model.measurements, top_wire, bottom_wire, theme)
+    if ops.len() == 0 {
+      moment_spans.push(none)
+      continue
+    }
+    let built = tequila.build(
+      n: total_wires,
+      x: start_x,
+      y: 0,
+      append-wire: true,
+      ..ops,
+    )
+    for item in built {
+      items.push(item)
+    }
+    let end_x = last-column(built)
+    moment_spans.push((start: start_x, end: end_x))
+    next_x = end_x + 1
+  }
+
+  for item in build-repeat-decorations(model, moment_spans, top_wire, total_wires, theme) {
+    items.push(item)
+  }
+
+  block(
+    inset: 8pt,
+    stroke: .5pt + luma(225),
+    radius: 6pt,
+    fill: white,
+    [
+      #set text(size: 10pt, fill: theme.color)
+      #strong(doc.at("standard", default: "QP101-ZY")) v#doc.at("version", default: "1.0")
+      #v(0.6em)
+      #quantum-circuit(
+        wire: theme.wire,
+        row-spacing: theme.row_spacing,
+        column-spacing: theme.column_spacing,
+        gate-padding: theme.gate_padding,
+        font-size: theme.font_size,
+        color: theme.color,
+        scale: theme.scale,
+        circuit-padding: theme.circuit_padding,
+        wires: total_wires,
+        ..items,
+      )
+    ],
+  )
+}
+
+#let qp101-timeline-file(path, theme: timeline-theme()) = {
+  qp101-timeline(json(path), theme: theme)
+}

--- a/qp101-viz/typst.toml
+++ b/qp101-viz/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "qp101-viz"
+version = "0.1.0"
+compiler = "0.13.0"
+entrypoint = "lib.typ"
+authors = [
+  "nzy",
+  "Codex"
+]
+license = "MIT"
+description = "Timeline visualization helpers for QP101-ZY circuit JSON."
+categories = ["visualization"]
+exclude = ["examples/", "checks/"]

--- a/rstim/doc/QP101-ZY.md
+++ b/rstim/doc/QP101-ZY.md
@@ -19,6 +19,7 @@ Quantum computing frameworks use diverse internal representations for circuits, 
 - a generic gate model for ordinary circuit interchange
 - an ordered `operations` stream for semantics that are not just gates
 - extension points for framework-specific metadata and rendering hints
+- generic per-operation annotations for visualization, debugging, and query results
 - a foundation for visualization, analysis, and future layout-aware renderers
 
 ## Scope And Applicability
@@ -67,41 +68,57 @@ The top-level `gates` array used by earlier draft text is not part of this draft
 
 Execution order lives in `operations`. Non-sequential or auxiliary data belongs in `metadata` or `extensions`.
 
-### rstim Query Highlight Extension
-
-`rstim` may attach query-specific visualization metadata under `extensions.rstim_query_highlights`.
-
-This extension is not part of the generic QP101-ZY core schema. It exists to preserve query results such as "which circuit-side noise sources produced DEM error line N" without mutating the base circuit structure.
-
-Example payload:
-
-```json
-{
-  "extensions": {
-    "rstim_query_highlights": {
-      "version": "1",
-      "query": {
-        "kind": "dem_error_origin",
-        "dem_error_index": 17
-      },
-      "highlights": [
-        {
-          "op_path": [12, 3, 5],
-          "repeat_iterations": [4, 2],
-          "target_slots": [1],
-          "target_qubits": [5],
-          "branch": "Y",
-          "label": "Y"
-        }
-      ]
-    }
-  }
-}
-```
-
 ## Operation Model
 
 Each item in `operations` MUST contain a string `type` field. The protocol defines one generic core operation and a set of standard extension operations.
+
+### Common Operation Fields
+
+Any operation MAY carry an `annotations` array. This field is intended for renderer hints, analysis overlays, query results, and other optional markings that should stay attached to a specific operation instead of living in top-level extension state.
+
+Example:
+
+```json
+{
+  "type": "noise",
+  "gate": "DEPOLARIZE1",
+  "params": [0.001],
+  "raw_targets": [
+    { "kind": "qubit", "index": 5 }
+  ],
+  "annotations": [
+    {
+      "kind": "marker",
+      "target_slots": [0],
+      "label": "X",
+      "text": "repeat[3]",
+      "style": {
+        "preset": "danger",
+        "color": "red",
+        "highlight": true
+      },
+      "tags": ["dem-origin", "query-result"],
+      "context": {
+        "dem_error_index": 17,
+        "op_path": [12, 3, 5],
+        "repeat_iterations": [3],
+        "source_branch": "X",
+        "target_qubits": [5]
+      }
+    }
+  ]
+}
+```
+
+Annotation objects use the following common fields:
+
+- `kind` (required): Annotation subtype such as `"marker"` or `"note"`.
+- `target_slots` (optional): Zero-based target-slot indices within the owning operation.
+- `label` (optional): Short inline label such as `"X"`, `"Y"`, or `"repeat"`.
+- `text` (optional): Longer renderer-facing text shown near the marker.
+- `style` (optional): Generic style hints such as `preset`, `color`, and `highlight`.
+- `tags` (optional): String tags for filtering or downstream processing.
+- `context` (optional): Arbitrary machine-readable JSON payload for tool-specific metadata.
 
 ### Core Gate Operation
 

--- a/rstim/doc/QP101-ZY.md
+++ b/rstim/doc/QP101-ZY.md
@@ -1,0 +1,410 @@
+# QP101-ZY: Quantum Circuit JSON Format
+
+**Version:** 1.0
+**Status:** Draft
+**Contributors:** Design Team
+**Date:** 2026-03-21
+
+## Abstract
+
+This standard defines a JSON format for representing quantum circuits in a framework-agnostic manner while preserving ordered execution semantics that cannot be reduced to a flat gate list. The format supports ordinary gates, parameterized operations, nested repeat blocks, explicit timing markers, coordinate annotations, detector and observable annotations, noise operations, and extension points for framework-specific metadata.
+
+The design goal is "generic core + extensions": ordinary circuit tools can consume the core gate model, while richer quantum error-correction and visualization tools can preserve additional semantics without inventing a separate file format.
+
+## Purpose
+
+Quantum computing frameworks use diverse internal representations for circuits, making it difficult to share circuits between tools, validate implementations, and build interoperable visualization pipelines. This standard provides:
+
+- a clear, human-readable JSON format for quantum circuits
+- a generic gate model for ordinary circuit interchange
+- an ordered `operations` stream for semantics that are not just gates
+- extension points for framework-specific metadata and rendering hints
+- a foundation for visualization, analysis, and future layout-aware renderers
+
+## Scope And Applicability
+
+**This standard covers:**
+
+- JSON representation of quantum circuits with ordered operations
+- common gate operations and parameterized gates
+- explicit timing separators such as `tick`
+- nested repeat structure
+- coordinate and annotation operations needed by visualization tools
+- detector and observable annotations
+- preservation of raw target forms when plain qubit indices are insufficient
+
+**This standard does NOT cover:**
+
+- measurement outcomes or classical post-processing data
+- continuous-time evolution or Hamiltonian simulation
+- optimization or compilation strategies
+- hardware-specific scheduling constraints
+- a canonical semantics for every possible custom extension
+
+## Core JSON Document
+
+A QP101-ZY document MUST contain:
+
+```json
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 2,
+  "operations": []
+}
+```
+
+The top-level `gates` array used by earlier draft text is not part of this draft. Ordered execution is represented by `operations`.
+
+### Top-Level Fields
+
+- `standard` (required): Protocol identifier. MUST be `"QP101-ZY"`.
+- `version` (required): Protocol version string. This draft remains at `"1.0"`.
+- `num_qubits` (required): Total number of qubits in the circuit. MUST be an integer >= 1.
+- `operations` (required): Ordered array of operation objects. May be empty for an identity circuit.
+- `metadata` (optional): Framework-neutral metadata such as source tool, generator info, description, or authoring notes.
+- `extensions` (optional): Non-sequential extension data for rendering, interoperability, or future domains.
+
+Execution order lives in `operations`. Non-sequential or auxiliary data belongs in `metadata` or `extensions`.
+
+### rstim Query Highlight Extension
+
+`rstim` may attach query-specific visualization metadata under `extensions.rstim_query_highlights`.
+
+This extension is not part of the generic QP101-ZY core schema. It exists to preserve query results such as "which circuit-side noise sources produced DEM error line N" without mutating the base circuit structure.
+
+Example payload:
+
+```json
+{
+  "extensions": {
+    "rstim_query_highlights": {
+      "version": "1",
+      "query": {
+        "kind": "dem_error_origin",
+        "dem_error_index": 17
+      },
+      "highlights": [
+        {
+          "op_path": [12, 3, 5],
+          "repeat_iterations": [4, 2],
+          "target_slots": [1],
+          "target_qubits": [5],
+          "branch": "Y",
+          "label": "Y"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Operation Model
+
+Each item in `operations` MUST contain a string `type` field. The protocol defines one generic core operation and a set of standard extension operations.
+
+### Core Gate Operation
+
+The generic core operation is `type: "gate"`:
+
+```json
+{
+  "type": "gate",
+  "gate": "CX",
+  "targets": [1],
+  "controls": [0],
+  "control_configs": [true],
+  "params": [],
+  "display": {
+    "label": "CX"
+  },
+  "tags": []
+}
+```
+
+#### Gate Fields
+
+- `type`: MUST be `"gate"`.
+- `gate` (required): Gate name such as `"H"`, `"X"`, `"CX"`, `"RX"`, or a tool-defined gate identifier.
+- `targets` (optional but usually present): Array of 0-indexed qubit indices addressed directly by the gate.
+- `controls` (optional): Array of 0-indexed control qubit indices.
+- `control_configs` (optional): Boolean array aligned with `controls`. `true` means active-high control and `false` means active-low control.
+- `params` (optional): Ordered numeric parameter list.
+- `raw_targets` (optional): Ordered raw target list for cases where plain `targets` and `controls` are insufficient.
+- `display` (optional): Rendering hint object. The standard currently defines optional `display.label`.
+- `tags` (optional): String tag list carried through from source tools.
+
+A `gate` operation MUST include enough addressing information to interpret the operation. In practice this means at least one of:
+
+- a non-empty `targets` array
+- a non-empty `controls` array
+- a non-empty `raw_targets` array
+
+### Standard Extension Operations
+
+The following operation kinds are standard extension operations. They still appear inside `operations` because they affect execution order, interpretation, or visualization.
+
+#### `repeat`
+
+```json
+{
+  "type": "repeat",
+  "count": 2,
+  "body": [
+    { "type": "tick" },
+    { "type": "gate", "gate": "CX", "targets": [0, 1] }
+  ]
+}
+```
+
+- `count` (required): Positive integer repeat count.
+- `body` (required): Ordered array of nested operations.
+
+`repeat` preserves hierarchical circuit structure and MUST NOT be flattened by default.
+
+#### `tick`
+
+```json
+{ "type": "tick" }
+```
+
+`tick` is an explicit execution marker. It is not derived implicitly from column numbers or rendering layers.
+
+#### `qubit_coords`
+
+```json
+{
+  "type": "qubit_coords",
+  "coords": [0.0, 1.0],
+  "targets": [3]
+}
+```
+
+- `coords` (required): Numeric coordinate vector.
+- `targets` (required): One or more qubit indices whose coordinates are being declared.
+
+#### `shift_coords`
+
+```json
+{
+  "type": "shift_coords",
+  "delta": [0.0, 1.0]
+}
+```
+
+- `delta` (required): Numeric coordinate delta vector.
+
+#### `detector`
+
+```json
+{
+  "type": "detector",
+  "coords": [1.0, 0.0, 0.0],
+  "sources": [
+    { "kind": "rec", "offset": -1 }
+  ]
+}
+```
+
+- `coords` (optional): Numeric coordinate vector. Empty coordinates may be encoded as `[]`.
+- `sources` (required): Ordered source-reference array.
+
+Detectors are annotations about circuit outputs and MUST NOT be coerced into ordinary gate entries.
+
+#### `observable_include`
+
+```json
+{
+  "type": "observable_include",
+  "index": 0,
+  "sources": [
+    { "kind": "rec", "offset": -1 }
+  ]
+}
+```
+
+- `index` (required): Non-negative observable index.
+- `sources` (required): Ordered source-reference array.
+
+#### `noise`
+
+```json
+{
+  "type": "noise",
+  "gate": "X_ERROR",
+  "params": [0.001],
+  "raw_targets": [
+    { "kind": "qubit", "index": 5 }
+  ]
+}
+```
+
+- `gate` (required): Noise or fault operator name.
+- `params` (optional): Numeric parameter list.
+- `raw_targets` (required): Ordered raw target list.
+
+#### `annotation`
+
+```json
+{
+  "type": "annotation",
+  "kind": "comment",
+  "text": "Ancilla preparation region"
+}
+```
+
+- `kind` (required): Annotation subtype identifier.
+- `text` (required): Human-readable annotation payload.
+
+## Raw Targets And Source References
+
+Some frameworks use target forms that cannot be reduced to plain qubit indices. QP101-ZY preserves them through explicit target-reference objects. These objects are used:
+
+- in `raw_targets`
+- in detector `sources`
+- in observable `sources`
+
+### Target-Reference Kinds
+
+#### Qubit Target
+
+```json
+{ "kind": "qubit", "index": 3 }
+```
+
+Optional inversion may be represented as:
+
+```json
+{ "kind": "qubit", "index": 3, "inverted": true }
+```
+
+#### Measurement Record Reference
+
+```json
+{ "kind": "rec", "offset": -1 }
+```
+
+#### Pauli Product Target
+
+```json
+{ "kind": "pauli", "basis": "X", "qubit": 5 }
+```
+
+Optional inversion may be represented as:
+
+```json
+{ "kind": "pauli", "basis": "Z", "qubit": 7, "inverted": true }
+```
+
+Allowed `basis` values are `"X"`, `"Y"`, and `"Z"`.
+
+#### Combiner
+
+```json
+{ "kind": "combiner" }
+```
+
+#### Sweep Target
+
+```json
+{ "kind": "sweep", "index": 7 }
+```
+
+## Validation Rules
+
+A conforming document MUST satisfy all of the following:
+
+1. `standard` MUST equal `"QP101-ZY"`.
+2. `version` MUST equal `"1.0"` for this draft.
+3. `num_qubits` MUST be an integer >= 1.
+4. All qubit indices in `targets`, `controls`, `qubit` target references, and `qubit_coords.targets` MUST be in `[0, num_qubits)`.
+5. `repeat.count` MUST be an integer >= 1.
+6. `repeat.body` MUST be present and MUST be an array.
+7. `tick` MUST NOT carry qubit indices, raw targets, or parameters.
+8. `detector.sources` and `observable_include.sources` MUST be explicit source-reference arrays.
+9. `observable_include.index` MUST be a non-negative integer.
+10. `control_configs`, if present, MUST have the same length as `controls`.
+11. `noise.raw_targets` MUST be present and MUST preserve target order.
+12. `raw_targets` MUST preserve data that cannot be losslessly normalized into plain qubit indices.
+
+## Examples
+
+### Example A: Ordinary Gate-Only Circuit
+
+```json
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 2,
+  "operations": [
+    { "type": "gate", "gate": "H", "targets": [0] },
+    {
+      "type": "gate",
+      "gate": "X",
+      "targets": [1],
+      "controls": [0],
+      "control_configs": [true]
+    },
+    { "type": "gate", "gate": "M", "targets": [0, 1] }
+  ],
+  "metadata": {
+    "source": "generic-demo"
+  }
+}
+```
+
+### Example B: Stim-Style QEC Circuit
+
+```json
+{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 2,
+  "operations": [
+    { "type": "qubit_coords", "coords": [0.0, 0.0], "targets": [0] },
+    { "type": "qubit_coords", "coords": [1.0, 0.0], "targets": [1] },
+    { "type": "tick" },
+    {
+      "type": "repeat",
+      "count": 2,
+      "body": [
+        { "type": "gate", "gate": "CX", "targets": [0, 1] },
+        { "type": "tick" },
+        { "type": "gate", "gate": "M", "targets": [1] },
+        {
+          "type": "detector",
+          "coords": [0.5, 0.0, 0.0],
+          "sources": [
+            { "kind": "rec", "offset": -1 }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "observable_include",
+      "index": 0,
+      "sources": [
+        { "kind": "rec", "offset": -1 }
+      ]
+    }
+  ],
+  "metadata": {
+    "framework": "rstim"
+  }
+}
+```
+
+## Rendering Guidance
+
+This standard does not mandate a single renderer, but it is designed to support:
+
+- timeline renderers with qubits on the vertical axis and operations on the horizontal axis
+- future coordinate-layout renderers that consume `qubit_coords`, `shift_coords`, and annotation coordinates
+
+Renderers SHOULD treat `detector`, `observable_include`, `qubit_coords`, and `shift_coords` as annotation-like elements rather than ordinary gate boxes. Renderers MAY expand `repeat` blocks for display, but serialized documents SHOULD preserve the nested structure.
+
+## Compatibility Notes
+
+- Tools that only understand generic circuits MAY ignore unknown extension operations, provided they do not claim full semantic fidelity.
+- Tools that need full semantic fidelity SHOULD preserve unknown fields and unknown operation types when possible.
+- Draft implementations SHOULD prefer adding information through optional fields or standard extension operations instead of inventing a second top-level execution stream.

--- a/rstim/src/cli.rs
+++ b/rstim/src/cli.rs
@@ -182,6 +182,8 @@ pub enum Commands {
         out: Option<String>,
         #[arg(long, default_value = "pretty")]
         format: String,
+        #[arg(long = "highlight_dem_error")]
+        highlight_dem_error: Option<usize>,
     },
 }
 
@@ -408,11 +410,16 @@ pub fn run(cli: Cli) -> Result<(), String> {
                 )
             }
         }
-        Some(Commands::ExportJson { r#in, out, format }) => {
+        Some(Commands::ExportJson {
+            r#in,
+            out,
+            format,
+            highlight_dem_error,
+        }) => {
             let text = read_input(r#in.as_deref())?;
             let format = parse_json_output_format(&format)?;
             let mut w = open_output(out.as_deref())?;
-            run_export_json(&text, format, &mut w)
+            run_export_json(&text, format, highlight_dem_error, &mut w)
         }
         None => {
             println!("rstim {}", crate::version());
@@ -689,9 +696,27 @@ pub fn run_analyze_errors_with_flags(
         .map_err(|e| format!("write error: {e}"))
 }
 
-fn run_export_json(text: &str, format: JsonOutputFormat, w: &mut dyn Write) -> Result<(), String> {
+fn run_export_json(
+    text: &str,
+    format: JsonOutputFormat,
+    highlight_dem_error: Option<usize>,
+    w: &mut dyn Write,
+) -> Result<(), String> {
     let instrs = parse_lines(text)?;
-    let doc = crate::qp101::export_qp101(&instrs)?;
+    let doc = match highlight_dem_error {
+        Some(index) => {
+            let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&instrs)?;
+            crate::qp101::export_qp101_with_highlighted_dem_error(&instrs, &tracked, index)
+                .map_err(|err| {
+                    if err.starts_with("DEM error index ") && err.contains(" out of range ") {
+                        format!("DEM error index out of range: {err}")
+                    } else {
+                        err
+                    }
+                })?
+        }
+        None => crate::qp101::export_qp101(&instrs)?,
+    };
     match format {
         JsonOutputFormat::Pretty => {
             serde_json::to_writer_pretty(&mut *w, &doc).map_err(|e| format!("write error: {e}"))?

--- a/rstim/src/cli.rs
+++ b/rstim/src/cli.rs
@@ -705,7 +705,15 @@ fn run_export_json(
     let instrs = parse_lines(text)?;
     let doc = match highlight_dem_error {
         Some(index) => {
-            let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&instrs)?;
+            let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&instrs).map_err(|err| {
+                if err.starts_with("tracked DEM does not yet support instruction ") {
+                    format!(
+                        "--highlight_dem_error currently supports a subset of noise instructions: {err}"
+                    )
+                } else {
+                    err
+                }
+            })?;
             crate::qp101::export_qp101_with_highlighted_dem_error(&instrs, &tracked, index)
                 .map_err(|err| {
                     if err.starts_with("DEM error index ") && err.contains(" out of range ") {

--- a/rstim/src/dem_provenance.rs
+++ b/rstim/src/dem_provenance.rs
@@ -1,0 +1,98 @@
+use crate::dem::{DemTarget, DetectorErrorModel};
+use serde::{Deserialize, Serialize};
+
+pub type SourceId = usize;
+pub type DemErrorId = usize;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SourceBranch {
+    X,
+    Y,
+    Z,
+    XX,
+    XY,
+    XZ,
+    YX,
+    YY,
+    YZ,
+    ZX,
+    ZY,
+    ZZ,
+    MeasurementFlip,
+    CorrelatedBranch { index: usize },
+    Custom { label: String },
+}
+
+impl SourceBranch {
+    pub fn label(&self) -> String {
+        match self {
+            SourceBranch::X => "X".to_string(),
+            SourceBranch::Y => "Y".to_string(),
+            SourceBranch::Z => "Z".to_string(),
+            SourceBranch::XX => "XX".to_string(),
+            SourceBranch::XY => "XY".to_string(),
+            SourceBranch::XZ => "XZ".to_string(),
+            SourceBranch::YX => "YX".to_string(),
+            SourceBranch::YY => "YY".to_string(),
+            SourceBranch::YZ => "YZ".to_string(),
+            SourceBranch::ZX => "ZX".to_string(),
+            SourceBranch::ZY => "ZY".to_string(),
+            SourceBranch::ZZ => "ZZ".to_string(),
+            SourceBranch::MeasurementFlip => "M".to_string(),
+            SourceBranch::CorrelatedBranch { index } => format!("E{index}"),
+            SourceBranch::Custom { label } => label.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TrackedSource {
+    pub source_id: SourceId,
+    pub op_path: Vec<usize>,
+    pub repeat_iterations: Vec<u64>,
+    pub instr_name: String,
+    pub target_slots: Vec<usize>,
+    pub target_qubits: Vec<u32>,
+    pub branch: SourceBranch,
+    pub probability_fragment: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackedErrorTerm {
+    pub probability: f64,
+    pub targets: Vec<DemTarget>,
+    pub source_ids: Vec<SourceId>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrackedDemResult {
+    pub dem: DetectorErrorModel,
+    pub sources: Vec<TrackedSource>,
+    pub dem_error_to_sources: Vec<Vec<SourceId>>,
+    pub source_to_dem_errors: Vec<Vec<DemErrorId>>,
+}
+
+impl TrackedDemResult {
+    pub fn from_terms_and_sources(sources: Vec<TrackedSource>, terms: Vec<TrackedErrorTerm>) -> Self {
+        let mut dem = DetectorErrorModel::new();
+        let mut dem_error_to_sources = Vec::with_capacity(terms.len());
+        for term in terms {
+            dem.add_error(term.probability, term.targets);
+            dem_error_to_sources.push(term.source_ids);
+        }
+
+        let mut source_to_dem_errors = vec![Vec::new(); sources.len()];
+        for (dem_error_id, source_ids) in dem_error_to_sources.iter().enumerate() {
+            for &source_id in source_ids {
+                source_to_dem_errors[source_id].push(dem_error_id);
+            }
+        }
+
+        Self {
+            dem,
+            sources,
+            dem_error_to_sources,
+            source_to_dem_errors,
+        }
+    }
+}

--- a/rstim/src/dem_provenance.rs
+++ b/rstim/src/dem_provenance.rs
@@ -57,6 +57,30 @@ pub struct TrackedSource {
     pub probability_fragment: f64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HighlightRecord {
+    pub op_path: Vec<usize>,
+    pub repeat_iterations: Vec<u64>,
+    pub target_slots: Vec<usize>,
+    pub target_qubits: Vec<u32>,
+    pub branch: String,
+    pub label: String,
+}
+
+impl HighlightRecord {
+    pub fn from_source(source: &TrackedSource) -> Self {
+        let branch = source.branch.label();
+        Self {
+            op_path: source.op_path.clone(),
+            repeat_iterations: source.repeat_iterations.clone(),
+            target_slots: source.target_slots.clone(),
+            target_qubits: source.target_qubits.clone(),
+            branch: branch.clone(),
+            label: format!("{} {}", source.instr_name, branch),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct TrackedErrorTerm {
     pub probability: f64,

--- a/rstim/src/dem_provenance.rs
+++ b/rstim/src/dem_provenance.rs
@@ -76,7 +76,7 @@ impl HighlightRecord {
             target_slots: source.target_slots.clone(),
             target_qubits: source.target_qubits.clone(),
             branch: branch.clone(),
-            label: format!("{} {}", source.instr_name, branch),
+            label: branch,
         }
     }
 }

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -158,6 +158,27 @@ impl ErrorAnalyzer {
         instrs: &[StimInstr],
         options: AnalyzeOptions,
     ) -> Result<TrackedDemResult, String> {
+        Self::circuit_to_tracked_dem_inner(instrs, options, false)
+    }
+
+    pub fn circuit_to_tracked_dem_decomposed(
+        instrs: &[StimInstr],
+    ) -> Result<TrackedDemResult, String> {
+        Self::circuit_to_tracked_dem_with_options_decomposed(instrs, AnalyzeOptions::default())
+    }
+
+    pub fn circuit_to_tracked_dem_with_options_decomposed(
+        instrs: &[StimInstr],
+        options: AnalyzeOptions,
+    ) -> Result<TrackedDemResult, String> {
+        Self::circuit_to_tracked_dem_inner(instrs, options, true)
+    }
+
+    fn circuit_to_tracked_dem_inner(
+        instrs: &[StimInstr],
+        options: AnalyzeOptions,
+        decompose_errors_after_merge: bool,
+    ) -> Result<TrackedDemResult, String> {
         let num_qubits = count_qubits(instrs);
         let num_measurements = count_measurements(instrs);
         let num_detectors = count_annotations(instrs, "DETECTOR");
@@ -181,6 +202,11 @@ impl ErrorAnalyzer {
 
         let annotations = collect_detector_annotations(instrs);
         let merged_terms = merge_tracked_terms(analyzer.tracked_terms);
+        let merged_terms = if decompose_errors_after_merge {
+            merge_tracked_terms(decompose_tracked_terms(merged_terms)?)
+        } else {
+            merged_terms
+        };
         let mut tracked =
             TrackedDemResult::from_terms_and_sources(analyzer.tracked_sources, merged_terms);
         tracked.dem.set_min_counts(num_detectors, num_observables);
@@ -2248,31 +2274,15 @@ pub fn decompose_errors(dem: &mut DetectorErrorModel) -> Result<(), String> {
     }
 
     let mut new_instrs = instrs;
-    let mut known_symptoms: BTreeMap<Vec<DemTarget>, Vec<DemTarget>> = BTreeMap::new();
-    for instr in &new_instrs {
-        let DemInstruction::Error {
-            probability,
-            targets,
-        } = instr
-        else {
-            continue;
-        };
-        if *probability == 0.0 || targets.is_empty() {
-            continue;
-        }
-
-        let mut start = 0usize;
-        for k in 0..=targets.len() {
-            if k == targets.len() || matches!(targets[k], DemTarget::Separator) {
-                let component = &targets[start..k];
-                let key = detector_symptom_key(component);
-                if key.len() == 1 || key.len() == 2 {
-                    known_symptoms.insert(key, component.to_vec());
-                }
-                start = k + 1;
-            }
-        }
-    }
+    let known_symptoms = collect_known_graphlike_symptoms(
+        new_instrs.iter().filter_map(|instr| match instr {
+            DemInstruction::Error {
+                probability,
+                targets,
+            } if *probability > 0.0 && !targets.is_empty() => Some(targets.as_slice()),
+            _ => None,
+        }),
+    );
 
     for instr in &mut new_instrs {
         let DemInstruction::Error { targets, .. } = instr else {
@@ -2282,37 +2292,7 @@ pub fn decompose_errors(dem: &mut DetectorErrorModel) -> Result<(), String> {
             continue;
         }
 
-        let original_targets = targets.clone();
-        let mut rewritten = Vec::new();
-        let mut start = 0usize;
-        for k in 0..=original_targets.len() {
-            if k == original_targets.len() || matches!(original_targets[k], DemTarget::Separator) {
-                let component = &original_targets[start..k];
-                let brute_force_attempt = brute_force_decomposition_into_known_graphlike_errors(
-                    component,
-                    &known_symptoms,
-                );
-                let brute_force = brute_force_attempt?;
-                let decomposed = if let Some(flat) = brute_force {
-                    flat
-                } else if let Some(flat) =
-                    decompose_component_with_remnants(component, &known_symptoms)
-                {
-                    flat
-                } else {
-                    return Err(format!(
-                        "failed to decompose non-graphlike error into graphlike components: {:?}",
-                        original_targets
-                    ));
-                };
-                if !rewritten.is_empty() && !decomposed.is_empty() {
-                    rewritten.push(DemTarget::Separator);
-                }
-                rewritten.extend(decomposed);
-                start = k + 1;
-            }
-        }
-        *targets = rewritten;
+        *targets = rewrite_error_targets_with_known_symptoms(targets, &known_symptoms)?;
     }
 
     let mut merged_errors: BTreeMap<Vec<DemTarget>, f64> = BTreeMap::new();
@@ -2354,6 +2334,90 @@ pub fn decompose_errors(dem: &mut DetectorErrorModel) -> Result<(), String> {
     Ok(())
 }
 
+fn collect_known_graphlike_symptoms<'a>(
+    error_targets: impl Iterator<Item = &'a [DemTarget]>,
+) -> BTreeMap<Vec<DemTarget>, Vec<DemTarget>> {
+    let mut known_symptoms = BTreeMap::new();
+    for targets in error_targets {
+        let mut start = 0usize;
+        for k in 0..=targets.len() {
+            if k == targets.len() || matches!(targets[k], DemTarget::Separator) {
+                let component = &targets[start..k];
+                let key = detector_symptom_key(component);
+                if key.len() == 1 || key.len() == 2 {
+                    known_symptoms.insert(key, component.to_vec());
+                }
+                start = k + 1;
+            }
+        }
+    }
+    known_symptoms
+}
+
+fn rewrite_error_targets_with_known_symptoms(
+    original_targets: &[DemTarget],
+    known_symptoms: &BTreeMap<Vec<DemTarget>, Vec<DemTarget>>,
+) -> Result<Vec<DemTarget>, String> {
+    let mut rewritten = Vec::new();
+    let mut start = 0usize;
+    for k in 0..=original_targets.len() {
+        if k == original_targets.len() || matches!(original_targets[k], DemTarget::Separator) {
+            let component = &original_targets[start..k];
+            let brute_force =
+                brute_force_decomposition_into_known_graphlike_errors(component, known_symptoms)?;
+            let decomposed = if let Some(flat) = brute_force {
+                flat
+            } else if let Some(flat) = decompose_component_with_remnants(component, known_symptoms)
+            {
+                flat
+            } else {
+                return Err(format!(
+                    "failed to decompose non-graphlike error into graphlike components: {:?}",
+                    original_targets
+                ));
+            };
+            if !rewritten.is_empty() && !decomposed.is_empty() {
+                rewritten.push(DemTarget::Separator);
+            }
+            rewritten.extend(decomposed);
+            start = k + 1;
+        }
+    }
+    Ok(rewritten)
+}
+
+fn decompose_tracked_terms(terms: Vec<TrackedErrorTerm>) -> Result<Vec<TrackedErrorTerm>, String> {
+    let known_symptoms = collect_known_graphlike_symptoms(
+        terms.iter()
+            .filter(|term| term.probability > 0.0 && !term.targets.is_empty())
+            .map(|term| term.targets.as_slice()),
+    );
+
+    terms.into_iter()
+        .map(|term| {
+            if term.probability <= 0.0
+                || term.targets.is_empty()
+                || component_is_graphlike(&term.targets)
+            {
+                return Ok(term);
+            }
+
+            let targets = match rewrite_error_targets_with_known_symptoms(
+                &term.targets,
+                &known_symptoms,
+            ) {
+                Ok(targets) => targets,
+                Err(_) => term.targets,
+            };
+            Ok(TrackedErrorTerm {
+                probability: term.probability,
+                targets,
+                source_ids: term.source_ids,
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod internal_branch_tests {
     use super::*;
@@ -2367,6 +2431,8 @@ mod internal_branch_tests {
             num_measurements,
             det_index: 0,
             errors: Vec::new(),
+            tracked_sources: Vec::new(),
+            tracked_terms: Vec::new(),
             decompose_channel_errors: false,
             options: AnalyzeOptions::default(),
         }

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -1043,7 +1043,7 @@ impl ErrorAnalyzer {
                     return Ok(());
                 }
 
-                let branch_probability = p / 3.0;
+                let branch_probability = depolarize1_to_independent(p);
                 for (target_slot, q) in qubits(targets).into_iter().enumerate() {
                     let x_targets = self.x_sens[q].targets.clone();
                     let z_targets = self.z_sens[q].targets.clone();

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -2402,13 +2402,10 @@ fn decompose_tracked_terms(terms: Vec<TrackedErrorTerm>) -> Result<Vec<TrackedEr
                 return Ok(term);
             }
 
-            let targets = match rewrite_error_targets_with_known_symptoms(
+            let targets = rewrite_error_targets_with_known_symptoms(
                 &term.targets,
                 &known_symptoms,
-            ) {
-                Ok(targets) => targets,
-                Err(_) => term.targets,
-            };
+            )?;
             Ok(TrackedErrorTerm {
                 probability: term.probability,
                 targets,

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -87,6 +87,42 @@ fn canonicalize_error_targets(targets: &[DemTarget]) -> Vec<DemTarget> {
     out
 }
 
+fn merge_tracked_terms(terms: Vec<TrackedErrorTerm>) -> Vec<TrackedErrorTerm> {
+    let mut merged: BTreeMap<Vec<DemTarget>, (f64, Vec<usize>)> = BTreeMap::new();
+    for term in terms.into_iter().rev() {
+        if term.probability <= 0.0 || term.targets.is_empty() {
+            continue;
+        }
+
+        let targets = canonicalize_error_targets(&term.targets);
+        merged
+            .entry(targets)
+            .and_modify(|(probability, source_ids)| {
+                *probability = *probability + term.probability - 2.0 * *probability * term.probability;
+                source_ids.extend(term.source_ids.iter().copied());
+                source_ids.sort_unstable();
+                source_ids.dedup();
+            })
+            .or_insert_with(|| {
+                let mut source_ids = term.source_ids;
+                source_ids.sort_unstable();
+                source_ids.dedup();
+                (term.probability, source_ids)
+            });
+    }
+
+    merged
+        .into_iter()
+        .filter_map(|(targets, (probability, source_ids))| {
+            (probability > 0.0).then_some(TrackedErrorTerm {
+                probability,
+                targets,
+                source_ids,
+            })
+        })
+        .collect()
+}
+
 pub struct ErrorAnalyzer {
     x_sens: Vec<SparseXorVec>,
     z_sens: Vec<SparseXorVec>,
@@ -144,8 +180,9 @@ impl ErrorAnalyzer {
         analyzer.ensure_no_pending_gauge()?;
 
         let annotations = collect_detector_annotations(instrs);
+        let merged_terms = merge_tracked_terms(analyzer.tracked_terms);
         let mut tracked =
-            TrackedDemResult::from_terms_and_sources(analyzer.tracked_sources, analyzer.tracked_terms);
+            TrackedDemResult::from_terms_and_sources(analyzer.tracked_sources, merged_terms);
         tracked.dem.set_min_counts(num_detectors, num_observables);
         for ann in annotations {
             tracked.dem.push(ann);
@@ -1012,6 +1049,51 @@ impl ErrorAnalyzer {
                         SourceBranch::Z,
                         branch_probability,
                         z_targets,
+                    );
+                }
+                Ok(())
+            }
+            "X_ERROR" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                for (target_slot, q) in qubits(targets).into_iter().enumerate() {
+                    self.emit_tracked_source_term(
+                        context,
+                        "X_ERROR",
+                        target_slot,
+                        q as u32,
+                        SourceBranch::X,
+                        p,
+                        self.x_sens[q].targets.clone(),
+                    );
+                }
+                Ok(())
+            }
+            "Y_ERROR" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                for (target_slot, q) in qubits(targets).into_iter().enumerate() {
+                    self.emit_tracked_source_term(
+                        context,
+                        "Y_ERROR",
+                        target_slot,
+                        q as u32,
+                        SourceBranch::Y,
+                        p,
+                        Self::xor_sorted_targets(&self.x_sens[q].targets, &self.z_sens[q].targets),
+                    );
+                }
+                Ok(())
+            }
+            "Z_ERROR" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                for (target_slot, q) in qubits(targets).into_iter().enumerate() {
+                    self.emit_tracked_source_term(
+                        context,
+                        "Z_ERROR",
+                        target_slot,
+                        q as u32,
+                        SourceBranch::Z,
+                        p,
+                        self.z_sens[q].targets.clone(),
                     );
                 }
                 Ok(())

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 use crate::dem::{DemInstruction, DemTarget, DetectorErrorModel};
+use crate::dem_provenance::{SourceBranch, TrackedDemResult, TrackedErrorTerm, TrackedSource};
 use crate::ir::{PauliBasis, StimInstr, StimTarget};
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -93,6 +94,8 @@ pub struct ErrorAnalyzer {
     num_measurements: usize,
     det_index: usize,
     errors: Vec<(f64, Vec<DemTarget>)>,
+    tracked_sources: Vec<TrackedSource>,
+    tracked_terms: Vec<TrackedErrorTerm>,
     decompose_channel_errors: bool,
     // Phase 2 options are threaded first and consumed by later tasks.
     #[allow(dead_code)]
@@ -109,6 +112,45 @@ impl ErrorAnalyzer {
         options: AnalyzeOptions,
     ) -> Result<DetectorErrorModel, String> {
         Self::circuit_to_dem_inner(instrs, options, false)
+    }
+
+    pub fn circuit_to_tracked_dem(instrs: &[StimInstr]) -> Result<TrackedDemResult, String> {
+        Self::circuit_to_tracked_dem_with_options(instrs, AnalyzeOptions::default())
+    }
+
+    pub fn circuit_to_tracked_dem_with_options(
+        instrs: &[StimInstr],
+        options: AnalyzeOptions,
+    ) -> Result<TrackedDemResult, String> {
+        let num_qubits = count_qubits(instrs);
+        let num_measurements = count_measurements(instrs);
+        let num_detectors = count_annotations(instrs, "DETECTOR");
+        let num_observables = count_annotations(instrs, "OBSERVABLE_INCLUDE");
+
+        let mut analyzer = ErrorAnalyzer {
+            x_sens: vec![SparseXorVec::default(); num_qubits],
+            z_sens: vec![SparseXorVec::default(); num_qubits],
+            measurement_sens: vec![SparseXorVec::default(); num_measurements],
+            num_measurements,
+            det_index: num_detectors,
+            errors: Vec::new(),
+            tracked_sources: Vec::new(),
+            tracked_terms: Vec::new(),
+            decompose_channel_errors: false,
+            options,
+        };
+
+        analyzer.undo_circuit_tracked(instrs, &TrackedTraversalContext::root())?;
+        analyzer.ensure_no_pending_gauge()?;
+
+        let annotations = collect_detector_annotations(instrs);
+        let mut tracked =
+            TrackedDemResult::from_terms_and_sources(analyzer.tracked_sources, analyzer.tracked_terms);
+        tracked.dem.set_min_counts(num_detectors, num_observables);
+        for ann in annotations {
+            tracked.dem.push(ann);
+        }
+        Ok(tracked)
     }
 
     fn circuit_to_dem_inner(
@@ -139,6 +181,8 @@ impl ErrorAnalyzer {
             num_measurements,
             det_index: num_detectors,
             errors: Vec::new(),
+            tracked_sources: Vec::new(),
+            tracked_terms: Vec::new(),
             decompose_channel_errors,
             options,
         };
@@ -247,6 +291,35 @@ impl ErrorAnalyzer {
                 StimInstr::Repeat { count, body } => {
                     for _ in 0..*count {
                         self.undo_circuit(body)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn undo_circuit_tracked(
+        &mut self,
+        instrs: &[StimInstr],
+        context: &TrackedTraversalContext,
+    ) -> Result<(), String> {
+        let mut i = instrs.len();
+        while i > 0 {
+            i -= 1;
+            match &instrs[i] {
+                StimInstr::Op {
+                    name,
+                    args,
+                    targets,
+                    ..
+                } => {
+                    let op_context = context.with_op_index(i);
+                    self.undo_op_tracked(name.as_str(), args, targets, &op_context)?;
+                }
+                StimInstr::Repeat { count, body } => {
+                    for iteration in (0..*count).rev() {
+                        let repeat_context = context.with_repeat_iteration(i, iteration);
+                        self.undo_circuit_tracked(body, &repeat_context)?;
                     }
                 }
             }
@@ -790,6 +863,177 @@ impl ErrorAnalyzer {
         Ok(())
     }
 
+    fn undo_op_tracked(
+        &mut self,
+        name: &str,
+        args: &[f64],
+        targets: &[StimTarget],
+        context: &TrackedTraversalContext,
+    ) -> Result<(), String> {
+        match name {
+            "M" | "MZ" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                let qubits = qubits_inv(targets);
+                for (target_slot, q) in qubits.iter().copied().enumerate().rev() {
+                    self.ensure_z_collapse_is_deterministic(q)?;
+                    self.emit_measurement_noise_tracked(
+                        p,
+                        context,
+                        target_slot,
+                        q as u32,
+                        name,
+                    );
+                    self.undo_mz(q);
+                }
+                Ok(())
+            }
+            "MX" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                let qubits = qubits_inv(targets);
+                for (target_slot, q) in qubits.iter().copied().enumerate().rev() {
+                    self.ensure_x_collapse_is_deterministic(q)?;
+                    self.emit_measurement_noise_tracked(
+                        p,
+                        context,
+                        target_slot,
+                        q as u32,
+                        name,
+                    );
+                    self.undo_mx(q);
+                }
+                Ok(())
+            }
+            "MY" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                let qubits = qubits_inv(targets);
+                for (target_slot, q) in qubits.iter().copied().enumerate().rev() {
+                    self.ensure_y_collapse_is_deterministic(q)?;
+                    self.emit_measurement_noise_tracked(
+                        p,
+                        context,
+                        target_slot,
+                        q as u32,
+                        name,
+                    );
+                    self.undo_my(q);
+                }
+                Ok(())
+            }
+            "MR" | "MRZ" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                let qubits = qubits_inv(targets);
+                for (target_slot, q) in qubits.iter().copied().enumerate().rev() {
+                    self.ensure_z_collapse_is_deterministic(q)?;
+                    self.emit_measurement_noise_tracked(
+                        p,
+                        context,
+                        target_slot,
+                        q as u32,
+                        name,
+                    );
+                    self.x_sens[q].clear();
+                    self.z_sens[q].clear();
+                    self.undo_mz(q);
+                }
+                Ok(())
+            }
+            "MRX" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                let qubits = qubits_inv(targets);
+                for (target_slot, q) in qubits.iter().copied().enumerate().rev() {
+                    self.ensure_x_collapse_is_deterministic(q)?;
+                    self.emit_measurement_noise_tracked(
+                        p,
+                        context,
+                        target_slot,
+                        q as u32,
+                        name,
+                    );
+                    self.x_sens[q].clear();
+                    self.z_sens[q].clear();
+                    self.undo_mx(q);
+                }
+                Ok(())
+            }
+            "MRY" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                let qubits = qubits_inv(targets);
+                for (target_slot, q) in qubits.iter().copied().enumerate().rev() {
+                    self.ensure_y_collapse_is_deterministic(q)?;
+                    self.emit_measurement_noise_tracked(
+                        p,
+                        context,
+                        target_slot,
+                        q as u32,
+                        name,
+                    );
+                    self.x_sens[q].clear();
+                    self.z_sens[q].clear();
+                    self.undo_my(q);
+                }
+                Ok(())
+            }
+            "DEPOLARIZE1" => {
+                let p = args.first().copied().unwrap_or(0.0);
+                ensure_valid_depolarize1_probability(p)?;
+                if p <= 0.0 {
+                    return Ok(());
+                }
+
+                let branch_probability = p / 3.0;
+                for (target_slot, q) in qubits(targets).into_iter().enumerate() {
+                    let x_targets = self.x_sens[q].targets.clone();
+                    let z_targets = self.z_sens[q].targets.clone();
+                    let y_targets = Self::xor_sorted_targets(&x_targets, &z_targets);
+
+                    self.emit_tracked_source_term(
+                        context,
+                        "DEPOLARIZE1",
+                        target_slot,
+                        q as u32,
+                        SourceBranch::X,
+                        branch_probability,
+                        x_targets,
+                    );
+                    self.emit_tracked_source_term(
+                        context,
+                        "DEPOLARIZE1",
+                        target_slot,
+                        q as u32,
+                        SourceBranch::Y,
+                        branch_probability,
+                        y_targets,
+                    );
+                    self.emit_tracked_source_term(
+                        context,
+                        "DEPOLARIZE1",
+                        target_slot,
+                        q as u32,
+                        SourceBranch::Z,
+                        branch_probability,
+                        z_targets,
+                    );
+                }
+                Ok(())
+            }
+            "I" | "X" | "Y" | "Z" | "TICK" | "QUBIT_COORDS" | "SHIFT_COORDS" | "H" | "S"
+            | "SQRT_Z" | "S_DAG" | "SQRT_Z_DAG" | "SQRT_X" | "SQRT_X_DAG" | "SQRT_Y"
+            | "SQRT_Y_DAG" | "H_XY" | "H_YZ" | "C_XYZ" | "C_NXYZ" | "C_XNYZ"
+            | "C_XYNZ" | "C_ZYX" | "C_NZYX" | "C_ZNYX" | "C_ZYNX" | "H_NXY"
+            | "H_NXZ" | "H_NYZ" | "CX" | "CNOT" | "ZCX" | "CY" | "ZCY" | "CZ"
+            | "ZCZ" | "XCX" | "XCY" | "XCZ" | "YCX" | "YCY" | "YCZ" | "SWAP"
+            | "ISWAP" | "ISWAP_DAG" | "CXSWAP" | "SWAPCX" | "CZSWAP" | "R" | "RZ"
+            | "RX" | "RY" | "MPAD" | "DETECTOR" | "OBSERVABLE_INCLUDE" | "MPP" | "SPP"
+            | "SPP_DAG" | "MXX" | "MYY" | "MZZ" | "I_ERROR" | "II_ERROR" => {
+                self.undo_op(name, args, targets)
+            }
+            _ => Err(format!(
+                "tracked DEM does not yet support instruction {}",
+                name
+            )),
+        }
+    }
+
     fn undo_mz(&mut self, q: usize) {
         self.num_measurements -= 1;
         let m_idx = self.num_measurements;
@@ -1034,6 +1278,63 @@ impl ErrorAnalyzer {
         if !targets.is_empty() {
             self.errors.push((probability, targets));
         }
+    }
+
+    fn emit_measurement_noise_tracked(
+        &mut self,
+        probability: f64,
+        context: &TrackedTraversalContext,
+        target_slot: usize,
+        target_qubit: u32,
+        instr_name: &str,
+    ) {
+        if probability <= 0.0 || self.num_measurements == 0 {
+            return;
+        }
+        let targets = self.measurement_sens[self.num_measurements - 1]
+            .targets
+            .clone();
+        self.emit_tracked_source_term(
+            context,
+            instr_name,
+            target_slot,
+            target_qubit,
+            SourceBranch::MeasurementFlip,
+            probability,
+            targets,
+        );
+    }
+
+    fn emit_tracked_source_term(
+        &mut self,
+        context: &TrackedTraversalContext,
+        instr_name: &str,
+        target_slot: usize,
+        target_qubit: u32,
+        branch: SourceBranch,
+        probability_fragment: f64,
+        targets: Vec<DemTarget>,
+    ) {
+        if probability_fragment <= 0.0 || targets.is_empty() {
+            return;
+        }
+
+        let source_id = self.tracked_sources.len();
+        self.tracked_sources.push(TrackedSource {
+            source_id,
+            op_path: context.op_path.clone(),
+            repeat_iterations: context.repeat_iterations.clone(),
+            instr_name: instr_name.to_string(),
+            target_slots: vec![target_slot],
+            target_qubits: vec![target_qubit],
+            branch,
+            probability_fragment,
+        });
+        self.tracked_terms.push(TrackedErrorTerm {
+            probability: probability_fragment,
+            targets,
+            source_ids: vec![source_id],
+        });
     }
 
     fn undo_h(&mut self, q: usize) {
@@ -1306,6 +1607,38 @@ impl ErrorAnalyzer {
             "observable"
         } else {
             "detector"
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct TrackedTraversalContext {
+    op_path: Vec<usize>,
+    repeat_iterations: Vec<u64>,
+}
+
+impl TrackedTraversalContext {
+    fn root() -> Self {
+        Self::default()
+    }
+
+    fn with_op_index(&self, op_index: usize) -> Self {
+        let mut op_path = self.op_path.clone();
+        op_path.push(op_index);
+        Self {
+            op_path,
+            repeat_iterations: self.repeat_iterations.clone(),
+        }
+    }
+
+    fn with_repeat_iteration(&self, repeat_op_index: usize, iteration: u64) -> Self {
+        let mut op_path = self.op_path.clone();
+        op_path.push(repeat_op_index);
+        let mut repeat_iterations = self.repeat_iterations.clone();
+        repeat_iterations.push(iteration);
+        Self {
+            op_path,
+            repeat_iterations,
         }
     }
 }

--- a/rstim/src/lib.rs
+++ b/rstim/src/lib.rs
@@ -11,6 +11,7 @@ pub mod sim;
 pub mod coords;
 pub mod sampler;
 pub mod dem;
+pub mod dem_provenance;
 pub mod error_analyzer;
 pub mod showcase;
 pub mod output;

--- a/rstim/src/qp101.rs
+++ b/rstim/src/qp101.rs
@@ -174,10 +174,7 @@ pub fn export_qp101_with_highlighted_dem_error(
             "highlights": highlights,
         }
     });
-    doc.extensions = Some(match doc.extensions.take() {
-        Some(existing) => merge_extension_objects(existing, highlight_extension),
-        None => highlight_extension,
-    });
+    doc.extensions = Some(highlight_extension);
     Ok(doc)
 }
 
@@ -251,16 +248,6 @@ fn export_operations(instrs: &[StimInstr]) -> Result<Vec<Qp101Operation>, String
         }
     }
     Ok(ops)
-}
-
-fn merge_extension_objects(existing: serde_json::Value, added: serde_json::Value) -> serde_json::Value {
-    match (existing, added) {
-        (serde_json::Value::Object(mut existing_map), serde_json::Value::Object(added_map)) => {
-            existing_map.extend(added_map);
-            serde_json::Value::Object(existing_map)
-        }
-        (_, added) => added,
-    }
 }
 
 fn export_plain_qubit_targets(name: &str, targets: &[StimTarget]) -> Result<Vec<u32>, String> {

--- a/rstim/src/qp101.rs
+++ b/rstim/src/qp101.rs
@@ -18,6 +18,33 @@ pub struct Qp101Document {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Qp101Annotation {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub target_slots: Vec<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style: Option<Qp101AnnotationStyle>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Qp101AnnotationStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preset: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub highlight: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum Qp101Operation {
     #[serde(rename = "gate")]
@@ -36,43 +63,62 @@ pub enum Qp101Operation {
         display: Option<Qp101Display>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tags: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
     },
     #[serde(rename = "tick")]
-    Tick,
+    Tick {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
+    },
     #[serde(rename = "repeat")]
     Repeat {
         count: u64,
         body: Vec<Qp101Operation>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
     },
     #[serde(rename = "qubit_coords")]
     QubitCoords {
         coords: Vec<f64>,
         targets: Vec<u32>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
     },
     #[serde(rename = "shift_coords")]
     ShiftCoords {
         delta: Vec<f64>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
     },
     #[serde(rename = "detector")]
     Detector {
         coords: Vec<f64>,
         sources: Vec<Qp101TargetRef>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
     },
     #[serde(rename = "observable_include")]
     ObservableInclude {
         index: u32,
         sources: Vec<Qp101TargetRef>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
     },
     #[serde(rename = "noise")]
     Noise {
         gate: String,
         params: Vec<f64>,
         raw_targets: Vec<Qp101TargetRef>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
     },
     #[serde(rename = "annotation")]
     Annotation {
         kind: String,
         text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Qp101Annotation>,
     },
 }
 
@@ -145,7 +191,6 @@ pub fn export_qp101_with_highlighted_dem_error(
 
     let mut doc = export_qp101(instrs)?;
     let mut seen = BTreeSet::new();
-    let mut highlights = Vec::new();
     for &source_id in source_ids {
         let source = tracked.sources.get(source_id).ok_or_else(|| {
             format!(
@@ -160,21 +205,29 @@ pub fn export_qp101_with_highlighted_dem_error(
             highlight.branch.clone(),
         );
         if seen.insert(dedupe_key) {
-            highlights.push(highlight);
+            let annotation = Qp101Annotation {
+                kind: "marker".to_string(),
+                target_slots: highlight.target_slots.clone(),
+                label: Some(highlight.label.clone()),
+                text: format_repeat_annotation_text(&highlight.repeat_iterations),
+                style: Some(Qp101AnnotationStyle {
+                    preset: Some("danger".to_string()),
+                    color: Some("red".to_string()),
+                    highlight: Some(true),
+                }),
+                tags: vec!["dem-origin".to_string(), "query-result".to_string()],
+                context: Some(json!({
+                    "query_kind": "dem_error_origin",
+                    "dem_error_index": dem_error_index,
+                    "op_path": highlight.op_path,
+                    "repeat_iterations": highlight.repeat_iterations,
+                    "target_qubits": highlight.target_qubits,
+                    "source_branch": highlight.branch,
+                })),
+            };
+            add_annotation_at_path(&mut doc.operations, &source.op_path, annotation)?;
         }
     }
-
-    let highlight_extension = json!({
-        "rstim_query_highlights": {
-            "version": "1",
-            "query": {
-                "kind": "dem_error_origin",
-                "dem_error_index": dem_error_index,
-            },
-            "highlights": highlights,
-        }
-    });
-    doc.extensions = Some(highlight_extension);
     Ok(doc)
 }
 
@@ -185,6 +238,7 @@ fn export_operations(instrs: &[StimInstr]) -> Result<Vec<Qp101Operation>, String
             StimInstr::Repeat { count, body } => ops.push(Qp101Operation::Repeat {
                 count: *count,
                 body: export_operations(body)?,
+                annotations: Vec::new(),
             }),
             StimInstr::Op {
                 name,
@@ -196,30 +250,37 @@ fn export_operations(instrs: &[StimInstr]) -> Result<Vec<Qp101Operation>, String
                 let op = match name.as_str() {
                     "TICK" => {
                         validate_no_args_or_targets(name, args, targets)?;
-                        Qp101Operation::Tick
+                        Qp101Operation::Tick {
+                            annotations: Vec::new(),
+                        }
                     }
                     "QUBIT_COORDS" => Qp101Operation::QubitCoords {
                         coords: args.clone(),
                         targets: export_plain_qubit_targets(name, targets)?,
+                        annotations: Vec::new(),
                     },
                     "SHIFT_COORDS" => {
                         validate_no_targets(name, targets)?;
                         Qp101Operation::ShiftCoords {
                             delta: args.clone(),
+                            annotations: Vec::new(),
                         }
                     }
                     "DETECTOR" => Qp101Operation::Detector {
                         coords: args.clone(),
                         sources: export_rec_sources(name, targets)?,
+                        annotations: Vec::new(),
                     },
                     "OBSERVABLE_INCLUDE" => Qp101Operation::ObservableInclude {
                         index: parse_observable_index(args)?,
                         sources: export_rec_sources(name, targets)?,
+                        annotations: Vec::new(),
                     },
                     n if is_noise_op(n) => Qp101Operation::Noise {
                         gate: n.to_string(),
                         params: args.clone(),
                         raw_targets: export_targets(targets),
+                        annotations: Vec::new(),
                     },
                     _ => {
                         let targets_out: Vec<u32> =
@@ -240,6 +301,7 @@ fn export_operations(instrs: &[StimInstr]) -> Result<Vec<Qp101Operation>, String
                             },
                             display: None,
                             tags: tag.iter().cloned().collect(),
+                            annotations: Vec::new(),
                         }
                     }
                 };
@@ -248,6 +310,58 @@ fn export_operations(instrs: &[StimInstr]) -> Result<Vec<Qp101Operation>, String
         }
     }
     Ok(ops)
+}
+
+fn format_repeat_annotation_text(repeat_iterations: &[u64]) -> Option<String> {
+    (!repeat_iterations.is_empty()).then(|| {
+        format!(
+            "repeat[{}]",
+            repeat_iterations
+                .iter()
+                .map(u64::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    })
+}
+
+fn add_annotation_at_path(
+    operations: &mut [Qp101Operation],
+    op_path: &[usize],
+    annotation: Qp101Annotation,
+) -> Result<(), String> {
+    let Some((&head, tail)) = op_path.split_first() else {
+        return Err("highlight source is missing an op_path".to_string());
+    };
+    let op = operations
+        .get_mut(head)
+        .ok_or_else(|| format!("highlight op_path component {head} out of range"))?;
+    if tail.is_empty() {
+        op.annotations_mut().push(annotation);
+        return Ok(());
+    }
+    match op {
+        Qp101Operation::Repeat { body, .. } => add_annotation_at_path(body, tail, annotation),
+        _ => Err(format!(
+            "highlight op_path descends into non-repeat operation at component {head}"
+        )),
+    }
+}
+
+impl Qp101Operation {
+    fn annotations_mut(&mut self) -> &mut Vec<Qp101Annotation> {
+        match self {
+            Qp101Operation::Gate { annotations, .. }
+            | Qp101Operation::Tick { annotations }
+            | Qp101Operation::Repeat { annotations, .. }
+            | Qp101Operation::QubitCoords { annotations, .. }
+            | Qp101Operation::ShiftCoords { annotations, .. }
+            | Qp101Operation::Detector { annotations, .. }
+            | Qp101Operation::ObservableInclude { annotations, .. }
+            | Qp101Operation::Noise { annotations, .. }
+            | Qp101Operation::Annotation { annotations, .. } => annotations,
+        }
+    }
 }
 
 fn export_plain_qubit_targets(name: &str, targets: &[StimTarget]) -> Result<Vec<u32>, String> {

--- a/rstim/src/qp101.rs
+++ b/rstim/src/qp101.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use crate::dem::{DemInstruction, DemTarget};
 use crate::dem_provenance::{HighlightRecord, TrackedDemResult};
 use crate::ir::{PauliBasis, StimInstr, StimTarget};
 use serde::{Deserialize, Serialize};
@@ -189,15 +190,32 @@ pub fn export_qp101_with_highlighted_dem_error(
             )
         })?;
 
-    let mut doc = export_qp101(instrs)?;
-    let mut seen = BTreeSet::new();
+    let mut source_highlights = Vec::with_capacity(source_ids.len());
     for &source_id in source_ids {
         let source = tracked.sources.get(source_id).ok_or_else(|| {
-            format!(
-                "tracked source index {source_id} missing for DEM error {dem_error_index}"
-            )
+            format!("tracked source index {source_id} missing for DEM error {dem_error_index}")
         })?;
-        let highlight = HighlightRecord::from_source(source);
+        source_highlights.push((source, HighlightRecord::from_source(source)));
+    }
+
+    let dem_targets = match tracked.dem.instructions().get(dem_error_index) {
+        Some(DemInstruction::Error { targets, .. }) => targets.clone(),
+        Some(_) => {
+            return Err(format!(
+                "DEM error index {dem_error_index} does not point to an error instruction"
+            ));
+        }
+        None => {
+            return Err(format!(
+                "DEM error index {dem_error_index} out of range for {} tracked DEM errors",
+                tracked.dem_error_to_sources.len()
+            ));
+        }
+    };
+
+    let mut doc = export_qp101(instrs)?;
+    let mut seen = BTreeSet::new();
+    for (source, highlight) in source_highlights {
         let dedupe_key = (
             highlight.op_path.clone(),
             highlight.repeat_iterations.clone(),
@@ -210,11 +228,7 @@ pub fn export_qp101_with_highlighted_dem_error(
                 target_slots: highlight.target_slots.clone(),
                 label: Some(highlight.label.clone()),
                 text: format_repeat_annotation_text(&highlight.repeat_iterations),
-                style: Some(Qp101AnnotationStyle {
-                    preset: Some("danger".to_string()),
-                    color: Some("red".to_string()),
-                    highlight: Some(true),
-                }),
+                style: Some(danger_annotation_style()),
                 tags: vec!["dem-origin".to_string(), "query-result".to_string()],
                 context: Some(json!({
                     "query_kind": "dem_error_origin",
@@ -228,6 +242,7 @@ pub fn export_qp101_with_highlighted_dem_error(
             add_annotation_at_path(&mut doc.operations, &source.op_path, annotation)?;
         }
     }
+    add_symptom_annotations(&mut doc.operations, instrs, &dem_targets, dem_error_index)?;
     Ok(doc)
 }
 
@@ -323,6 +338,183 @@ fn format_repeat_annotation_text(repeat_iterations: &[u64]) -> Option<String> {
                 .join(",")
         )
     })
+}
+
+fn danger_annotation_style() -> Qp101AnnotationStyle {
+    Qp101AnnotationStyle {
+        preset: Some("danger".to_string()),
+        color: Some("red".to_string()),
+        highlight: Some(true),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct QueryAnnotationLocation {
+    op_path: Vec<usize>,
+    repeat_iterations: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct QueryTraversalContext {
+    op_path: Vec<usize>,
+    repeat_iterations: Vec<u64>,
+}
+
+impl QueryTraversalContext {
+    fn with_op_index(&self, op_index: usize) -> Self {
+        let mut op_path = self.op_path.clone();
+        op_path.push(op_index);
+        Self {
+            op_path,
+            repeat_iterations: self.repeat_iterations.clone(),
+        }
+    }
+
+    fn with_repeat_iteration(&self, repeat_op_index: usize, iteration: u64) -> Self {
+        let mut op_path = self.op_path.clone();
+        op_path.push(repeat_op_index);
+        let mut repeat_iterations = self.repeat_iterations.clone();
+        repeat_iterations.push(iteration);
+        Self {
+            op_path,
+            repeat_iterations,
+        }
+    }
+}
+
+fn add_symptom_annotations(
+    operations: &mut [Qp101Operation],
+    instrs: &[StimInstr],
+    dem_targets: &[DemTarget],
+    dem_error_index: usize,
+) -> Result<(), String> {
+    let mut detector_locations = Vec::new();
+    let mut observable_locations = Vec::new();
+    collect_query_annotation_locations(
+        instrs,
+        &QueryTraversalContext::default(),
+        &mut detector_locations,
+        &mut observable_locations,
+    )?;
+
+    let mut seen = BTreeSet::new();
+    for target in dem_targets {
+        match target {
+            DemTarget::Detector(index) => {
+                let location = detector_locations.get(*index).ok_or_else(|| {
+                    format!("detector index {index} missing from exported QP101 operations")
+                })?;
+                let key = (
+                    "D".to_string(),
+                    *index,
+                    location.op_path.clone(),
+                    location.repeat_iterations.clone(),
+                );
+                if seen.insert(key) {
+                    add_annotation_at_path(
+                        operations,
+                        &location.op_path,
+                        Qp101Annotation {
+                            kind: "marker".to_string(),
+                            target_slots: Vec::new(),
+                            label: Some(format!("D{index}")),
+                            text: format_repeat_annotation_text(&location.repeat_iterations),
+                            style: Some(danger_annotation_style()),
+                            tags: vec!["dem-symptom".to_string(), "query-result".to_string()],
+                            context: Some(json!({
+                                "query_kind": "dem_error_origin",
+                                "dem_error_index": dem_error_index,
+                                "detector_index": index,
+                                "op_path": location.op_path,
+                                "repeat_iterations": location.repeat_iterations,
+                            })),
+                        },
+                    )?;
+                }
+            }
+            DemTarget::Observable(index) => {
+                let matching_locations: Vec<_> = observable_locations
+                    .iter()
+                    .filter(|entry| entry.0 == *index)
+                    .collect();
+                // A DEM logical observable target only names the aggregate observable index.
+                // If that index is emitted by multiple OBSERVABLE_INCLUDE ops, the exact site is ambiguous.
+                if let [location] = matching_locations.as_slice() {
+                    let key = (
+                        "L".to_string(),
+                        *index,
+                        location.1.op_path.clone(),
+                        location.1.repeat_iterations.clone(),
+                    );
+                    if seen.insert(key) {
+                        add_annotation_at_path(
+                            operations,
+                            &location.1.op_path,
+                            Qp101Annotation {
+                                kind: "marker".to_string(),
+                                target_slots: Vec::new(),
+                                label: Some(format!("L{index}")),
+                                text: format_repeat_annotation_text(&location.1.repeat_iterations),
+                                style: Some(danger_annotation_style()),
+                                tags: vec!["dem-symptom".to_string(), "query-result".to_string()],
+                                context: Some(json!({
+                                    "query_kind": "dem_error_origin",
+                                    "dem_error_index": dem_error_index,
+                                    "observable_index": index,
+                                    "op_path": location.1.op_path,
+                                    "repeat_iterations": location.1.repeat_iterations,
+                                })),
+                            },
+                        )?;
+                    }
+                }
+            }
+            DemTarget::Separator => {}
+        }
+    }
+    Ok(())
+}
+
+fn collect_query_annotation_locations(
+    instrs: &[StimInstr],
+    context: &QueryTraversalContext,
+    detector_locations: &mut Vec<QueryAnnotationLocation>,
+    observable_locations: &mut Vec<(usize, QueryAnnotationLocation)>,
+) -> Result<(), String> {
+    for (i, instr) in instrs.iter().enumerate() {
+        match instr {
+            StimInstr::Repeat { count, body } => {
+                for iteration in 0..*count {
+                    let repeat_context = context.with_repeat_iteration(i, iteration);
+                    collect_query_annotation_locations(
+                        body,
+                        &repeat_context,
+                        detector_locations,
+                        observable_locations,
+                    )?;
+                }
+            }
+            StimInstr::Op { name, args, .. } => {
+                let op_context = context.with_op_index(i);
+                if name == "DETECTOR" {
+                    detector_locations.push(QueryAnnotationLocation {
+                        op_path: op_context.op_path,
+                        repeat_iterations: op_context.repeat_iterations,
+                    });
+                } else if name == "OBSERVABLE_INCLUDE" {
+                    let index = args.first().copied().unwrap_or(0.0) as usize;
+                    observable_locations.push((
+                        index,
+                        QueryAnnotationLocation {
+                            op_path: op_context.op_path,
+                            repeat_iterations: op_context.repeat_iterations,
+                        },
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn add_annotation_at_path(

--- a/rstim/src/qp101.rs
+++ b/rstim/src/qp101.rs
@@ -166,7 +166,7 @@ pub fn export_qp101_with_highlighted_dem_error(
 
     let highlight_extension = json!({
         "rstim_query_highlights": {
-            "version": 1,
+            "version": "1",
             "query": {
                 "kind": "dem_error_origin",
                 "dem_error_index": dem_error_index,

--- a/rstim/src/qp101.rs
+++ b/rstim/src/qp101.rs
@@ -1,3 +1,6 @@
+use std::collections::BTreeSet;
+
+use crate::dem_provenance::{HighlightRecord, TrackedDemResult};
 use crate::ir::{PauliBasis, StimInstr, StimTarget};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -125,6 +128,59 @@ pub fn export_qp101(instrs: &[StimInstr]) -> Result<Qp101Document, String> {
     })
 }
 
+pub fn export_qp101_with_highlighted_dem_error(
+    instrs: &[StimInstr],
+    tracked: &TrackedDemResult,
+    dem_error_index: usize,
+) -> Result<Qp101Document, String> {
+    let source_ids = tracked
+        .dem_error_to_sources
+        .get(dem_error_index)
+        .ok_or_else(|| {
+            format!(
+                "DEM error index {dem_error_index} out of range for {} tracked DEM errors",
+                tracked.dem_error_to_sources.len()
+            )
+        })?;
+
+    let mut doc = export_qp101(instrs)?;
+    let mut seen = BTreeSet::new();
+    let mut highlights = Vec::new();
+    for &source_id in source_ids {
+        let source = tracked.sources.get(source_id).ok_or_else(|| {
+            format!(
+                "tracked source index {source_id} missing for DEM error {dem_error_index}"
+            )
+        })?;
+        let highlight = HighlightRecord::from_source(source);
+        let dedupe_key = (
+            highlight.op_path.clone(),
+            highlight.repeat_iterations.clone(),
+            highlight.target_slots.clone(),
+            highlight.branch.clone(),
+        );
+        if seen.insert(dedupe_key) {
+            highlights.push(highlight);
+        }
+    }
+
+    let highlight_extension = json!({
+        "rstim_query_highlights": {
+            "version": 1,
+            "query": {
+                "kind": "dem_error_origin",
+                "dem_error_index": dem_error_index,
+            },
+            "highlights": highlights,
+        }
+    });
+    doc.extensions = Some(match doc.extensions.take() {
+        Some(existing) => merge_extension_objects(existing, highlight_extension),
+        None => highlight_extension,
+    });
+    Ok(doc)
+}
+
 fn export_operations(instrs: &[StimInstr]) -> Result<Vec<Qp101Operation>, String> {
     let mut ops = Vec::with_capacity(instrs.len());
     for instr in instrs {
@@ -195,6 +251,16 @@ fn export_operations(instrs: &[StimInstr]) -> Result<Vec<Qp101Operation>, String
         }
     }
     Ok(ops)
+}
+
+fn merge_extension_objects(existing: serde_json::Value, added: serde_json::Value) -> serde_json::Value {
+    match (existing, added) {
+        (serde_json::Value::Object(mut existing_map), serde_json::Value::Object(added_map)) => {
+            existing_map.extend(added_map);
+            serde_json::Value::Object(existing_map)
+        }
+        (_, added) => added,
+    }
 }
 
 fn export_plain_qubit_targets(name: &str, targets: &[StimTarget]) -> Result<Vec<u32>, String> {

--- a/rstim/tests/cli_export_json.rs
+++ b/rstim/tests/cli_export_json.rs
@@ -134,3 +134,31 @@ fn export_json_invalid_circuit_fails_cleanly() {
     assert!(stderr.contains("REPEAT") || stderr.contains("repeat"));
     assert!(!stderr.contains("panicked"));
 }
+
+#[test]
+fn export_json_can_highlight_dem_error_origins() {
+    let output = run_export_json_with_stdin(
+        &["--highlight_dem_error", "0"],
+        "REPEAT 2 {\n  DEPOLARIZE1(0.3) 5 7\n}\nM 5 7\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        value["extensions"]["rstim_query_highlights"]["query"]["dem_error_index"],
+        0
+    );
+}
+
+#[test]
+fn export_json_rejects_invalid_highlight_dem_error_index() {
+    let output =
+        run_export_json_with_stdin(&["--highlight_dem_error", "99"], "X_ERROR(0.1) 0\nM 0\nDETECTOR rec[-1]\n");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("DEM error index out of range"));
+}

--- a/rstim/tests/cli_export_json.rs
+++ b/rstim/tests/cli_export_json.rs
@@ -162,3 +162,17 @@ fn export_json_rejects_invalid_highlight_dem_error_index() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("DEM error index out of range"));
 }
+
+#[test]
+fn export_json_reports_unsupported_highlight_instruction_clearly() {
+    let output = run_export_json_with_stdin(
+        &["--highlight_dem_error", "0"],
+        "R 0 1\nDEPOLARIZE2(0.1) 0 1\nM 0 1\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(
+        "--highlight_dem_error currently supports a subset of noise instructions"
+    ));
+    assert!(stderr.contains("DEPOLARIZE2"));
+}

--- a/rstim/tests/cli_export_json.rs
+++ b/rstim/tests/cli_export_json.rs
@@ -152,6 +152,11 @@ fn export_json_can_highlight_dem_error_origins() {
         value["operations"][0]["body"][0]["annotations"][0]["context"]["dem_error_index"],
         0
     );
+    assert_eq!(value["operations"][2]["annotations"][0]["label"], "D0");
+    assert_eq!(
+        value["operations"][2]["annotations"][0]["context"]["detector_index"],
+        0
+    );
 }
 
 #[test]

--- a/rstim/tests/cli_export_json.rs
+++ b/rstim/tests/cli_export_json.rs
@@ -155,6 +155,47 @@ fn export_json_can_highlight_dem_error_origins() {
 }
 
 #[test]
+fn export_json_can_highlight_dem_error_to_compact_output_file() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    let out = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        input.path(),
+        "REPEAT 2 {\n  DEPOLARIZE1(0.3) 5 7\n}\nM 5 7\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let output = rstim_cmd()
+        .arg("export_json")
+        .arg("--in")
+        .arg(input.path())
+        .arg("--out")
+        .arg(out.path())
+        .arg("--format")
+        .arg("compact")
+        .arg("--highlight_dem_error")
+        .arg("0")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stdout.is_empty());
+
+    let text = std::fs::read_to_string(out.path()).unwrap();
+    let text = text.trim_end_matches('\n');
+    assert!(!text.contains('\n'));
+
+    let value: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(
+        value["extensions"]["rstim_query_highlights"]["query"]["dem_error_index"],
+        0
+    );
+}
+
+#[test]
 fn export_json_rejects_invalid_highlight_dem_error_index() {
     let output =
         run_export_json_with_stdin(&["--highlight_dem_error", "99"], "X_ERROR(0.1) 0\nM 0\nDETECTOR rec[-1]\n");
@@ -175,4 +216,28 @@ fn export_json_reports_unsupported_highlight_instruction_clearly() {
         "--highlight_dem_error currently supports a subset of noise instructions"
     ));
     assert!(stderr.contains("DEPOLARIZE2"));
+}
+
+#[test]
+fn export_json_preserves_non_support_tracking_errors_when_highlighting() {
+    let output = run_export_json_with_stdin(
+        &["--highlight_dem_error", "0"],
+        "R 0\nDEPOLARIZE1(0.9) 0\nM 0\nDETECTOR rec[-1]\n",
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("DEPOLARIZE1(0.9) exceeds exact-analysis limit of 3/4"));
+    assert!(!stderr.contains("subset of noise instructions"));
+}
+
+#[test]
+fn export_json_preserves_non_range_export_errors_when_highlighting() {
+    let output = run_export_json_with_stdin(
+        &["--highlight_dem_error", "0"],
+        "QUBIT_COORDS(1,2) !0\nX_ERROR(0.1) 0\nM 0\nDETECTOR rec[-1]\n",
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("QUBIT_COORDS expects qubit targets"));
+    assert!(!stderr.contains("DEM error index out of range"));
 }

--- a/rstim/tests/cli_export_json.rs
+++ b/rstim/tests/cli_export_json.rs
@@ -149,7 +149,7 @@ fn export_json_can_highlight_dem_error_origins() {
 
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
-        value["extensions"]["rstim_query_highlights"]["query"]["dem_error_index"],
+        value["operations"][0]["body"][0]["annotations"][0]["context"]["dem_error_index"],
         0
     );
 }
@@ -190,7 +190,7 @@ fn export_json_can_highlight_dem_error_to_compact_output_file() {
 
     let value: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(
-        value["extensions"]["rstim_query_highlights"]["query"]["dem_error_index"],
+        value["operations"][0]["body"][0]["annotations"][0]["context"]["dem_error_index"],
         0
     );
 }

--- a/rstim/tests/qp101_export.rs
+++ b/rstim/tests/qp101_export.rs
@@ -1,7 +1,8 @@
 use rstim::ir::{PauliBasis, StimInstr, StimTarget};
 use rstim::parser::parse_lines;
 use rstim::qp101::{
-    export_qp101, Qp101Display, Qp101Document, Qp101Operation, Qp101PauliBasis, Qp101TargetRef,
+    export_qp101, Qp101Annotation, Qp101AnnotationStyle, Qp101Display, Qp101Document,
+    Qp101Operation, Qp101PauliBasis, Qp101TargetRef,
 };
 use serde_json::json;
 
@@ -20,6 +21,7 @@ fn serializes_minimal_gate_document_full_contract() {
             raw_targets: None,
             display: None,
             tags: Vec::new(),
+            annotations: Vec::new(),
         }],
         metadata: None,
         extensions: None,
@@ -49,10 +51,15 @@ fn serializes_tick_and_repeat_operations_full_contract() {
         version: "1.0".to_string(),
         num_qubits: 1,
         operations: vec![
-            Qp101Operation::Tick,
+            Qp101Operation::Tick {
+                annotations: Vec::new(),
+            },
             Qp101Operation::Repeat {
                 count: 3,
-                body: vec![Qp101Operation::Tick],
+                body: vec![Qp101Operation::Tick {
+                    annotations: Vec::new(),
+                }],
+                annotations: Vec::new(),
             },
         ],
         metadata: None,
@@ -128,10 +135,12 @@ fn serializes_display_annotation_and_remaining_target_variants() {
                     label: Some("feedback".to_string()),
                 }),
                 tags: vec!["tagged".to_string()],
+                annotations: Vec::new(),
             },
             Qp101Operation::Annotation {
                 kind: "note".to_string(),
                 text: "hello".to_string(),
+                annotations: Vec::new(),
             },
         ],
         metadata: None,
@@ -180,12 +189,68 @@ fn serializes_display_annotation_and_remaining_target_variants() {
 }
 
 #[test]
+fn serializes_operation_annotations_when_present() {
+    let doc = Qp101Document {
+        standard: "QP101-ZY".to_string(),
+        version: "1.0".to_string(),
+        num_qubits: 1,
+        operations: vec![Qp101Operation::Noise {
+            gate: "X_ERROR".to_string(),
+            params: vec![0.001],
+            raw_targets: vec![Qp101TargetRef::Qubit {
+                index: 0,
+                inverted: None,
+            }],
+            annotations: vec![Qp101Annotation {
+                kind: "marker".to_string(),
+                target_slots: vec![0],
+                label: Some("X".to_string()),
+                text: Some("repeat[2]".to_string()),
+                style: Some(Qp101AnnotationStyle {
+                    preset: Some("danger".to_string()),
+                    color: Some("red".to_string()),
+                    highlight: Some(true),
+                }),
+                tags: vec!["dem-origin".to_string()],
+                context: Some(json!({
+                    "dem_error_index": 17,
+                    "source_branch": "X"
+                })),
+            }],
+        }],
+        metadata: None,
+        extensions: None,
+    };
+
+    let value = serde_json::to_value(doc).unwrap();
+    assert_eq!(
+        value["operations"][0]["annotations"][0],
+        json!({
+            "kind": "marker",
+            "target_slots": [0],
+            "label": "X",
+            "text": "repeat[2]",
+            "style": {
+                "preset": "danger",
+                "color": "red",
+                "highlight": true
+            },
+            "tags": ["dem-origin"],
+            "context": {
+                "dem_error_index": 17,
+                "source_branch": "X"
+            }
+        })
+    );
+}
+
+#[test]
 fn export_preserves_repeat_and_tick() {
     let instrs = parse_lines("H 0\nTICK\nREPEAT 2 {\n  M 0\n}\n").unwrap();
     let doc = export_qp101(&instrs).unwrap();
-    assert!(matches!(doc.operations[1], Qp101Operation::Tick));
+    assert!(matches!(doc.operations[1], Qp101Operation::Tick { .. }));
     match &doc.operations[2] {
-        Qp101Operation::Repeat { count, body } => {
+        Qp101Operation::Repeat { count, body, .. } => {
             assert_eq!(*count, 2);
             assert_eq!(body.len(), 1);
             match &body[0] {
@@ -211,14 +276,18 @@ fn export_preserves_detector_and_coords() {
     let instrs = parse_lines("QUBIT_COORDS(1,2) 0\nM 0\nDETECTOR(5,6) rec[-1]\n").unwrap();
     let doc = export_qp101(&instrs).unwrap();
     match &doc.operations[0] {
-        Qp101Operation::QubitCoords { coords, targets } => {
+        Qp101Operation::QubitCoords {
+            coords, targets, ..
+        } => {
             assert_eq!(coords, &vec![1.0, 2.0]);
             assert_eq!(targets, &vec![0]);
         }
         other => panic!("unexpected coords op: {other:?}"),
     }
     match &doc.operations[2] {
-        Qp101Operation::Detector { coords, sources } => {
+        Qp101Operation::Detector {
+            coords, sources, ..
+        } => {
             assert_eq!(coords, &vec![5.0, 6.0]);
             assert_eq!(sources, &vec![Qp101TargetRef::Rec { offset: -1 }]);
         }
@@ -370,7 +439,9 @@ fn export_preserves_observable_noise_tags_and_special_targets() {
     let doc = export_qp101(&instrs).unwrap();
 
     match &doc.operations[0] {
-        Qp101Operation::ObservableInclude { index, sources } => {
+        Qp101Operation::ObservableInclude {
+            index, sources, ..
+        } => {
             assert_eq!(*index, 2);
             assert_eq!(sources, &vec![Qp101TargetRef::Rec { offset: -1 }]);
         }
@@ -382,6 +453,7 @@ fn export_preserves_observable_noise_tags_and_special_targets() {
             gate,
             params,
             raw_targets,
+            ..
         } => {
             assert_eq!(gate, "DEPOLARIZE1");
             assert_eq!(params, &vec![0.125]);

--- a/rstim/tests/qp101_highlights.rs
+++ b/rstim/tests/qp101_highlights.rs
@@ -1,0 +1,28 @@
+use rstim::error_analyzer::ErrorAnalyzer;
+use rstim::parser::parse_lines;
+use rstim::qp101::export_qp101_with_highlighted_dem_error;
+
+#[test]
+fn qp101_export_includes_dem_origin_highlights() {
+    let circuit = parse_lines(
+        "REPEAT 2 {\n  DEPOLARIZE1(0.3) 5 7\n}\nM 5 7\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    let doc = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 0).unwrap();
+    let value = serde_json::to_value(doc).unwrap();
+
+    assert_eq!(
+        value["extensions"]["rstim_query_highlights"]["query"]["kind"],
+        "dem_error_origin"
+    );
+    assert_eq!(
+        value["extensions"]["rstim_query_highlights"]["highlights"][0]["target_slots"],
+        serde_json::json!([0])
+    );
+    assert!(
+        value["extensions"]["rstim_query_highlights"]["highlights"][0]["repeat_iterations"]
+            .is_array()
+    );
+}

--- a/rstim/tests/qp101_highlights.rs
+++ b/rstim/tests/qp101_highlights.rs
@@ -15,24 +15,22 @@ fn qp101_export_includes_dem_origin_highlights() {
 
     let doc = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 0).unwrap();
     let value = serde_json::to_value(doc).unwrap();
+    let annotations = value["operations"][0]["body"][0]["annotations"]
+        .as_array()
+        .unwrap();
 
-    assert_eq!(
-        value["extensions"]["rstim_query_highlights"]["query"]["kind"],
-        "dem_error_origin"
-    );
-    assert_eq!(value["extensions"]["rstim_query_highlights"]["version"], "1");
-    assert_eq!(
-        value["extensions"]["rstim_query_highlights"]["highlights"][0]["target_slots"],
-        serde_json::json!([0])
-    );
-    assert_eq!(
-        value["extensions"]["rstim_query_highlights"]["highlights"][0]["label"],
-        value["extensions"]["rstim_query_highlights"]["highlights"][0]["branch"]
-    );
-    assert!(
-        value["extensions"]["rstim_query_highlights"]["highlights"][0]["repeat_iterations"]
-            .is_array()
-    );
+    assert_eq!(annotations.len(), 4);
+    for annotation in annotations {
+        assert_eq!(annotation["kind"], "marker");
+        assert_eq!(annotation["target_slots"], serde_json::json!([0]));
+        assert_eq!(annotation["label"], annotation["context"]["source_branch"]);
+        assert_eq!(annotation["style"]["preset"], "danger");
+        assert_eq!(annotation["style"]["color"], "red");
+        assert_eq!(annotation["style"]["highlight"], true);
+        assert!(annotation["context"]["repeat_iterations"].is_array());
+        assert!(annotation["text"].as_str().unwrap().starts_with("repeat["));
+        assert_eq!(annotation["tags"], serde_json::json!(["dem-origin", "query-result"]));
+    }
 }
 
 #[test]
@@ -94,13 +92,15 @@ fn qp101_export_dedupes_equivalent_source_highlights() {
     );
 
     let doc = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 0).unwrap();
-    let highlights = serde_json::to_value(doc).unwrap()["extensions"]["rstim_query_highlights"]
-        ["highlights"]
+    let highlights = serde_json::to_value(doc).unwrap()["operations"][1]["annotations"]
         .as_array()
         .unwrap()
         .clone();
 
     assert_eq!(highlights.len(), 1);
-    assert_eq!(highlights[0]["repeat_iterations"], serde_json::json!([2]));
-    assert_eq!(highlights[0]["target_qubits"], serde_json::json!([0]));
+    assert_eq!(
+        highlights[0]["context"]["repeat_iterations"],
+        serde_json::json!([2])
+    );
+    assert_eq!(highlights[0]["context"]["target_qubits"], serde_json::json!([0]));
 }

--- a/rstim/tests/qp101_highlights.rs
+++ b/rstim/tests/qp101_highlights.rs
@@ -1,3 +1,6 @@
+use rstim::dem::DetectorErrorModel;
+use rstim::dem::DemTarget;
+use rstim::dem_provenance::{SourceBranch, TrackedDemResult, TrackedErrorTerm, TrackedSource};
 use rstim::error_analyzer::ErrorAnalyzer;
 use rstim::parser::parse_lines;
 use rstim::qp101::export_qp101_with_highlighted_dem_error;
@@ -30,4 +33,74 @@ fn qp101_export_includes_dem_origin_highlights() {
         value["extensions"]["rstim_query_highlights"]["highlights"][0]["repeat_iterations"]
             .is_array()
     );
+}
+
+#[test]
+fn qp101_export_rejects_out_of_range_dem_error_index_directly() {
+    let circuit = parse_lines("R 0\nX_ERROR(0.1) 0\nM 0\nDETECTOR rec[-1]\n").unwrap();
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    let err = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 99).unwrap_err();
+
+    assert!(err.contains("DEM error index 99 out of range"));
+}
+
+#[test]
+fn qp101_export_rejects_missing_tracked_source_entry() {
+    let circuit = parse_lines("R 0\nM 0\nDETECTOR rec[-1]\n").unwrap();
+    let tracked = TrackedDemResult {
+        dem: DetectorErrorModel::new(),
+        sources: Vec::new(),
+        dem_error_to_sources: vec![vec![0]],
+        source_to_dem_errors: Vec::new(),
+    };
+
+    let err = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 0).unwrap_err();
+
+    assert!(err.contains("tracked source index 0 missing for DEM error 0"));
+}
+
+#[test]
+fn qp101_export_dedupes_equivalent_source_highlights() {
+    let circuit = parse_lines("R 0\nX_ERROR(0.1) 0\nM 0\nDETECTOR rec[-1]\n").unwrap();
+    let tracked = TrackedDemResult::from_terms_and_sources(
+        vec![
+            TrackedSource {
+                source_id: 0,
+                op_path: vec![1],
+                repeat_iterations: vec![2],
+                instr_name: "X_ERROR".to_string(),
+                target_slots: vec![0],
+                target_qubits: vec![0],
+                branch: SourceBranch::X,
+                probability_fragment: 0.1,
+            },
+            TrackedSource {
+                source_id: 1,
+                op_path: vec![1],
+                repeat_iterations: vec![2],
+                instr_name: "X_ERROR".to_string(),
+                target_slots: vec![0],
+                target_qubits: vec![0],
+                branch: SourceBranch::X,
+                probability_fragment: 0.1,
+            },
+        ],
+        vec![TrackedErrorTerm {
+            probability: 0.1,
+            targets: vec![DemTarget::Detector(0)],
+            source_ids: vec![0, 1],
+        }],
+    );
+
+    let doc = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 0).unwrap();
+    let highlights = serde_json::to_value(doc).unwrap()["extensions"]["rstim_query_highlights"]
+        ["highlights"]
+        .as_array()
+        .unwrap()
+        .clone();
+
+    assert_eq!(highlights.len(), 1);
+    assert_eq!(highlights[0]["repeat_iterations"], serde_json::json!([2]));
+    assert_eq!(highlights[0]["target_qubits"], serde_json::json!([0]));
 }

--- a/rstim/tests/qp101_highlights.rs
+++ b/rstim/tests/qp101_highlights.rs
@@ -17,9 +17,14 @@ fn qp101_export_includes_dem_origin_highlights() {
         value["extensions"]["rstim_query_highlights"]["query"]["kind"],
         "dem_error_origin"
     );
+    assert_eq!(value["extensions"]["rstim_query_highlights"]["version"], "1");
     assert_eq!(
         value["extensions"]["rstim_query_highlights"]["highlights"][0]["target_slots"],
         serde_json::json!([0])
+    );
+    assert_eq!(
+        value["extensions"]["rstim_query_highlights"]["highlights"][0]["label"],
+        value["extensions"]["rstim_query_highlights"]["highlights"][0]["branch"]
     );
     assert!(
         value["extensions"]["rstim_query_highlights"]["highlights"][0]["repeat_iterations"]

--- a/rstim/tests/qp101_highlights.rs
+++ b/rstim/tests/qp101_highlights.rs
@@ -1,5 +1,5 @@
-use rstim::dem::DetectorErrorModel;
 use rstim::dem::DemTarget;
+use rstim::dem::DetectorErrorModel;
 use rstim::dem_provenance::{SourceBranch, TrackedDemResult, TrackedErrorTerm, TrackedSource};
 use rstim::error_analyzer::ErrorAnalyzer;
 use rstim::parser::parse_lines;
@@ -29,8 +29,24 @@ fn qp101_export_includes_dem_origin_highlights() {
         assert_eq!(annotation["style"]["highlight"], true);
         assert!(annotation["context"]["repeat_iterations"].is_array());
         assert!(annotation["text"].as_str().unwrap().starts_with("repeat["));
-        assert_eq!(annotation["tags"], serde_json::json!(["dem-origin", "query-result"]));
+        assert_eq!(
+            annotation["tags"],
+            serde_json::json!(["dem-origin", "query-result"])
+        );
     }
+
+    let detector_annotations = value["operations"][2]["annotations"].as_array().unwrap();
+    assert_eq!(detector_annotations.len(), 1);
+    assert_eq!(detector_annotations[0]["kind"], "marker");
+    assert_eq!(detector_annotations[0]["label"], "D0");
+    assert_eq!(
+        detector_annotations[0]["tags"],
+        serde_json::json!(["dem-symptom", "query-result"])
+    );
+    assert_eq!(
+        detector_annotations[0]["context"]["detector_index"],
+        serde_json::json!(0)
+    );
 }
 
 #[test]
@@ -102,5 +118,46 @@ fn qp101_export_dedupes_equivalent_source_highlights() {
         highlights[0]["context"]["repeat_iterations"],
         serde_json::json!([2])
     );
-    assert_eq!(highlights[0]["context"]["target_qubits"], serde_json::json!([0]));
+    assert_eq!(
+        highlights[0]["context"]["target_qubits"],
+        serde_json::json!([0])
+    );
+}
+
+#[test]
+fn qp101_export_skips_ambiguous_observable_symptom_highlights() {
+    let circuit = parse_lines(
+        "R 0 1\nX_ERROR(0.1) 0\nM 0 1\nOBSERVABLE_INCLUDE(0) rec[-2]\nOBSERVABLE_INCLUDE(0) rec[-1]\n",
+    )
+    .unwrap();
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    let doc = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 0).unwrap();
+    let value = serde_json::to_value(doc).unwrap();
+
+    assert_eq!(value["operations"][3]["type"], "observable_include");
+    assert_eq!(value["operations"][4]["type"], "observable_include");
+    assert!(value["operations"][3]["annotations"].is_null());
+    assert!(value["operations"][4]["annotations"].is_null());
+}
+
+#[test]
+fn qp101_export_marks_unambiguous_observable_symptom_highlights() {
+    let circuit = parse_lines("R 0\nX_ERROR(0.1) 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n").unwrap();
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    let doc = export_qp101_with_highlighted_dem_error(&circuit, &tracked, 0).unwrap();
+    let value = serde_json::to_value(doc).unwrap();
+    let observable_annotations = value["operations"][3]["annotations"].as_array().unwrap();
+
+    assert_eq!(observable_annotations.len(), 1);
+    assert_eq!(observable_annotations[0]["label"], "L0");
+    assert_eq!(
+        observable_annotations[0]["tags"],
+        serde_json::json!(["dem-symptom", "query-result"])
+    );
+    assert_eq!(
+        observable_annotations[0]["context"]["observable_index"],
+        serde_json::json!(0)
+    );
 }

--- a/rstim/tests/tracked_dem.rs
+++ b/rstim/tests/tracked_dem.rs
@@ -51,6 +51,36 @@ fn tracked_result_builds_reverse_indices() {
 }
 
 #[test]
+fn source_branch_labels_match_expected_markers() {
+    let cases = [
+        (SourceBranch::X, "X"),
+        (SourceBranch::Y, "Y"),
+        (SourceBranch::Z, "Z"),
+        (SourceBranch::XX, "XX"),
+        (SourceBranch::XY, "XY"),
+        (SourceBranch::XZ, "XZ"),
+        (SourceBranch::YX, "YX"),
+        (SourceBranch::YY, "YY"),
+        (SourceBranch::YZ, "YZ"),
+        (SourceBranch::ZX, "ZX"),
+        (SourceBranch::ZY, "ZY"),
+        (SourceBranch::ZZ, "ZZ"),
+        (SourceBranch::MeasurementFlip, "M"),
+        (SourceBranch::CorrelatedBranch { index: 7 }, "E7"),
+        (
+            SourceBranch::Custom {
+                label: "custom".to_string(),
+            },
+            "custom",
+        ),
+    ];
+
+    for (branch, expected) in cases {
+        assert_eq!(branch.label(), expected);
+    }
+}
+
+#[test]
 fn tracked_dem_records_repeat_iteration_target_slot_and_branch() {
     let circuit = parse_lines(
         "REPEAT 2 {\n  DEPOLARIZE1(0.3) 5 7\n  TICK\n}\nM 5 7\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
@@ -122,6 +152,58 @@ fn tracked_dem_matches_plain_dem_for_depolarize1() {
 
     let plain = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
     let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    assert_eq!(tracked.dem.to_string(), plain.to_string());
+}
+
+#[test]
+fn tracked_dem_matches_plain_dem_for_supported_single_qubit_pauli_errors() {
+    let cases = [
+        ("X_ERROR", "R 0\nX_ERROR(0.1) 0\nM 0\nDETECTOR rec[-1]\n"),
+        ("Y_ERROR", "R 0\nY_ERROR(0.1) 0\nM 0\nDETECTOR rec[-1]\n"),
+        ("Z_ERROR", "H 0\nZ_ERROR(0.1) 0\nH 0\nM 0\nDETECTOR rec[-1]\n"),
+    ];
+
+    for (name, text) in cases {
+        let circuit = parse_lines(text).unwrap();
+        let plain = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
+        let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+        assert_eq!(tracked.dem.to_string(), plain.to_string(), "{name}");
+    }
+}
+
+#[test]
+fn tracked_dem_matches_plain_dem_for_supported_measurement_noise_ops() {
+    let cases = [
+        ("M", "R 0\nM(0.125) 0\nDETECTOR rec[-1]\n"),
+        ("MZ", "R 0\nMZ(0.125) 0\nDETECTOR rec[-1]\n"),
+        ("MX", "RX 0\nMX(0.125) 0\nDETECTOR rec[-1]\n"),
+        ("MY", "RY 0\nMY(0.125) 0\nDETECTOR rec[-1]\n"),
+        ("MR", "R 0\nMR(0.125) 0\nDETECTOR rec[-1]\n"),
+        ("MRZ", "R 0\nMRZ(0.125) 0\nDETECTOR rec[-1]\n"),
+        ("MRX", "RX 0\nMRX(0.125) 0\nDETECTOR rec[-1]\n"),
+        ("MRY", "RY 0\nMRY(0.125) 0\nDETECTOR rec[-1]\n"),
+    ];
+
+    for (name, text) in cases {
+        let circuit = parse_lines(text).unwrap();
+        let plain = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
+        let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+        assert_eq!(tracked.dem.to_string(), plain.to_string(), "{name}");
+    }
+}
+
+#[test]
+fn tracked_dem_decomposed_matches_plain_dem_decomposed() {
+    let circuit = parse_lines(
+        "R 0 1 2\nX_ERROR(0.1) 0\nX_ERROR(0.1) 1\nCX 0 1\nCX 1 2\nM 0 1 2\nDETECTOR rec[-3]\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let plain = ErrorAnalyzer::circuit_to_dem_decomposed(&circuit).unwrap();
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem_decomposed(&circuit).unwrap();
 
     assert_eq!(tracked.dem.to_string(), plain.to_string());
 }

--- a/rstim/tests/tracked_dem.rs
+++ b/rstim/tests/tracked_dem.rs
@@ -91,7 +91,7 @@ fn tracked_dem_merge_keeps_exact_source_union() {
 #[test]
 fn tracked_dem_decomposition_keeps_reverse_links() {
     let circuit = parse_lines(
-        "R 0 1 2\nX_ERROR(0.1) 0\nCX 0 1\nCX 1 2\nM 0 1 2\nDETECTOR rec[-3]\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+        "R 0 1 2\nX_ERROR(0.1) 0\nX_ERROR(0.1) 1\nCX 0 1\nCX 1 2\nM 0 1 2\nDETECTOR rec[-3]\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
     )
     .unwrap();
 
@@ -102,4 +102,16 @@ fn tracked_dem_decomposition_keeps_reverse_links() {
     for &dem_id in dem_ids {
         assert!(tracked.dem_error_to_sources[dem_id].contains(&0));
     }
+}
+
+#[test]
+fn tracked_dem_decomposition_propagates_failure() {
+    let circuit = parse_lines(
+        "R 0 1 2\nX_ERROR(0.1) 0\nCX 0 1\nCX 1 2\nM 0 1 2\nDETECTOR rec[-3]\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let err = ErrorAnalyzer::circuit_to_tracked_dem_decomposed(&circuit).unwrap_err();
+
+    assert!(err.contains("failed to decompose non-graphlike error"));
 }

--- a/rstim/tests/tracked_dem.rs
+++ b/rstim/tests/tracked_dem.rs
@@ -87,3 +87,19 @@ fn tracked_dem_merge_keeps_exact_source_union() {
     assert_eq!(tracked.source_to_dem_errors[0], vec![0]);
     assert_eq!(tracked.source_to_dem_errors[1], vec![0]);
 }
+
+#[test]
+fn tracked_dem_decomposition_keeps_reverse_links() {
+    let circuit = parse_lines(
+        "R 0 1 2\nX_ERROR(0.1) 0\nCX 0 1\nCX 1 2\nM 0 1 2\nDETECTOR rec[-3]\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem_decomposed(&circuit).unwrap();
+
+    let dem_ids = &tracked.source_to_dem_errors[0];
+    assert!(!dem_ids.is_empty());
+    for &dem_id in dem_ids {
+        assert!(tracked.dem_error_to_sources[dem_id].contains(&0));
+    }
+}

--- a/rstim/tests/tracked_dem.rs
+++ b/rstim/tests/tracked_dem.rs
@@ -2,6 +2,8 @@ use rstim::dem::DemTarget;
 use rstim::dem_provenance::{
     SourceBranch, TrackedDemResult, TrackedErrorTerm, TrackedSource,
 };
+use rstim::error_analyzer::ErrorAnalyzer;
+use rstim::parser::parse_lines;
 
 #[test]
 fn tracked_result_builds_reverse_indices() {
@@ -46,4 +48,26 @@ fn tracked_result_builds_reverse_indices() {
     assert_eq!(result.dem_error_to_sources[1], vec![0, 1]);
     assert_eq!(result.source_to_dem_errors[0], vec![0, 1]);
     assert_eq!(result.source_to_dem_errors[1], vec![1]);
+}
+
+#[test]
+fn tracked_dem_records_repeat_iteration_target_slot_and_branch() {
+    let circuit = parse_lines(
+        "REPEAT 2 {\n  DEPOLARIZE1(0.3) 5 7\n  TICK\n}\nM 5 7\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+    let source = tracked
+        .sources
+        .iter()
+        .find(|source| {
+            source.repeat_iterations == vec![1]
+                && source.target_slots == vec![1]
+                && source.branch.label() == "Y"
+        })
+        .unwrap();
+
+    assert_eq!(source.op_path, vec![0, 0]);
+    assert_eq!(source.target_qubits, vec![7]);
 }

--- a/rstim/tests/tracked_dem.rs
+++ b/rstim/tests/tracked_dem.rs
@@ -71,3 +71,19 @@ fn tracked_dem_records_repeat_iteration_target_slot_and_branch() {
     assert_eq!(source.op_path, vec![0, 0]);
     assert_eq!(source.target_qubits, vec![7]);
 }
+
+#[test]
+fn tracked_dem_merge_keeps_exact_source_union() {
+    let circuit = parse_lines(
+        "R 0\nX_ERROR(0.1) 0\nX_ERROR(0.2) 0\nM 0\nDETECTOR rec[-1]\n",
+    )
+    .unwrap();
+
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    assert_eq!(tracked.dem.instructions().len(), 1);
+    assert_eq!(tracked.dem_error_to_sources.len(), 1);
+    assert_eq!(tracked.dem_error_to_sources[0].len(), 2);
+    assert_eq!(tracked.source_to_dem_errors[0], vec![0]);
+    assert_eq!(tracked.source_to_dem_errors[1], vec![0]);
+}

--- a/rstim/tests/tracked_dem.rs
+++ b/rstim/tests/tracked_dem.rs
@@ -115,3 +115,13 @@ fn tracked_dem_decomposition_propagates_failure() {
 
     assert!(err.contains("failed to decompose non-graphlike error"));
 }
+
+#[test]
+fn tracked_dem_matches_plain_dem_for_depolarize1() {
+    let circuit = parse_lines("R 0\nDEPOLARIZE1(0.3) 0\nM 0\nDETECTOR rec[-1]\n").unwrap();
+
+    let plain = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
+    let tracked = ErrorAnalyzer::circuit_to_tracked_dem(&circuit).unwrap();
+
+    assert_eq!(tracked.dem.to_string(), plain.to_string());
+}

--- a/rstim/tests/tracked_dem.rs
+++ b/rstim/tests/tracked_dem.rs
@@ -1,0 +1,49 @@
+use rstim::dem::DemTarget;
+use rstim::dem_provenance::{
+    SourceBranch, TrackedDemResult, TrackedErrorTerm, TrackedSource,
+};
+
+#[test]
+fn tracked_result_builds_reverse_indices() {
+    let sources = vec![
+        TrackedSource {
+            source_id: 0,
+            op_path: vec![3, 1],
+            repeat_iterations: vec![2],
+            instr_name: "DEPOLARIZE1".to_string(),
+            target_slots: vec![0],
+            target_qubits: vec![5],
+            branch: SourceBranch::Y,
+            probability_fragment: 0.125,
+        },
+        TrackedSource {
+            source_id: 1,
+            op_path: vec![3, 1],
+            repeat_iterations: vec![2],
+            instr_name: "DEPOLARIZE1".to_string(),
+            target_slots: vec![1],
+            target_qubits: vec![7],
+            branch: SourceBranch::X,
+            probability_fragment: 0.125,
+        },
+    ];
+    let dem_terms = vec![
+        TrackedErrorTerm {
+            probability: 0.2,
+            targets: vec![DemTarget::Detector(0)],
+            source_ids: vec![0],
+        },
+        TrackedErrorTerm {
+            probability: 0.3,
+            targets: vec![DemTarget::Detector(1)],
+            source_ids: vec![0, 1],
+        },
+    ];
+
+    let result = TrackedDemResult::from_terms_and_sources(sources, dem_terms);
+
+    assert_eq!(result.dem_error_to_sources[0], vec![0]);
+    assert_eq!(result.dem_error_to_sources[1], vec![0, 1]);
+    assert_eq!(result.source_to_dem_errors[0], vec![0, 1]);
+    assert_eq!(result.source_to_dem_errors[1], vec![1]);
+}


### PR DESCRIPTION
## Summary
- add tracked DEM provenance analysis with repeat-aware source tracking, merge/decomposition preservation, and reverse links
- export DEM-origin highlight metadata in QP101 JSON and expose it via `export_json --highlight_dem_error`
- include the design spec, implementation plan, and QP101 extension documentation for the new workflow

## Test Plan
- cargo test -p rstim --test tracked_dem --test qp101_highlights --test cli_export_json
