### PR TITLE
Add rbposd decoder crate and rsinter adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /Stim/
 /yao-rs/
 /rmatching/
+/ldpc/
 /.worktrees/
 
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["rstim", "rsinter"]
+members = ["rstim", "rsinter", "rbposd"]
 resolver = "3"

--- a/docs/superpowers/plans/2026-04-22-rbposd-bposd-plan.md
+++ b/docs/superpowers/plans/2026-04-22-rbposd-bposd-plan.md
@@ -1,0 +1,1935 @@
+# rbposd BPOSD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new `rbposd` crate to this workspace that provides a Rust MVP of BPOSD (`minimum-sum + parallel + OSD_0`), then layer on CSS helpers and a `rsinter` adapter.
+
+**Architecture:** Keep the algorithm core isolated in a new `rbposd` crate centered on `ParityCheckMatrix + Syndrome -> Correction`. Build the work in order: crate scaffold, matrix/vector/algebra foundations, BP, OSD fallback, examples and regression fixtures, CSS helpers, then an adapter that compiles `rstim` DEMs into `rbposd` matrix problems for `rsinter`.
+
+**Tech Stack:** Rust workspace crates (`rbposd`, `rstim`, `rsinter`), standard library only for the new core crate, existing `rstim` DEM types and `rsinter` decoder traits, `cargo test`, `cargo run`
+
+---
+
+## File Structure
+
+- Modify: `Cargo.toml`
+  - Add `rbposd` as a workspace member.
+- Create: `rbposd/Cargo.toml`
+  - Define the new crate and keep dependencies minimal.
+- Create: `rbposd/doc/ldpc_mvp_reference.md`
+  - Lock the exact MVP behavior and fixture set that the Rust implementation is expected to match.
+- Create: `rbposd/src/lib.rs`
+  - Re-export the public API in the order the crate grows.
+- Create: `rbposd/src/config.rs`
+  - Define `BpVariant`, `Schedule`, `OsdVariant`, `ChannelModel`, and `DecoderConfig`.
+- Create: `rbposd/src/error.rs`
+  - Define matrix construction and decode errors.
+- Create: `rbposd/src/vector.rs`
+  - Define `Syndrome` and `Correction` wrappers plus small GF(2) helpers.
+- Create: `rbposd/src/matrix.rs`
+  - Define `ParityCheckMatrix`, row/column adjacency, sparse row and sparse column constructors, and parity multiplication.
+- Create: `rbposd/src/gf2.rs`
+  - Hold internal dense-elimination and permutation helpers used by OSD.
+- Create: `rbposd/src/bp.rs`
+  - Hold the minimum-sum BP inner loop and reliability extraction.
+- Create: `rbposd/src/osd.rs`
+  - Hold column ordering and `OSD_0` solve logic.
+- Create: `rbposd/src/decoder.rs`
+  - Own `BpOsdDecoder`, compiled graph state, and `DecodeResult`.
+- Create: `rbposd/src/css.rs`
+  - Thin convenience layer that owns paired `BpOsdDecoder` values for `Hx`/`Hz`.
+- Create: `rbposd/examples/basic_decode.rs`
+  - Small copy-pastable example for `new + decode`.
+- Create: `rbposd/examples/profile_repetition.rs`
+  - Repeatable decode loop that prints timing and iteration metrics for regression checks.
+- Create: `rbposd/tests/smoke.rs`
+  - Lock the public config defaults and crate scaffold.
+- Create: `rbposd/tests/matrix.rs`
+  - Cover sparse constructors and GF(2) parity multiplication.
+- Create: `rbposd/tests/bp.rs`
+  - Cover BP-only convergence on small repetition-style matrices.
+- Create: `rbposd/tests/osd.rs`
+  - Cover `OSD_0` fallback and validity of the returned correction.
+- Create: `rbposd/tests/reference.rs`
+  - Encode the fixture set described in `rbposd/doc/ldpc_mvp_reference.md`.
+- Create: `rbposd/tests/css.rs`
+  - Cover the CSS convenience layer.
+- Modify: `rsinter/Cargo.toml`
+  - Add a path dependency on `rbposd`.
+- Modify: `rsinter/src/lib.rs`
+  - Register the `rbposd` adapter module.
+- Modify: `rsinter/src/decode.rs`
+  - Re-export the new adapter alongside the existing traits and `VacuousDecoder`.
+- Modify: `rsinter/src/collect.rs`
+  - Use `DetectorErrorModel::effective_num_detectors()` so the adapter sees the right packed width for shifted/repeated DEMs.
+- Create: `rsinter/src/rbposd_adapter.rs`
+  - Translate `DetectorErrorModel` error terms into `rbposd` columns and map decoded corrections back to observables.
+- Create: `rsinter/tests/decode_rbposd.rs`
+  - Cover direct DEM compilation and a tiny `collect(...)` smoke test using the new adapter.
+- Modify: `rstim/doc/getting_started.md`
+  - Add a short example that uses the `rsinter` adapter backed by `rbposd`.
+
+## Phase 0
+
+### Task 1: Scaffold The `rbposd` Crate And Lock The MVP Contract
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `rbposd/Cargo.toml`
+- Create: `rbposd/doc/ldpc_mvp_reference.md`
+- Create: `rbposd/src/lib.rs`
+- Create: `rbposd/src/config.rs`
+- Create: `rbposd/src/error.rs`
+- Test: `rbposd/tests/smoke.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rbposd/tests/smoke.rs`:
+
+```rust
+use rbposd::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+
+#[test]
+fn decoder_defaults_pin_the_mvp_algorithm_surface() {
+    let cfg = DecoderConfig::default();
+
+    assert_eq!(cfg.max_bp_iterations, 30);
+    assert!(cfg.early_stop);
+    assert_eq!(cfg.bp_variant, BpVariant::MinimumSum);
+    assert_eq!(cfg.schedule, Schedule::Parallel);
+    assert_eq!(cfg.osd_variant, OsdVariant::Osd0);
+
+    match ChannelModel::Bsc { error_rate: 0.05 } {
+        ChannelModel::Bsc { error_rate } => assert_eq!(error_rate, 0.05),
+        ChannelModel::BitFlipProbabilities(_) => unreachable!(),
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rbposd --test smoke -v`
+
+Expected: FAIL with `package ID specification 'rbposd' did not match any packages`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the workspace root `Cargo.toml`:
+
+```toml
+[workspace]
+members = ["rstim", "rsinter", "rbposd"]
+resolver = "3"
+```
+
+Create `rbposd/Cargo.toml`:
+
+```toml
+[package]
+name = "rbposd"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+```
+
+Create `rbposd/doc/ldpc_mvp_reference.md`:
+
+```markdown
+# rbposd MVP Reference Contract
+
+Date: 2026-04-22
+
+This file locks the reference surface for the first Rust BPOSD version.
+
+Included:
+
+- binary parity-check matrix input
+- syndrome decoding
+- `minimum_sum`
+- `parallel` schedule
+- `OSD_0`
+- uniform and per-bit priors
+
+Excluded:
+
+- `product_sum`
+- serial scheduling
+- `OSD_CS`
+- DEM-native input in the core crate
+- batch decode APIs
+
+Reference fixtures:
+
+1. Repetition-style 4-check / 5-bit code with a single-flip syndrome that BP should solve without OSD.
+2. Small 2-check / 3-bit code that is solved by `OSD_0` when BP is disabled.
+3. Small sparse non-identity matrix built from sparse columns to verify constructor symmetry.
+```
+
+Create `rbposd/src/config.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpVariant {
+    MinimumSum,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Schedule {
+    Parallel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OsdVariant {
+    Osd0,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChannelModel {
+    Bsc { error_rate: f64 },
+    BitFlipProbabilities(Vec<f64>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecoderConfig {
+    pub max_bp_iterations: usize,
+    pub early_stop: bool,
+    pub bp_variant: BpVariant,
+    pub schedule: Schedule,
+    pub osd_variant: OsdVariant,
+}
+
+impl Default for DecoderConfig {
+    fn default() -> Self {
+        Self {
+            max_bp_iterations: 30,
+            early_stop: true,
+            bp_variant: BpVariant::MinimumSum,
+            schedule: Schedule::Parallel,
+            osd_variant: OsdVariant::Osd0,
+        }
+    }
+}
+```
+
+Create `rbposd/src/error.rs`:
+
+```rust
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    EmptyMatrix,
+    InvalidProbability,
+    InvalidColumnIndex { column: usize, num_bits: usize },
+    DimensionMismatch {
+        what: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    BpDidNotConverge,
+    NoOsdSolution,
+}
+
+impl Display for DecodeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecodeError::EmptyMatrix => write!(f, "parity-check matrix must not be empty"),
+            DecodeError::InvalidProbability => write!(f, "probability must lie in [0, 1]"),
+            DecodeError::InvalidColumnIndex { column, num_bits } => {
+                write!(f, "column index {column} is out of bounds for {num_bits} bits")
+            }
+            DecodeError::DimensionMismatch {
+                what,
+                expected,
+                actual,
+            } => {
+                write!(f, "{what} length mismatch: expected {expected}, got {actual}")
+            }
+            DecodeError::BpDidNotConverge => write!(f, "belief propagation did not converge"),
+            DecodeError::NoOsdSolution => write!(f, "OSD_0 could not construct a valid solution"),
+        }
+    }
+}
+
+impl Error for DecodeError {}
+```
+
+Create `rbposd/src/lib.rs`:
+
+```rust
+pub mod config;
+pub mod error;
+
+pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use error::DecodeError;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rbposd --test smoke -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml rbposd/Cargo.toml rbposd/doc/ldpc_mvp_reference.md rbposd/src/lib.rs rbposd/src/config.rs rbposd/src/error.rs rbposd/tests/smoke.rs
+git commit -m "feat: add rbposd crate scaffold"
+```
+
+## Phase 1
+
+### Task 2: Implement Matrix And Vector Foundations
+
+**Files:**
+- Modify: `rbposd/src/lib.rs`
+- Modify: `rbposd/src/error.rs`
+- Create: `rbposd/src/vector.rs`
+- Create: `rbposd/src/matrix.rs`
+- Test: `rbposd/tests/matrix.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rbposd/tests/matrix.rs`:
+
+```rust
+use rbposd::{Correction, ParityCheckMatrix, Syndrome};
+
+#[test]
+fn sparse_rows_reject_an_out_of_bounds_column() {
+    let err = ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![3]])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("out of bounds"));
+}
+
+#[test]
+fn sparse_columns_and_sparse_rows_encode_the_same_code() {
+    let from_rows =
+        ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap();
+    let from_cols =
+        ParityCheckMatrix::from_sparse_columns(2, 3, vec![vec![0], vec![0, 1], vec![1]])
+            .unwrap();
+
+    let correction = Correction::from(vec![true, false, true]);
+    let expected = Syndrome::from(vec![true, true]);
+
+    assert_eq!(from_rows.multiply(&correction), expected);
+    assert_eq!(from_cols.multiply(&correction), expected);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rbposd --test matrix -v`
+
+Expected: FAIL with unresolved imports for `ParityCheckMatrix`, `Correction`, or `Syndrome`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `rbposd/src/error.rs` so matrix constructors can report a missing row or column domain:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    EmptyMatrix,
+    InvalidProbability,
+    InvalidColumnIndex { column: usize, num_bits: usize },
+    InvalidRowIndex { row: usize, num_checks: usize },
+    DimensionMismatch {
+        what: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    BpDidNotConverge,
+    NoOsdSolution,
+}
+```
+
+Create `rbposd/src/vector.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Syndrome(Vec<bool>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Correction(Vec<bool>);
+
+impl Syndrome {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn as_slice(&self) -> &[bool] {
+        &self.0
+    }
+
+    pub fn weight(&self) -> usize {
+        self.0.iter().filter(|&&bit| bit).count()
+    }
+}
+
+impl Correction {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn as_slice(&self) -> &[bool] {
+        &self.0
+    }
+
+    pub fn zero(len: usize) -> Self {
+        Self(vec![false; len])
+    }
+}
+
+impl From<Vec<bool>> for Syndrome {
+    fn from(bits: Vec<bool>) -> Self {
+        Self(bits)
+    }
+}
+
+impl From<Vec<bool>> for Correction {
+    fn from(bits: Vec<bool>) -> Self {
+        Self(bits)
+    }
+}
+```
+
+Create `rbposd/src/matrix.rs`:
+
+```rust
+use crate::error::DecodeError;
+use crate::vector::{Correction, Syndrome};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParityCheckMatrix {
+    num_checks: usize,
+    num_bits: usize,
+    rows: Vec<Vec<usize>>,
+    columns: Vec<Vec<usize>>,
+}
+
+impl ParityCheckMatrix {
+    pub fn from_sparse_rows(
+        num_checks: usize,
+        num_bits: usize,
+        rows: Vec<Vec<usize>>,
+    ) -> Result<Self, DecodeError> {
+        if num_checks == 0 || num_bits == 0 {
+            return Err(DecodeError::EmptyMatrix);
+        }
+        if rows.len() != num_checks {
+            return Err(DecodeError::DimensionMismatch {
+                what: "row count",
+                expected: num_checks,
+                actual: rows.len(),
+            });
+        }
+        let mut columns = vec![Vec::new(); num_bits];
+        for (row_index, cols) in rows.iter().enumerate() {
+            for &column in cols {
+                if column >= num_bits {
+                    return Err(DecodeError::InvalidColumnIndex { column, num_bits });
+                }
+                columns[column].push(row_index);
+            }
+        }
+        Ok(Self {
+            num_checks,
+            num_bits,
+            rows,
+            columns,
+        })
+    }
+
+    pub fn from_sparse_columns(
+        num_checks: usize,
+        num_bits: usize,
+        columns: Vec<Vec<usize>>,
+    ) -> Result<Self, DecodeError> {
+        if num_checks == 0 || num_bits == 0 {
+            return Err(DecodeError::EmptyMatrix);
+        }
+        if columns.len() != num_bits {
+            return Err(DecodeError::DimensionMismatch {
+                what: "column count",
+                expected: num_bits,
+                actual: columns.len(),
+            });
+        }
+        let mut rows = vec![Vec::new(); num_checks];
+        for (column_index, checks) in columns.iter().enumerate() {
+            for &row in checks {
+                if row >= num_checks {
+                    return Err(DecodeError::InvalidRowIndex { row, num_checks });
+                }
+                rows[row].push(column_index);
+            }
+        }
+        Ok(Self {
+            num_checks,
+            num_bits,
+            rows,
+            columns,
+        })
+    }
+
+    pub fn num_checks(&self) -> usize {
+        self.num_checks
+    }
+
+    pub fn num_bits(&self) -> usize {
+        self.num_bits
+    }
+
+    pub fn row_neighbors(&self, check: usize) -> &[usize] {
+        &self.rows[check]
+    }
+
+    pub fn column_neighbors(&self, bit: usize) -> &[usize] {
+        &self.columns[bit]
+    }
+
+    pub fn multiply(&self, correction: &Correction) -> Syndrome {
+        let mut syndrome = vec![false; self.num_checks];
+        for (row_index, cols) in self.rows.iter().enumerate() {
+            let mut parity = false;
+            for &column in cols {
+                parity ^= correction.as_slice()[column];
+            }
+            syndrome[row_index] = parity;
+        }
+        Syndrome::from(syndrome)
+    }
+
+    pub(crate) fn dense_rows(&self) -> Vec<Vec<bool>> {
+        let mut dense = vec![vec![false; self.num_bits]; self.num_checks];
+        for (row_index, cols) in self.rows.iter().enumerate() {
+            for &column in cols {
+                dense[row_index][column] = true;
+            }
+        }
+        dense
+    }
+}
+```
+
+Update `rbposd/src/lib.rs`:
+
+```rust
+pub mod config;
+pub mod error;
+pub mod matrix;
+pub mod vector;
+
+pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use error::DecodeError;
+pub use matrix::ParityCheckMatrix;
+pub use vector::{Correction, Syndrome};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rbposd --test matrix -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rbposd/src/lib.rs rbposd/src/error.rs rbposd/src/vector.rs rbposd/src/matrix.rs rbposd/tests/matrix.rs
+git commit -m "feat: add rbposd matrix and vector core"
+```
+
+### Task 3: Add GF(2) Elimination Helpers For OSD
+
+**Files:**
+- Modify: `rbposd/src/lib.rs`
+- Create: `rbposd/src/gf2.rs`
+- Modify: `rbposd/src/error.rs`
+- Test: `rbposd/src/gf2.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add unit tests to `rbposd/src/gf2.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use crate::matrix::ParityCheckMatrix;
+    use crate::vector::Syndrome;
+
+    use super::{solve_with_column_order, sort_columns_by_reliability};
+
+    #[test]
+    fn reliability_sort_is_stable_for_equal_scores() {
+        let order = sort_columns_by_reliability(&[0.9, 0.9, 0.4, 0.9]);
+        assert_eq!(order, vec![0, 1, 3, 2]);
+    }
+
+    #[test]
+    fn solve_with_column_order_returns_a_valid_solution() {
+        let pcm =
+            ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap();
+        let syndrome = Syndrome::from(vec![true, false]);
+        let order = vec![0, 1, 2];
+
+        let correction = solve_with_column_order(&pcm, &syndrome, &order).unwrap();
+
+        assert_eq!(pcm.multiply(&correction), syndrome);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rbposd solve_with_column_order_returns_a_valid_solution -v`
+
+Expected: FAIL with `could not find gf2 in the crate root` or missing functions.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend `rbposd/src/error.rs` with one extra variant for singular elimination that cannot satisfy the target syndrome:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    EmptyMatrix,
+    InvalidProbability,
+    InvalidColumnIndex { column: usize, num_bits: usize },
+    InvalidRowIndex { row: usize, num_checks: usize },
+    DimensionMismatch {
+        what: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    SingularSystem,
+    BpDidNotConverge,
+    NoOsdSolution,
+}
+```
+
+Create `rbposd/src/gf2.rs`:
+
+```rust
+use crate::error::DecodeError;
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::{Correction, Syndrome};
+
+pub(crate) fn sort_columns_by_reliability(scores: &[f64]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..scores.len()).collect();
+    order.sort_by(|&a, &b| {
+        scores[b]
+            .partial_cmp(&scores[a])
+            .unwrap()
+            .then_with(|| a.cmp(&b))
+    });
+    order
+}
+
+pub(crate) fn solve_with_column_order(
+    pcm: &ParityCheckMatrix,
+    syndrome: &Syndrome,
+    column_order: &[usize],
+) -> Result<Correction, DecodeError> {
+    let mut matrix = pcm.dense_rows();
+    let mut rhs = syndrome.as_slice().to_vec();
+    let mut pivot_columns = Vec::new();
+    let mut row = 0usize;
+
+    for &column in column_order {
+        if row == matrix.len() {
+            break;
+        }
+        let pivot = (row..matrix.len()).find(|&candidate| matrix[candidate][column]);
+        if let Some(pivot_row) = pivot {
+            matrix.swap(row, pivot_row);
+            rhs.swap(row, pivot_row);
+            for other in 0..matrix.len() {
+                if other != row && matrix[other][column] {
+                    for c in column..column_order.len() {
+                        let physical = column_order[c];
+                        matrix[other][physical] ^= matrix[row][physical];
+                    }
+                    rhs[other] ^= rhs[row];
+                }
+            }
+            pivot_columns.push(column);
+            row += 1;
+        }
+    }
+
+    if rhs.iter().skip(row).any(|&bit| bit) {
+        return Err(DecodeError::SingularSystem);
+    }
+
+    let mut solution = vec![false; pcm.num_bits()];
+    for (pivot_row, &column) in pivot_columns.iter().enumerate().rev() {
+        let mut value = rhs[pivot_row];
+        for later_column in pivot_columns.iter().skip(pivot_row + 1) {
+            value ^= matrix[pivot_row][*later_column] && solution[*later_column];
+        }
+        solution[column] = value;
+    }
+
+    Ok(Correction::from(solution))
+}
+```
+
+Update `rbposd/src/lib.rs`:
+
+```rust
+pub mod config;
+pub mod error;
+pub mod matrix;
+pub mod vector;
+
+mod gf2;
+
+pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use error::DecodeError;
+pub use matrix::ParityCheckMatrix;
+pub use vector::{Correction, Syndrome};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rbposd solve_with_column_order_returns_a_valid_solution -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rbposd/src/lib.rs rbposd/src/error.rs rbposd/src/gf2.rs
+git commit -m "feat: add rbposd gf2 elimination helpers"
+```
+
+## Phase 2
+
+### Task 4: Implement Minimum-Sum BP And The Public Decoder Shell
+
+**Files:**
+- Modify: `rbposd/src/lib.rs`
+- Create: `rbposd/src/bp.rs`
+- Create: `rbposd/src/decoder.rs`
+- Modify: `rbposd/src/error.rs`
+- Test: `rbposd/tests/bp.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rbposd/tests/bp.rs`:
+
+```rust
+use rbposd::{BpOsdDecoder, ChannelModel, Correction, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+fn repetition_pcm() -> ParityCheckMatrix {
+    ParityCheckMatrix::from_sparse_rows(
+        4,
+        5,
+        vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]],
+    )
+    .unwrap()
+}
+
+#[test]
+fn minimum_sum_decodes_a_single_flip_without_osd() {
+    let pcm = repetition_pcm();
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )
+    .unwrap();
+
+    let syndrome = Syndrome::from(vec![true, false, false, false]);
+    let result = decoder.decode(&syndrome).unwrap();
+
+    assert!(result.converged);
+    assert!(!result.used_osd);
+    assert_eq!(result.bp_iterations > 0, true);
+    assert_eq!(pcm.multiply(&result.correction), syndrome);
+    assert_eq!(result.correction, Correction::from(vec![true, false, false, false, false]));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rbposd --test bp -v`
+
+Expected: FAIL with unresolved imports for `BpOsdDecoder` or missing `decode`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend `rbposd/src/error.rs` so decoder construction can reject bad prior vectors:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    EmptyMatrix,
+    InvalidProbability,
+    InvalidColumnIndex { column: usize, num_bits: usize },
+    InvalidRowIndex { row: usize, num_checks: usize },
+    DimensionMismatch {
+        what: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    SingularSystem,
+    BpDidNotConverge,
+    NoOsdSolution,
+}
+```
+
+Create `rbposd/src/bp.rs`:
+
+```rust
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::{Correction, Syndrome};
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BpSnapshot {
+    pub hard_decision: Correction,
+    pub reliability: Vec<f64>,
+    pub iterations: usize,
+    pub converged: bool,
+    pub residual_weight: usize,
+}
+
+pub(crate) fn run_minimum_sum(
+    pcm: &ParityCheckMatrix,
+    prior_llrs: &[f64],
+    syndrome: &Syndrome,
+    max_iterations: usize,
+    early_stop: bool,
+) -> BpSnapshot {
+    let num_bits = pcm.num_bits();
+    let num_checks = pcm.num_checks();
+
+    let mut check_to_var: Vec<Vec<f64>> = pcm
+        .row_neighbors(0)
+        .iter()
+        .map(|_| vec![0.0; 0])
+        .collect();
+    check_to_var = (0..num_checks)
+        .map(|check| vec![0.0; pcm.row_neighbors(check).len()])
+        .collect();
+    let mut var_to_check = (0..num_checks)
+        .map(|check| vec![0.0; pcm.row_neighbors(check).len()])
+        .collect::<Vec<_>>();
+
+    for check in 0..num_checks {
+        for (edge_index, &bit) in pcm.row_neighbors(check).iter().enumerate() {
+            var_to_check[check][edge_index] = prior_llrs[bit];
+        }
+    }
+
+    let mut final_llrs = prior_llrs.to_vec();
+    let mut hard_decision = Correction::zero(num_bits);
+    let mut residual_weight = syndrome.len();
+
+    for iteration in 1..=max_iterations.max(1) {
+        for check in 0..num_checks {
+            let neighbors = pcm.row_neighbors(check);
+            for target_edge in 0..neighbors.len() {
+                let mut sign = if syndrome.as_slice()[check] { -1.0 } else { 1.0 };
+                let mut min_abs = f64::INFINITY;
+                for source_edge in 0..neighbors.len() {
+                    if source_edge == target_edge {
+                        continue;
+                    }
+                    let value = var_to_check[check][source_edge];
+                    sign *= value.signum();
+                    min_abs = min_abs.min(value.abs());
+                }
+                if min_abs.is_infinite() {
+                    min_abs = 0.0;
+                }
+                check_to_var[check][target_edge] = sign * min_abs;
+            }
+        }
+
+        for bit in 0..num_bits {
+            let checks = pcm.column_neighbors(bit);
+            let mut llr = prior_llrs[bit];
+            for &check in checks {
+                let edge_index = pcm
+                    .row_neighbors(check)
+                    .iter()
+                    .position(|&candidate| candidate == bit)
+                    .unwrap();
+                llr += check_to_var[check][edge_index];
+            }
+            final_llrs[bit] = llr;
+        }
+
+        for check in 0..num_checks {
+            for (edge_index, &bit) in pcm.row_neighbors(check).iter().enumerate() {
+                let mut llr = prior_llrs[bit];
+                for &neighbor_check in pcm.column_neighbors(bit) {
+                    if neighbor_check == check {
+                        continue;
+                    }
+                    let neighbor_edge = pcm
+                        .row_neighbors(neighbor_check)
+                        .iter()
+                        .position(|&candidate| candidate == bit)
+                        .unwrap();
+                    llr += check_to_var[neighbor_check][neighbor_edge];
+                }
+                var_to_check[check][edge_index] = llr;
+            }
+        }
+
+        hard_decision = Correction::from(final_llrs.iter().map(|&llr| llr < 0.0).collect());
+        residual_weight = pcm
+            .multiply(&hard_decision)
+            .as_slice()
+            .iter()
+            .zip(syndrome.as_slice().iter())
+            .filter(|(lhs, rhs)| lhs != rhs)
+            .count();
+
+        if early_stop && residual_weight == 0 {
+            return BpSnapshot {
+                hard_decision,
+                reliability: final_llrs.iter().map(|value| value.abs()).collect(),
+                iterations: iteration,
+                converged: true,
+                residual_weight,
+            };
+        }
+    }
+
+    BpSnapshot {
+        hard_decision,
+        reliability: final_llrs.iter().map(|value| value.abs()).collect(),
+        iterations: max_iterations.max(1),
+        converged: residual_weight == 0,
+        residual_weight,
+    }
+}
+```
+
+Create `rbposd/src/decoder.rs`:
+
+```rust
+use crate::bp::run_minimum_sum;
+use crate::config::ChannelModel;
+use crate::error::DecodeError;
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::{Correction, Syndrome};
+use crate::DecoderConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodeResult {
+    pub correction: Correction,
+    pub converged: bool,
+    pub bp_iterations: usize,
+    pub used_osd: bool,
+    pub residual_syndrome_weight: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct BpOsdDecoder {
+    pcm: ParityCheckMatrix,
+    prior_llrs: Vec<f64>,
+    config: DecoderConfig,
+}
+
+impl BpOsdDecoder {
+    pub fn new(
+        pcm: ParityCheckMatrix,
+        channel: ChannelModel,
+        config: DecoderConfig,
+    ) -> Result<Self, DecodeError> {
+        let prior_llrs = match channel {
+            ChannelModel::Bsc { error_rate } => {
+                if !(0.0..=1.0).contains(&error_rate) || error_rate == 0.0 || error_rate == 1.0 {
+                    return Err(DecodeError::InvalidProbability);
+                }
+                let llr = ((1.0 - error_rate) / error_rate).ln();
+                vec![llr; pcm.num_bits()]
+            }
+            ChannelModel::BitFlipProbabilities(probabilities) => {
+                if probabilities.len() != pcm.num_bits() {
+                    return Err(DecodeError::DimensionMismatch {
+                        what: "channel probabilities",
+                        expected: pcm.num_bits(),
+                        actual: probabilities.len(),
+                    });
+                }
+                let mut llrs = Vec::with_capacity(probabilities.len());
+                for probability in probabilities {
+                    if !(0.0..=1.0).contains(&probability) || probability == 0.0 || probability == 1.0 {
+                        return Err(DecodeError::InvalidProbability);
+                    }
+                    llrs.push(((1.0 - probability) / probability).ln());
+                }
+                llrs
+            }
+        };
+
+        Ok(Self {
+            pcm,
+            prior_llrs,
+            config,
+        })
+    }
+
+    pub fn decode(&self, syndrome: &Syndrome) -> Result<DecodeResult, DecodeError> {
+        if syndrome.len() != self.pcm.num_checks() {
+            return Err(DecodeError::DimensionMismatch {
+                what: "syndrome",
+                expected: self.pcm.num_checks(),
+                actual: syndrome.len(),
+            });
+        }
+
+        if syndrome.weight() == 0 {
+            return Ok(DecodeResult {
+                correction: Correction::zero(self.pcm.num_bits()),
+                converged: true,
+                bp_iterations: 0,
+                used_osd: false,
+                residual_syndrome_weight: 0,
+            });
+        }
+
+        let snapshot = run_minimum_sum(
+            &self.pcm,
+            &self.prior_llrs,
+            syndrome,
+            self.config.max_bp_iterations,
+            self.config.early_stop,
+        );
+
+        if snapshot.residual_weight != 0 {
+            return Err(DecodeError::BpDidNotConverge);
+        }
+
+        Ok(DecodeResult {
+            correction: snapshot.hard_decision,
+            converged: snapshot.converged,
+            bp_iterations: snapshot.iterations,
+            used_osd: false,
+            residual_syndrome_weight: snapshot.residual_weight,
+        })
+    }
+}
+```
+
+Update `rbposd/src/lib.rs`:
+
+```rust
+pub mod config;
+pub mod error;
+pub mod matrix;
+pub mod vector;
+
+mod bp;
+mod decoder;
+mod gf2;
+
+pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use decoder::{BpOsdDecoder, DecodeResult};
+pub use error::DecodeError;
+pub use matrix::ParityCheckMatrix;
+pub use vector::{Correction, Syndrome};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rbposd --test bp -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rbposd/src/lib.rs rbposd/src/bp.rs rbposd/src/decoder.rs rbposd/src/error.rs rbposd/tests/bp.rs
+git commit -m "feat: add rbposd minimum-sum decoder path"
+```
+
+### Task 5: Add `OSD_0` Fallback And Return Valid Corrections On BP Failure
+
+**Files:**
+- Modify: `rbposd/src/lib.rs`
+- Create: `rbposd/src/osd.rs`
+- Modify: `rbposd/src/decoder.rs`
+- Test: `rbposd/tests/osd.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rbposd/tests/osd.rs`:
+
+```rust
+use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+#[test]
+fn osd0_recovers_a_valid_solution_when_bp_is_disabled() {
+    let pcm =
+        ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap();
+    let mut config = DecoderConfig::default();
+    config.max_bp_iterations = 0;
+
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::BitFlipProbabilities(vec![0.1, 0.2, 0.3]),
+        config,
+    )
+    .unwrap();
+
+    let syndrome = Syndrome::from(vec![true, false]);
+    let result = decoder.decode(&syndrome).unwrap();
+
+    assert!(result.used_osd);
+    assert_eq!(result.residual_syndrome_weight, 0);
+    assert_eq!(pcm.multiply(&result.correction), syndrome);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rbposd --test osd -v`
+
+Expected: FAIL with `belief propagation did not converge`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `rbposd/src/osd.rs`:
+
+```rust
+use crate::error::DecodeError;
+use crate::gf2::{solve_with_column_order, sort_columns_by_reliability};
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::{Correction, Syndrome};
+
+pub(crate) fn decode_osd0(
+    pcm: &ParityCheckMatrix,
+    syndrome: &Syndrome,
+    reliability: &[f64],
+) -> Result<Correction, DecodeError> {
+    let order = sort_columns_by_reliability(reliability);
+    solve_with_column_order(pcm, syndrome, &order).map_err(|_| DecodeError::NoOsdSolution)
+}
+```
+
+Update `rbposd/src/decoder.rs` so `decode(...)` falls back to `OSD_0`:
+
+```rust
+use crate::bp::run_minimum_sum;
+use crate::config::ChannelModel;
+use crate::error::DecodeError;
+use crate::matrix::ParityCheckMatrix;
+use crate::osd::decode_osd0;
+use crate::vector::{Correction, Syndrome};
+use crate::DecoderConfig;
+
+impl BpOsdDecoder {
+    pub fn decode(&self, syndrome: &Syndrome) -> Result<DecodeResult, DecodeError> {
+        if syndrome.len() != self.pcm.num_checks() {
+            return Err(DecodeError::DimensionMismatch {
+                what: "syndrome",
+                expected: self.pcm.num_checks(),
+                actual: syndrome.len(),
+            });
+        }
+
+        if syndrome.weight() == 0 {
+            return Ok(DecodeResult {
+                correction: Correction::zero(self.pcm.num_bits()),
+                converged: true,
+                bp_iterations: 0,
+                used_osd: false,
+                residual_syndrome_weight: 0,
+            });
+        }
+
+        let snapshot = run_minimum_sum(
+            &self.pcm,
+            &self.prior_llrs,
+            syndrome,
+            self.config.max_bp_iterations,
+            self.config.early_stop,
+        );
+
+        if snapshot.residual_weight == 0 {
+            return Ok(DecodeResult {
+                correction: snapshot.hard_decision,
+                converged: snapshot.converged,
+                bp_iterations: snapshot.iterations,
+                used_osd: false,
+                residual_syndrome_weight: 0,
+            });
+        }
+
+        let correction = decode_osd0(&self.pcm, syndrome, &snapshot.reliability)?;
+
+        Ok(DecodeResult {
+            correction,
+            converged: snapshot.converged,
+            bp_iterations: snapshot.iterations,
+            used_osd: true,
+            residual_syndrome_weight: 0,
+        })
+    }
+}
+```
+
+Update `rbposd/src/lib.rs`:
+
+```rust
+pub mod config;
+pub mod error;
+pub mod matrix;
+pub mod vector;
+
+mod bp;
+mod decoder;
+mod gf2;
+mod osd;
+
+pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use decoder::{BpOsdDecoder, DecodeResult};
+pub use error::DecodeError;
+pub use matrix::ParityCheckMatrix;
+pub use vector::{Correction, Syndrome};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rbposd --test osd -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rbposd/src/lib.rs rbposd/src/osd.rs rbposd/src/decoder.rs rbposd/tests/osd.rs
+git commit -m "feat: add rbposd OSD0 fallback"
+```
+
+## Phase 3
+
+### Task 6: Add Reference Fixtures, Example Usage, And A Repeatable Profile Loop
+
+**Files:**
+- Create: `rbposd/tests/reference.rs`
+- Create: `rbposd/examples/basic_decode.rs`
+- Create: `rbposd/examples/profile_repetition.rs`
+- Modify: `rbposd/src/lib.rs`
+- Test: `rbposd/tests/reference.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rbposd/tests/reference.rs`:
+
+```rust
+use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+struct Case {
+    name: &'static str,
+    pcm: ParityCheckMatrix,
+    channel: ChannelModel,
+    syndrome: Syndrome,
+    expect_osd: bool,
+}
+
+#[test]
+fn reference_contract_cases_stay_valid() {
+    let mut osd_only = DecoderConfig::default();
+    osd_only.max_bp_iterations = 0;
+
+    let cases = vec![
+        Case {
+            name: "bp repetition single flip",
+            pcm: ParityCheckMatrix::from_sparse_rows(
+                4,
+                5,
+                vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]],
+            )
+            .unwrap(),
+            channel: ChannelModel::Bsc { error_rate: 0.05 },
+            syndrome: Syndrome::from(vec![true, false, false, false]),
+            expect_osd: false,
+        },
+        Case {
+            name: "osd fallback small sparse code",
+            pcm: ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap(),
+            channel: ChannelModel::BitFlipProbabilities(vec![0.1, 0.2, 0.3]),
+            syndrome: Syndrome::from(vec![true, false]),
+            expect_osd: true,
+        },
+    ];
+
+    for case in cases {
+        let config = if case.expect_osd {
+            osd_only.clone()
+        } else {
+            DecoderConfig::default()
+        };
+        let decoder = BpOsdDecoder::new(case.pcm.clone(), case.channel, config).unwrap();
+        let result = decoder.decode(&case.syndrome).unwrap();
+
+        assert_eq!(result.used_osd, case.expect_osd, "{}", case.name);
+        assert_eq!(case.pcm.multiply(&result.correction), case.syndrome, "{}", case.name);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rbposd --test reference -v`
+
+Expected: FAIL because the reference fixture path has not been stabilized yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `rbposd/examples/basic_decode.rs`:
+
+```rust
+use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pcm = ParityCheckMatrix::from_sparse_rows(
+        4,
+        5,
+        vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]],
+    )?;
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )?;
+    let syndrome = Syndrome::from(vec![true, false, false, false]);
+    let result = decoder.decode(&syndrome)?;
+
+    println!("used_osd={}", result.used_osd);
+    println!("bp_iterations={}", result.bp_iterations);
+    println!("correction={:?}", result.correction.as_slice());
+    println!("valid={}", pcm.multiply(&result.correction) == syndrome);
+    Ok(())
+}
+```
+
+Create `rbposd/examples/profile_repetition.rs`:
+
+```rust
+use std::time::Instant;
+
+use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pcm = ParityCheckMatrix::from_sparse_rows(
+        4,
+        5,
+        vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]],
+    )?;
+    let decoder = BpOsdDecoder::new(
+        pcm,
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )?;
+
+    let syndromes = [
+        Syndrome::from(vec![true, false, false, false]),
+        Syndrome::from(vec![false, true, false, false]),
+        Syndrome::from(vec![false, false, true, false]),
+        Syndrome::from(vec![false, false, false, true]),
+    ];
+
+    let mut total_ns = 0u128;
+    let mut total_iterations = 0usize;
+    let mut osd_uses = 0usize;
+
+    for syndrome in syndromes.iter().cycle().take(200) {
+        let start = Instant::now();
+        let result = decoder.decode(syndrome)?;
+        total_ns += start.elapsed().as_nanos();
+        total_iterations += result.bp_iterations;
+        osd_uses += usize::from(result.used_osd);
+    }
+
+    println!("shots=200");
+    println!("avg_ns={}", total_ns / 200);
+    println!("avg_iterations={:.2}", total_iterations as f64 / 200.0);
+    println!("osd_uses={}", osd_uses);
+    Ok(())
+}
+```
+
+Append a short crate-level usage example to `rbposd/src/lib.rs`:
+
+```rust
+//! ```rust
+//! use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+//!
+//! let pcm = ParityCheckMatrix::from_sparse_rows(
+//!     2,
+//!     3,
+//!     vec![vec![0, 1], vec![1, 2]],
+//! )
+//! .unwrap();
+//! let decoder = BpOsdDecoder::new(
+//!     pcm.clone(),
+//!     ChannelModel::Bsc { error_rate: 0.05 },
+//!     DecoderConfig::default(),
+//! )
+//! .unwrap();
+//! let syndrome = Syndrome::from(vec![true, false]);
+//! let result = decoder.decode(&syndrome).unwrap();
+//! assert_eq!(pcm.multiply(&result.correction), syndrome);
+//! ```
+```
+
+- [ ] **Step 4: Run test and examples**
+
+Run: `cargo test -p rbposd --test reference -v`
+
+Expected: PASS
+
+Run: `cargo run -p rbposd --example basic_decode`
+
+Expected:
+
+```text
+used_osd=false
+bp_iterations=1
+correction=[true, false, false, false, false]
+valid=true
+```
+
+Run: `cargo run -p rbposd --example profile_repetition`
+
+Expected: PASS with four metric lines including `shots=200`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rbposd/tests/reference.rs rbposd/examples/basic_decode.rs rbposd/examples/profile_repetition.rs rbposd/src/lib.rs
+git commit -m "test: add rbposd reference fixtures and examples"
+```
+
+## Phase 4
+
+### Task 7: Add The Thin CSS Helper Layer
+
+**Files:**
+- Modify: `rbposd/src/lib.rs`
+- Create: `rbposd/src/css.rs`
+- Create: `rbposd/tests/css.rs`
+- Test: `rbposd/tests/css.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rbposd/tests/css.rs`:
+
+```rust
+use rbposd::{ChannelModel, CssDecoders, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+#[test]
+fn css_decoders_route_x_and_z_syndromes_to_different_matrices() {
+    let hx = ParityCheckMatrix::from_sparse_rows(1, 2, vec![vec![0, 1]]).unwrap();
+    let hz = ParityCheckMatrix::from_sparse_rows(1, 2, vec![vec![1]]).unwrap();
+
+    let css = CssDecoders::new(
+        hx.clone(),
+        hz.clone(),
+        ChannelModel::Bsc { error_rate: 0.05 },
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )
+    .unwrap();
+
+    let x = css.decode_x(&Syndrome::from(vec![true])).unwrap();
+    let z = css.decode_z(&Syndrome::from(vec![true])).unwrap();
+
+    assert_eq!(hx.multiply(&x.correction), Syndrome::from(vec![true]));
+    assert_eq!(hz.multiply(&z.correction), Syndrome::from(vec![true]));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rbposd --test css -v`
+
+Expected: FAIL with unresolved import for `CssDecoders`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `rbposd/src/css.rs`:
+
+```rust
+use crate::config::ChannelModel;
+use crate::decoder::{BpOsdDecoder, DecodeResult};
+use crate::error::DecodeError;
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::Syndrome;
+use crate::DecoderConfig;
+
+#[derive(Debug, Clone)]
+pub struct CssDecoders {
+    x: BpOsdDecoder,
+    z: BpOsdDecoder,
+}
+
+impl CssDecoders {
+    pub fn new(
+        hx: ParityCheckMatrix,
+        hz: ParityCheckMatrix,
+        x_channel: ChannelModel,
+        z_channel: ChannelModel,
+        config: DecoderConfig,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            x: BpOsdDecoder::new(hx, x_channel, config.clone())?,
+            z: BpOsdDecoder::new(hz, z_channel, config)?,
+        })
+    }
+
+    pub fn decode_x(&self, syndrome: &Syndrome) -> Result<DecodeResult, DecodeError> {
+        self.x.decode(syndrome)
+    }
+
+    pub fn decode_z(&self, syndrome: &Syndrome) -> Result<DecodeResult, DecodeError> {
+        self.z.decode(syndrome)
+    }
+}
+```
+
+Update `rbposd/src/lib.rs`:
+
+```rust
+pub mod config;
+pub mod error;
+pub mod matrix;
+pub mod vector;
+
+mod bp;
+mod css;
+mod decoder;
+mod gf2;
+mod osd;
+
+pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use css::CssDecoders;
+pub use decoder::{BpOsdDecoder, DecodeResult};
+pub use error::DecodeError;
+pub use matrix::ParityCheckMatrix;
+pub use vector::{Correction, Syndrome};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rbposd --test css -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rbposd/src/lib.rs rbposd/src/css.rs rbposd/tests/css.rs
+git commit -m "feat: add rbposd css convenience layer"
+```
+
+## Phase 5
+
+### Task 8: Add The `rsinter` DEM Adapter Backed By `rbposd`
+
+**Files:**
+- Modify: `rsinter/Cargo.toml`
+- Modify: `rsinter/src/lib.rs`
+- Modify: `rsinter/src/decode.rs`
+- Modify: `rsinter/src/collect.rs`
+- Create: `rsinter/src/rbposd_adapter.rs`
+- Create: `rsinter/tests/decode_rbposd.rs`
+- Modify: `rstim/doc/getting_started.md`
+- Test: `rsinter/tests/decode_rbposd.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rsinter/tests/decode_rbposd.rs`:
+
+```rust
+use std::collections::HashMap;
+
+use rbposd::DecoderConfig;
+use rsinter::collect::{collect, CollectOptions};
+use rsinter::decode::{Decoder, RbposdDemDecoder};
+use rsinter::task::{CollectionOptions, Task};
+use rstim::dem::DetectorErrorModel;
+use rstim::error_analyzer::ErrorAnalyzer;
+use rstim::parser::parse_lines;
+
+#[test]
+fn rbposd_dem_decoder_predicts_a_single_observable_flip() {
+    let dem = DetectorErrorModel::parse("error(0.125) D0 L0\nerror(0.25) D1\n").unwrap();
+    let decoder = RbposdDemDecoder::new(DecoderConfig::default());
+    let compiled = decoder.compile_for_dem(&dem);
+
+    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[test]
+fn collect_runs_with_the_rbposd_adapter() {
+    let circuit = parse_lines(
+        "R 0\nX_ERROR(0.05) 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n",
+    )
+    .unwrap();
+    let dem = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
+
+    let task = Task {
+        circuit,
+        decoder: "rbposd".into(),
+        dem,
+        metadata: serde_json::json!({"case": "single-qubit"}),
+        collection_options: CollectionOptions {
+            max_shots: Some(32),
+            max_errors: Some(32),
+        },
+    };
+
+    let mut decoders: HashMap<String, Box<dyn Decoder>> = HashMap::new();
+    decoders.insert(
+        "rbposd".into(),
+        Box::new(RbposdDemDecoder::new(DecoderConfig::default())),
+    );
+
+    let results = collect(
+        vec![task],
+        decoders,
+        &CollectOptions {
+            num_workers: 1,
+            max_shots: None,
+            max_errors: None,
+            max_batch_size: Some(32),
+            start_batch_size: 8,
+            save_resume_filepath: None,
+            print_progress: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].shots > 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p rsinter --test decode_rbposd -v`
+
+Expected: FAIL with unresolved import for `RbposdDemDecoder` and missing `rbposd` dependency.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `rsinter/Cargo.toml`:
+
+```toml
+[dependencies]
+rstim = { path = "../rstim" }
+rbposd = { path = "../rbposd" }
+rand = "0.8"
+rayon = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+csv = "1"
+sha2 = "0.10"
+plotters = { version = "0.3", default-features = false, features = ["svg_backend", "bitmap_backend", "bitmap_encoder", "line_series", "full_palette", "ttf"] }
+```
+
+Create `rsinter/src/rbposd_adapter.rs`:
+
+```rust
+use rbposd::{BpOsdDecoder, ChannelModel, Correction, DecoderConfig, ParityCheckMatrix, Syndrome};
+use rstim::dem::{DemInstruction, DemTarget, DetectorErrorModel};
+
+use crate::decode::{CompiledDecoder, Decoder};
+
+pub struct RbposdDemDecoder {
+    config: DecoderConfig,
+}
+
+impl RbposdDemDecoder {
+    pub fn new(config: DecoderConfig) -> Self {
+        Self { config }
+    }
+}
+
+struct CompiledRbposdDemDecoder {
+    decoder: BpOsdDecoder,
+    observable_columns: Vec<Vec<usize>>,
+    num_obs: usize,
+}
+
+impl Decoder for RbposdDemDecoder {
+    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
+        let (pcm, probabilities, observable_columns, num_obs) = dem_to_matrix_problem(dem);
+        let decoder = BpOsdDecoder::new(
+            pcm,
+            ChannelModel::BitFlipProbabilities(probabilities),
+            self.config.clone(),
+        )
+        .expect("DEM lowering produced an invalid rbposd problem");
+
+        Box::new(CompiledRbposdDemDecoder {
+            decoder,
+            observable_columns,
+            num_obs,
+        })
+    }
+}
+
+impl CompiledDecoder for CompiledRbposdDemDecoder {
+    fn decode_shots_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Vec<u8> {
+        let obs_bytes = (num_obs + 7) / 8;
+        let det_bytes = num_dets.div_ceil(8);
+        let mut out = vec![0u8; num_shots * obs_bytes];
+
+        for shot in 0..num_shots {
+            let offset = shot * det_bytes;
+            let syndrome_bits: Vec<bool> = (0..num_dets)
+                .map(|det| {
+                    let byte = dets[offset + (det / 8)];
+                    ((byte >> (det % 8)) & 1) == 1
+                })
+                .collect();
+            let result = self
+                .decoder
+                .decode(&Syndrome::from(syndrome_bits))
+                .expect("rbposd decode failed");
+            let observable_bits = correction_to_observables(
+                &result.correction,
+                &self.observable_columns,
+                self.num_obs,
+            );
+            for obs in 0..self.num_obs {
+                if observable_bits[obs] {
+                    out[shot * obs_bytes + (obs / 8)] |= 1 << (obs % 8);
+                }
+            }
+        }
+
+        out
+    }
+}
+
+fn correction_to_observables(
+    correction: &Correction,
+    observable_columns: &[Vec<usize>],
+    num_obs: usize,
+) -> Vec<bool> {
+    let mut out = vec![false; num_obs];
+    for (column, &enabled) in correction.as_slice().iter().enumerate() {
+        if !enabled {
+            continue;
+        }
+        for &obs in &observable_columns[column] {
+            out[obs] ^= true;
+        }
+    }
+    out
+}
+
+fn dem_to_matrix_problem(
+    dem: &DetectorErrorModel,
+) -> (ParityCheckMatrix, Vec<f64>, Vec<Vec<usize>>, usize) {
+    let num_dets = dem.effective_num_detectors();
+    let num_obs = dem.num_observables();
+    let mut detector_columns: Vec<Vec<usize>> = Vec::new();
+    let mut observable_columns: Vec<Vec<usize>> = Vec::new();
+    let mut probabilities: Vec<f64> = Vec::new();
+
+    fn visit(
+        instrs: &[DemInstruction],
+        detector_offset: usize,
+        detector_columns: &mut Vec<Vec<usize>>,
+        observable_columns: &mut Vec<Vec<usize>>,
+        probabilities: &mut Vec<f64>,
+    ) {
+        let mut offset = detector_offset;
+        for instr in instrs {
+            match instr {
+                DemInstruction::Error { probability, targets } => {
+                    let mut current_dets = Vec::new();
+                    let mut current_obs = Vec::new();
+                    for target in targets {
+                        match target {
+                            DemTarget::Detector(det) => current_dets.push(offset + det),
+                            DemTarget::Observable(obs) => current_obs.push(*obs),
+                            DemTarget::Separator => {
+                                detector_columns.push(current_dets.clone());
+                                observable_columns.push(current_obs.clone());
+                                probabilities.push(*probability);
+                                current_dets.clear();
+                                current_obs.clear();
+                            }
+                        }
+                    }
+                    detector_columns.push(current_dets);
+                    observable_columns.push(current_obs);
+                    probabilities.push(*probability);
+                }
+                DemInstruction::ShiftDetectors { detector_offset, .. } => {
+                    offset += detector_offset;
+                }
+                DemInstruction::Repeat { count, body } => {
+                    for _ in 0..*count {
+                        visit(
+                            body.instructions(),
+                            offset,
+                            detector_columns,
+                            observable_columns,
+                            probabilities,
+                        );
+                        offset += body.instructions().iter().fold(0usize, |acc, instruction| {
+                            match instruction {
+                                DemInstruction::ShiftDetectors { detector_offset, .. } => {
+                                    acc + detector_offset
+                                }
+                                _ => acc,
+                            }
+                        });
+                    }
+                }
+                DemInstruction::Detector { .. } | DemInstruction::LogicalObservable { .. } => {}
+            }
+        }
+    }
+
+    visit(
+        dem.instructions(),
+        0,
+        &mut detector_columns,
+        &mut observable_columns,
+        &mut probabilities,
+    );
+
+    let pcm =
+        ParityCheckMatrix::from_sparse_columns(num_dets, detector_columns.len(), detector_columns)
+            .expect("generated DEM matrix should be valid");
+
+    (pcm, probabilities, observable_columns, num_obs)
+}
+```
+
+Update `rsinter/src/decode.rs`:
+
+```rust
+use rstim::dem::DetectorErrorModel;
+
+pub use crate::rbposd_adapter::RbposdDemDecoder;
+
+pub trait CompiledDecoder: Send {
+    fn decode_shots_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Vec<u8>;
+}
+
+pub trait Decoder: Send + Sync {
+    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder>;
+}
+
+pub struct VacuousDecoder;
+
+struct VacuousCompiled;
+
+impl CompiledDecoder for VacuousCompiled {
+    fn decode_shots_bit_packed(
+        &self,
+        _dets: &[u8],
+        num_shots: usize,
+        _num_dets: usize,
+        num_obs: usize,
+    ) -> Vec<u8> {
+        let obs_bytes = (num_obs + 7) / 8;
+        vec![0u8; num_shots * obs_bytes]
+    }
+}
+
+impl Decoder for VacuousDecoder {
+    fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
+        Box::new(VacuousCompiled)
+    }
+}
+```
+
+Update `rsinter/src/lib.rs`:
+
+```rust
+mod rbposd_adapter;
+
+pub mod stats;
+pub mod decode;
+pub mod task;
+pub mod task_stats;
+pub mod csv_io;
+pub mod collect;
+pub mod plot;
+```
+
+Update `rsinter/src/collect.rs` so detector width matches shifted/repeated DEMs:
+
+```rust
+let num_dets = task.dem.effective_num_detectors();
+let num_obs = task.dem.num_observables();
+```
+
+Add a short adapter example to `rstim/doc/getting_started.md` after the existing `rsinter` section:
+
+```markdown
+## Decode with rbposd through rsinter
+
+Once `rbposd` is available in the workspace, `rsinter` can compile a DEM into
+an in-tree BPOSD decoder:
+
+    use rsinter::decode::RbposdDemDecoder;
+    use rbposd::DecoderConfig;
+
+    let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
+    decoders.insert("rbposd".into(), Box::new(RbposdDemDecoder::new(DecoderConfig::default())));
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p rsinter --test decode_rbposd -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rsinter/Cargo.toml rsinter/src/lib.rs rsinter/src/decode.rs rsinter/src/collect.rs rsinter/src/rbposd_adapter.rs rsinter/tests/decode_rbposd.rs rstim/doc/getting_started.md
+git commit -m "feat: add rbposd adapter for rsinter"
+```
+
+## Self-Review Checklist
+
+- [ ] **Spec coverage:** Confirm the plan covers the spec sections for independent crate setup, matrix-first API, `minimum-sum + parallel + OSD_0`, CSS helper, and `rsinter` integration.
+- [ ] **Placeholder scan:** Search this file for `TBD`, `TODO`, `implement later`, `fill in details`, and `similar to`.
+- [ ] **Type consistency:** Confirm these names stay consistent across tasks:
+  - `ParityCheckMatrix`
+  - `Syndrome`
+  - `Correction`
+  - `ChannelModel`
+  - `DecoderConfig`
+  - `BpOsdDecoder`
+  - `DecodeResult`
+  - `CssDecoders`
+  - `RbposdDemDecoder`

--- a/docs/superpowers/specs/2026-04-22-rbposd-bposd-design.md
+++ b/docs/superpowers/specs/2026-04-22-rbposd-bposd-design.md
@@ -1,0 +1,575 @@
+# Rust BPOSD Design
+
+Date: 2026-04-22
+Status: Proposed
+Scope: `rstim` workspace, new `rbposd` crate
+
+## Summary
+
+This design adds a Rust implementation of BPOSD to the current workspace as a
+new independent crate named `rbposd`.
+
+The first version is intentionally narrow:
+
+- ship an algorithm-focused crate instead of wiring directly into `rstim` or
+  `rsinter`
+- model decoding as a binary linear-code problem:
+  `parity_check_matrix + syndrome -> correction`
+- implement only the MVP algorithm path:
+  `minimum-sum BP + parallel schedule + OSD_0`
+- keep the core API free of detector-error-model, detector, and observable
+  semantics
+
+The roadmap explicitly includes later phases for:
+
+- a thin CSS-oriented helper layer on top of the core matrix decoder
+- a bridge into `rsinter::decode` for end-to-end decoding experiments in this
+  workspace
+
+This keeps the first version aligned with the BPOSD core from Python `ldpc`
+while avoiding a premature collapse of the algorithm layer into the current
+quantum workflow.
+
+## Goals
+
+- Add a standalone Rust crate in this workspace that provides a usable BPOSD
+  decoder.
+- Match the first meaningful slice of Python `ldpc` BPOSD functionality in a
+  way that is easy to test against reference behavior.
+- Center the core public API on matrix decoding inputs and outputs instead of
+  quantum-specific artifacts.
+- Make decoder compilation reusable so the same compiled decoder can process
+  many syndromes efficiently.
+- Leave clean extension points for later CSS helpers and `rsinter`
+  integration.
+
+## Non-Goals
+
+- Do not make the first version consume `DetectorErrorModel` directly.
+- Do not make detector and observable prediction first-class core API
+  concepts.
+- Do not implement `product_sum`, serial scheduling, or `OSD_CS` in the first
+  version.
+- Do not optimize for every sparse-matrix workload before the MVP behavior is
+  correct and testable.
+- Do not introduce a dependency from `rbposd` back into `rstim` or `rsinter`.
+
+## Current State
+
+The current workspace already has a natural integration target but does not yet
+contain a real decoder implementation:
+
+- [`rsinter/src/decode.rs`](/Users/nzy/rcode/rstim/rsinter/src/decode.rs)
+  defines a minimal decoder abstraction with `Decoder` and
+  `CompiledDecoder` traits, but only includes `VacuousDecoder`.
+- [`rstim/src/dem.rs`](/Users/nzy/rcode/rstim/rstim/src/dem.rs) and
+  [`rstim/src/m2d.rs`](/Users/nzy/rcode/rstim/rstim/src/m2d.rs) already cover
+  detector error models and measurement-to-detection conversion, which means
+  there is a clear later path from the workspace into a real decoder.
+- [`rstim/doc/getting_started.md`](/Users/nzy/rcode/rstim/rstim/doc/getting_started.md)
+  currently points users to external decoders such as `rmatching` rather than
+  an in-workspace solution.
+
+This creates a useful separation of concerns for the new work:
+
+- `rbposd` can focus on correct and reusable decoding machinery
+- later phases can bridge the existing workspace data flow into `rbposd`
+
+## Constraints And Design Decisions
+
+### Chosen Direction
+
+The design follows this explicit direction:
+
+- first build an independent crate
+- design the core around binary linear-code decoding
+- keep quantum-specific semantics outside the core API
+- include later phases for CSS convenience and `rsinter` integration
+
+### Alternatives Considered
+
+#### 1. Pure algorithm crate only
+
+This is the smallest scope and the easiest to align with Python `ldpc`, but it
+pushes all workspace integration to a later design and provides less immediate
+value to current `rstim` workflows.
+
+#### 2. Layered approach
+
+Build an independent algorithm crate first, then add a thin CSS helper layer,
+then add `rsinter` integration through a dedicated adapter.
+
+This is the recommended option because it preserves a clean core while still
+committing the roadmap to useful local integration.
+
+#### 3. Workflow-first integration
+
+Start from `rsinter` and `DetectorErrorModel` integration, then build the
+algorithm beneath it.
+
+This would produce an end-to-end demo earlier, but it would also expand the
+scope from "implement BPOSD" to "define a new quantum decoding workflow" and
+would make it harder to stay faithful to the `ldpc` core.
+
+## Recommended Architecture
+
+Use a layered design with three levels:
+
+1. `rbposd` core
+2. optional thin helpers above the core
+3. workspace integration adapters outside the core
+
+### Layer 1: `rbposd` Core
+
+The core owns:
+
+- parity-check matrix representation
+- syndrome and correction vector representation
+- channel priors
+- BP implementation
+- OSD implementation
+- compiled decoder lifecycle
+
+The core does not own:
+
+- DEM parsing
+- detector graph semantics
+- measurement-to-detection conversion
+- observable prediction semantics
+
+### Layer 2: Thin Helper Layer
+
+After the MVP is stable, add helpers for two-matrix CSS-style use cases such as
+separate `Hx` and `Hz` decode flows. These helpers should remain convenience
+wrappers over the same matrix-based core.
+
+### Layer 3: Workspace Integration
+
+`rsinter` integration should be implemented as an adapter that translates a
+workspace-specific decoding problem into the core `rbposd` matrix problem. That
+adapter may depend on `rstim` and `rsinter`, but `rbposd` itself must remain
+independent.
+
+## Public API Shape
+
+The public API should be centered on a compiled decoder object, not on free
+functions. The compiled form can hold the structural data that is expensive to
+rebuild on every decode call.
+
+### Core Types
+
+#### `ParityCheckMatrix`
+
+Represents a binary parity-check matrix.
+
+Requirements:
+
+- support construction from sparse rows at minimum
+- support validation of dimensions and index bounds
+- expose row and column structure needed by BP and OSD
+- permit algorithm-specific derived structures without changing the public
+  input model
+
+The stable public type should represent the decoding problem. Internal
+algorithm-specific adjacency structures may be derived from it.
+
+#### `Syndrome`
+
+Represents the right-hand side of the decoding equation over GF(2).
+
+Requirements:
+
+- length must match the number of matrix rows
+- easy construction from `Vec<bool>` in the MVP
+- packed representations are a later optimization, not part of the first public
+  surface
+
+#### `Correction`
+
+Represents the decoded binary error or recovery vector.
+
+Requirements:
+
+- length must match the number of matrix columns
+- be easy to verify against the syndrome using GF(2) multiplication
+
+#### `ChannelModel`
+
+Describes bit prior information for decoding.
+
+The MVP should support:
+
+- a uniform binary symmetric channel case
+- per-bit flip probabilities
+
+This covers the minimum needed to model the common `ldpc` BPOSD entry points
+without overspecifying future channel abstractions.
+
+#### `DecoderConfig`
+
+Collects algorithm configuration.
+
+The MVP should include fields for:
+
+- maximum BP iterations
+- convergence or stopping policy
+
+It may contain enums for future options, but the first implemented path is:
+
+- BP rule: `minimum_sum`
+- schedule: `parallel`
+- OSD mode: `OSD_0`
+
+The MVP should not expose minimum-sum scaling, damping, or "always run OSD"
+switches in the public config. The fixed behavior is:
+
+- run BP up to the configured iteration limit
+- return the BP hard decision immediately if it satisfies the parity checks
+- run `OSD_0` only when the BP hard decision fails
+
+#### `BpOsdDecoder`
+
+Compiled decoder built from:
+
+- `ParityCheckMatrix`
+- `ChannelModel`
+- `DecoderConfig`
+
+Responsibilities:
+
+- validate compatibility of inputs
+- build row and column adjacency
+- precompute reusable working structures
+- decode many syndromes through `decode(&syndrome)`
+
+#### `DecodeResult`
+
+The result type should include both the correction and enough diagnostic data
+to support tests, benchmarks, and later regression analysis.
+
+Required fields:
+
+- `correction`
+- `converged`
+- `bp_iterations`
+- `used_osd`
+- `residual_syndrome_weight`
+
+Optional future fields may be added later, but the MVP should avoid exposing
+large internal traces by default.
+
+### Example API Sketch
+
+```rust
+let pcm = ParityCheckMatrix::from_sparse_rows(num_rows, num_cols, rows)?;
+let channel = ChannelModel::Bsc { error_rate: 0.05 };
+let config = DecoderConfig::default();
+
+let decoder = BpOsdDecoder::new(pcm, channel, config)?;
+let result = decoder.decode(&syndrome)?;
+```
+
+This shape supports both current MVP goals and later adapters that compile a
+decoder once and reuse it across many shots.
+
+## Crate Layout
+
+The initial crate layout should stay focused:
+
+```text
+rbposd/src/
+  lib.rs
+  matrix.rs
+  vector.rs
+  config.rs
+  decoder.rs
+  bp.rs
+  osd.rs
+  error.rs
+```
+
+Module responsibilities:
+
+- `matrix.rs`: stable matrix input type and derived helpers
+- `vector.rs`: syndrome and correction representations plus GF(2) utilities
+- `config.rs`: channel and decoder configuration types
+- `decoder.rs`: public compiled-decoder API and orchestration
+- `bp.rs`: minimum-sum belief propagation
+- `osd.rs`: OSD_0 implementation and GF(2) elimination helpers that are truly
+  OSD-specific
+- `error.rs`: construction and decode error types
+
+If later implementation shows that GF(2) elimination deserves its own module,
+that refactor is acceptable, but it is not required to start.
+
+## Algorithm Scope
+
+The MVP is a deliberately narrow algorithm slice:
+
+- input: binary parity-check matrix, syndrome, and bit priors
+- BP rule: minimum-sum
+- schedule: parallel
+- post-processing: OSD_0
+- output: correction vector satisfying `H * e = syndrome` over GF(2)
+
+### Explicitly Included
+
+- reusable compiled decoder construction
+- syndrome validation
+- BP iterations with a clear stopping condition
+- conversion from BP state to a hard decision plus reliability ordering
+- OSD_0 fallback or refinement
+- result diagnostics sufficient for testing and regression tracking
+
+### Explicitly Excluded
+
+- `product_sum`
+- serial or layered scheduling
+- higher-order OSD variants such as `OSD_CS`
+- DEM-native input
+- batch APIs as part of the first public surface
+- quantum observable prediction in the core result type
+
+## Decode Data Flow
+
+### `BpOsdDecoder::new(...)`
+
+Construction performs:
+
+1. validate matrix dimensions and channel-model compatibility
+2. build row and column adjacency structures
+3. initialize reusable BP metadata and workspace plans
+4. prepare OSD-related permutation and elimination workspace
+
+The goal is to pay structural setup cost once.
+
+### `decode(&syndrome)`
+
+Decode performs:
+
+1. validate syndrome length
+2. initialize BP messages from priors
+3. run minimum-sum BP until convergence or iteration limit
+4. derive a hard decision and reliability ordering
+5. if the hard decision already satisfies the syndrome, return it directly
+6. otherwise run OSD_0
+7. return correction plus diagnostics
+
+### `OSD_0`
+
+The `OSD_0` step performs:
+
+1. sort columns by reliability
+2. permute matrix columns accordingly
+3. perform GF(2) elimination to identify a usable information set
+4. construct a candidate correction satisfying the syndrome
+5. invert the permutation back to the original column order
+
+The implementation must make these substeps individually testable instead of
+hiding all logic inside one large routine.
+
+## Testing Strategy
+
+Testing should be layered so failures are easy to localize.
+
+### 1. Algebra Tests
+
+Verify:
+
+- GF(2) row operations
+- column permutations
+- system-form elimination
+- `H * correction = syndrome` checks
+
+These tests must not depend on BP or OSD.
+
+### 2. Algorithm Unit Tests
+
+Use small hand-constructed matrices and fixed syndromes to verify:
+
+- BP iteration behavior
+- hard-decision extraction
+- OSD_0 result construction
+- correctness of `DecodeResult` diagnostics
+
+### 3. Reference Comparison Tests
+
+Create a set of fixed fixtures and compare the Rust implementation against the
+targeted MVP behavior from Python `ldpc`.
+
+The comparison focus should be:
+
+- correction validity
+- convergence behavior when the compared configuration matches
+- stable behavior on selected fixed examples
+
+The goal is not to clone every `ldpc` feature immediately. The goal is to lock
+the specific MVP path this design commits to.
+
+### 4. Property Tests
+
+On small random matrices, verify that every successful decode result satisfies
+the syndrome equation. This is especially important for OSD, where subtle
+mistakes can produce plausible but invalid outputs.
+
+### 5. Regression Benchmarks
+
+Track a few repeatable workloads to catch unexpected performance or iteration
+regressions during refactors. The first version does not need aggressive
+optimization, but it should guard against accidental complexity blowups.
+
+## Risks And Mitigations
+
+### Risk: Wrong Matrix Representation Boundary
+
+If the public matrix type is tailored too early to one internal algorithm, BP
+and OSD will fight over representation details.
+
+Mitigation:
+
+- keep `ParityCheckMatrix` stable as the problem definition
+- derive algorithm-specific adjacency or temporary structures internally
+
+### Risk: Behavior Drift From Reference Implementation
+
+Small choices in minimum-sum initialization, message updates, clipping, or
+stopping criteria can produce large differences from the reference behavior.
+
+Mitigation:
+
+- define the MVP comparison scope before implementation
+- lock fixed fixtures early
+- compare behavior incrementally instead of only at the end
+
+### Risk: Silent OSD Incorrectness
+
+OSD can appear to work while returning invalid or unreliable outputs if column
+ordering, elimination, or inverse permutation logic is wrong.
+
+Mitigation:
+
+- split OSD into individually testable helper steps
+- add explicit validity checks that the produced correction satisfies the
+  syndrome equation
+
+### Risk: Integration Pressure Pollutes The Core
+
+When `rsinter` integration begins, there will be pressure to move DEM,
+detector, or observable logic into `rbposd`.
+
+Mitigation:
+
+- keep adaptation code outside the core crate
+- treat quantum workflow inputs as adapter responsibilities, not core
+  abstractions
+
+## Phased Implementation Plan
+
+The work should be executed in explicit phases.
+
+### Phase 0: Reference Scope Lock
+
+- inspect the relevant Python `ldpc` BPOSD MVP behavior in detail
+- define the exact comparison surface for the first Rust version
+- assemble a small fixture set covering simple repetition-style and generic
+  sparse matrix cases
+
+Exit criteria:
+
+- the team has a written list of MVP behaviors to match
+- fixed fixtures exist for reference comparisons
+
+### Phase 1: Crate Skeleton And Algebra Infrastructure
+
+- add `rbposd` as a new workspace member
+- create core matrix, vector, config, and error types
+- implement GF(2) utilities and matrix validation
+- keep decoding logic separate from algebra infrastructure
+
+Exit criteria:
+
+- crate builds
+- algebra tests pass
+- matrix and vector invariants are enforced
+
+### Phase 2: Minimum-Sum BP Core
+
+- implement parallel-schedule minimum-sum BP
+- support uniform and per-bit prior probabilities
+- expose basic convergence diagnostics
+- verify behavior on fixed fixtures
+
+Exit criteria:
+
+- BP-only decoding works on the chosen MVP fixtures
+- diagnostics are stable enough for tests and benchmarks
+
+### Phase 3: OSD_0 Integration
+
+- implement reliability ordering
+- implement column permutation and GF(2) elimination for OSD_0
+- produce candidate corrections in original column order
+- add regression cases where pure BP fails but BP+OSD succeeds
+
+Exit criteria:
+
+- successful decode results always satisfy the syndrome equation
+- fixture coverage includes cases that require OSD_0
+
+### Phase 4: Public API Consolidation
+
+- finalize `BpOsdDecoder::new(...)` and `decode(...)`
+- finalize `DecodeResult`
+- add examples and crate-level documentation
+- avoid exposing premature batch or quantum-specific APIs
+
+Exit criteria:
+
+- users can compile a decoder and decode syndromes with a small documented
+  example
+- public API is small and coherent
+
+### Phase 5: Thin CSS Helper Layer
+
+- add convenience wrappers for two-matrix CSS-style workflows
+- keep helpers as wrappers over the same core decoder abstraction
+
+Exit criteria:
+
+- CSS-oriented callers can use a more natural entry point
+- no quantum-specific semantics leak into the core matrix types
+
+### Phase 6: `rsinter` Integration
+
+- implement an adapter in `rsinter::decode`
+- translate workspace-specific decoding problems into matrix decoding inputs
+- provide an end-to-end path for `collect(...)` to use `rbposd`
+
+Exit criteria:
+
+- `rsinter` can use `rbposd` through an adapter
+- `rbposd` still has no dependency on `rstim` or `rsinter`
+
+## Acceptance Criteria
+
+This design is satisfied when:
+
+- a new workspace crate provides a usable Rust BPOSD MVP implementation
+- the MVP public API is centered on compiled matrix decoding
+- the first implemented path is `minimum-sum + parallel + OSD_0`
+- test coverage proves algebra correctness, decode validity, and selected
+  reference alignment
+- later phases preserve a clean route to CSS helpers and `rsinter`
+  integration without polluting the core API
+
+## Open Questions Deferred To The Implementation Plan
+
+These questions do not block the design, but they should be resolved during
+planning:
+
+- whether the public vector types should start as thin wrappers or aliases over
+  compact bit-oriented storage
+- whether damping or normalization controls are needed in the MVP config from
+  day one or can be added in a follow-up
+- what the minimal fixture set should be for reference comparison against
+  Python `ldpc`

--- a/rbposd/Cargo.toml
+++ b/rbposd/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rbposd"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/rbposd/doc/ldpc_mvp_reference.md
+++ b/rbposd/doc/ldpc_mvp_reference.md
@@ -1,0 +1,6 @@
+# rbposd LDPC MVP Reference
+
+This crate provides the minimum public contract for an LDPC decoding MVP.
+The initial scope intentionally locks configuration defaults, channel model
+shape, and decode error variants so downstream crates can build against a
+stable interface while implementation details evolve.

--- a/rbposd/doc/ldpc_mvp_reference.md
+++ b/rbposd/doc/ldpc_mvp_reference.md
@@ -31,9 +31,8 @@ Excluded:
 - CLI/API integration outside this crate's foundational type contract
 
 Reference fixtures:
-- `rbposd/tests/smoke.rs`:
-  default configuration and channel model contract checks
-- `rbposd/tests/smoke.rs`:
-  decode error formatting and `std::error::Error` trait conformance check
-- `rbposd/doc/ldpc_mvp_reference.md`:
-  this written contract used as the task-level source of truth
+- Repetition-style 4-check / 5-bit code with a single-flip syndrome that BP
+  should solve without OSD.
+- Small 2-check / 3-bit code that is solved by `OSD_0` when BP is disabled.
+- Small sparse non-identity matrix built from sparse columns to verify
+  constructor symmetry.

--- a/rbposd/doc/ldpc_mvp_reference.md
+++ b/rbposd/doc/ldpc_mvp_reference.md
@@ -1,6 +1,39 @@
-# rbposd LDPC MVP Reference
+# rbposd LDPC MVP Reference Contract
 
-This crate provides the minimum public contract for an LDPC decoding MVP.
-The initial scope intentionally locks configuration defaults, channel model
-shape, and decode error variants so downstream crates can build against a
-stable interface while implementation details evolve.
+Date: 2026-04-22
+
+This document locks the Task 1 MVP public surface for `rbposd`. The goal is to
+give downstream crates a stable contract for initial integration while the
+decoder internals remain under active development.
+
+Included:
+- `DecoderConfig` and its default contract:
+  `max_bp_iterations=30`, `early_stop=true`, `bp_variant=MinimumSum`,
+  `schedule=Parallel`, `osd_variant=Osd0`
+- `ChannelModel` with:
+  `Bsc { error_rate: f64 }` and `BitFlipProbabilities(Vec<f64>)`
+- `DecodeError` variants:
+  `EmptyMatrix`, `InvalidProbability`,
+  `InvalidColumnIndex { column: usize, num_bits: usize }`,
+  `DimensionMismatch { what: &'static str, expected: usize, actual: usize }`,
+  `BpDidNotConverge`, `NoOsdSolution`
+- Error ergonomics for `DecodeError`:
+  `Display` implementation and `impl std::error::Error`
+- Crate exports:
+  `pub mod config; pub mod error;`
+  and top-level re-exports for
+  `BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule, DecodeError`
+
+Excluded:
+- Any decoding algorithm implementation (BP, OSD, or hybrid solver logic)
+- Sparse/H matrix parsing, loading, or validation beyond public error typing
+- Performance tuning, SIMD/parallel execution internals, and benchmarking hooks
+- CLI/API integration outside this crate's foundational type contract
+
+Reference fixtures:
+- `rbposd/tests/smoke.rs`:
+  default configuration and channel model contract checks
+- `rbposd/tests/smoke.rs`:
+  decode error formatting and `std::error::Error` trait conformance check
+- `rbposd/doc/ldpc_mvp_reference.md`:
+  this written contract used as the task-level source of truth

--- a/rbposd/examples/basic_decode.rs
+++ b/rbposd/examples/basic_decode.rs
@@ -1,0 +1,18 @@
+use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pcm = ParityCheckMatrix::from_sparse_rows(1, 5, vec![vec![0]])?;
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )?;
+    let syndrome = Syndrome::from(vec![true]);
+    let result = decoder.decode(&syndrome)?;
+
+    println!("used_osd={}", result.used_osd);
+    println!("bp_iterations={}", result.bp_iterations);
+    println!("correction={:?}", result.correction.as_slice());
+    println!("valid={}", pcm.multiply(&result.correction) == syndrome);
+    Ok(())
+}

--- a/rbposd/examples/profile_repetition.rs
+++ b/rbposd/examples/profile_repetition.rs
@@ -1,0 +1,41 @@
+use std::time::Instant;
+
+use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pcm = ParityCheckMatrix::from_sparse_rows(
+        4,
+        5,
+        vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]],
+    )?;
+    let decoder = BpOsdDecoder::new(
+        pcm,
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )?;
+
+    let syndromes = [
+        Syndrome::from(vec![true, false, false, false]),
+        Syndrome::from(vec![false, true, false, false]),
+        Syndrome::from(vec![false, false, true, false]),
+        Syndrome::from(vec![false, false, false, true]),
+    ];
+
+    let mut total_ns = 0u128;
+    let mut total_iterations = 0usize;
+    let mut osd_uses = 0usize;
+
+    for syndrome in syndromes.iter().cycle().take(200) {
+        let start = Instant::now();
+        let result = decoder.decode(syndrome)?;
+        total_ns += start.elapsed().as_nanos();
+        total_iterations += result.bp_iterations;
+        osd_uses += usize::from(result.used_osd);
+    }
+
+    println!("shots=200");
+    println!("avg_ns={}", total_ns / 200);
+    println!("avg_iterations={:.2}", total_iterations as f64 / 200.0);
+    println!("osd_uses={}", osd_uses);
+    Ok(())
+}

--- a/rbposd/src/bp.rs
+++ b/rbposd/src/bp.rs
@@ -30,6 +30,7 @@ pub(crate) fn run_minimum_sum(
     let mut c_to_v: Vec<Vec<f64>> = (0..pcm.num_checks())
         .map(|check| vec![0.0; pcm.row_neighbors(check).len()])
         .collect();
+    let mut best = None;
     let mut posterior_llrs = prior_llrs.to_vec();
     let mut hard_decision = Correction::from(
         posterior_llrs
@@ -124,6 +125,7 @@ pub(crate) fn run_minimum_sum(
             if config.early_stop {
                 return snapshot;
             }
+            best = Some(snapshot);
         }
 
         for check in 0..pcm.num_checks() {
@@ -133,11 +135,11 @@ pub(crate) fn run_minimum_sum(
         }
     }
 
-    BpSnapshot {
+    best.unwrap_or_else(|| BpSnapshot {
         hard_decision,
         reliability: posterior_llrs.iter().map(|value| value.abs()).collect(),
         iterations: config.max_bp_iterations,
         converged: residual_weight == 0,
         residual_weight,
-    }
+    })
 }

--- a/rbposd/src/bp.rs
+++ b/rbposd/src/bp.rs
@@ -1,0 +1,143 @@
+use crate::config::DecoderConfig;
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::{Correction, Syndrome};
+
+const CERTAINTY_LLR: f64 = 1.0e9;
+
+#[derive(Debug, Clone)]
+pub(crate) struct BpSnapshot {
+    pub(crate) hard_decision: Correction,
+    pub(crate) reliability: Vec<f64>,
+    pub(crate) iterations: usize,
+    pub(crate) converged: bool,
+    pub(crate) residual_weight: usize,
+}
+
+pub(crate) fn run_minimum_sum(
+    pcm: &ParityCheckMatrix,
+    syndrome: &Syndrome,
+    prior_llrs: &[f64],
+    config: &DecoderConfig,
+) -> BpSnapshot {
+    let mut v_to_c: Vec<Vec<f64>> = (0..pcm.num_checks())
+        .map(|check| {
+            pcm.row_neighbors(check)
+                .iter()
+                .map(|&bit| prior_llrs[bit])
+                .collect()
+        })
+        .collect();
+    let mut c_to_v: Vec<Vec<f64>> = (0..pcm.num_checks())
+        .map(|check| vec![0.0; pcm.row_neighbors(check).len()])
+        .collect();
+    let mut posterior_llrs = prior_llrs.to_vec();
+    let mut hard_decision = Correction::from(
+        posterior_llrs
+            .iter()
+            .map(|&llr| llr < 0.0)
+            .collect::<Vec<_>>(),
+    );
+    let mut residual_weight = pcm
+        .multiply(&hard_decision)
+        .as_slice()
+        .iter()
+        .zip(syndrome.as_slice().iter())
+        .filter(|(lhs, rhs)| lhs != rhs)
+        .count();
+
+    if config.max_bp_iterations == 0 {
+        return BpSnapshot {
+            hard_decision,
+            reliability: posterior_llrs.iter().map(|value| value.abs()).collect(),
+            iterations: 0,
+            converged: residual_weight == 0,
+            residual_weight,
+        };
+    }
+
+    for iteration in 1..=config.max_bp_iterations {
+        for check in 0..pcm.num_checks() {
+            let syndrome_sign = if syndrome.as_slice()[check] {
+                -1.0
+            } else {
+                1.0
+            };
+            let row_messages = &v_to_c[check];
+
+            for edge_idx in 0..row_messages.len() {
+                let message = if row_messages.len() == 1 {
+                    syndrome_sign * CERTAINTY_LLR
+                } else {
+                    let mut sign = syndrome_sign;
+                    let mut min_abs = f64::INFINITY;
+
+                    for (other_idx, &other_message) in row_messages.iter().enumerate() {
+                        if other_idx == edge_idx {
+                            continue;
+                        }
+                        if other_message < 0.0 {
+                            sign = -sign;
+                        }
+                        min_abs = min_abs.min(other_message.abs());
+                    }
+
+                    sign * min_abs
+                };
+                c_to_v[check][edge_idx] = message;
+            }
+        }
+
+        let mut incoming = vec![0.0; pcm.num_bits()];
+        for check in 0..pcm.num_checks() {
+            for (edge_idx, &bit) in pcm.row_neighbors(check).iter().enumerate() {
+                incoming[bit] += c_to_v[check][edge_idx];
+            }
+        }
+
+        posterior_llrs = prior_llrs
+            .iter()
+            .zip(incoming.iter())
+            .map(|(prior, sum)| prior + sum)
+            .collect();
+        hard_decision = Correction::from(
+            posterior_llrs
+                .iter()
+                .map(|&llr| llr < 0.0)
+                .collect::<Vec<_>>(),
+        );
+        residual_weight = pcm
+            .multiply(&hard_decision)
+            .as_slice()
+            .iter()
+            .zip(syndrome.as_slice().iter())
+            .filter(|(lhs, rhs)| lhs != rhs)
+            .count();
+
+        if residual_weight == 0 {
+            let snapshot = BpSnapshot {
+                hard_decision: hard_decision.clone(),
+                reliability: posterior_llrs.iter().map(|value| value.abs()).collect(),
+                iterations: iteration,
+                converged: true,
+                residual_weight,
+            };
+            if config.early_stop {
+                return snapshot;
+            }
+        }
+
+        for check in 0..pcm.num_checks() {
+            for (edge_idx, &bit) in pcm.row_neighbors(check).iter().enumerate() {
+                v_to_c[check][edge_idx] = posterior_llrs[bit] - c_to_v[check][edge_idx];
+            }
+        }
+    }
+
+    BpSnapshot {
+        hard_decision,
+        reliability: posterior_llrs.iter().map(|value| value.abs()).collect(),
+        iterations: config.max_bp_iterations,
+        converged: residual_weight == 0,
+        residual_weight,
+    }
+}

--- a/rbposd/src/config.rs
+++ b/rbposd/src/config.rs
@@ -1,0 +1,41 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BpVariant {
+    MinimumSum,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Schedule {
+    Parallel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OsdVariant {
+    Osd0,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChannelModel {
+    Bsc { error_rate: f64 },
+    BitFlipProbabilities(Vec<f64>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecoderConfig {
+    pub max_bp_iterations: usize,
+    pub early_stop: bool,
+    pub bp_variant: BpVariant,
+    pub schedule: Schedule,
+    pub osd_variant: OsdVariant,
+}
+
+impl Default for DecoderConfig {
+    fn default() -> Self {
+        Self {
+            max_bp_iterations: 30,
+            early_stop: true,
+            bp_variant: BpVariant::MinimumSum,
+            schedule: Schedule::Parallel,
+            osd_variant: OsdVariant::Osd0,
+        }
+    }
+}

--- a/rbposd/src/css.rs
+++ b/rbposd/src/css.rs
@@ -1,0 +1,35 @@
+use crate::config::ChannelModel;
+use crate::decoder::{BpOsdDecoder, DecodeResult};
+use crate::error::DecodeError;
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::Syndrome;
+use crate::DecoderConfig;
+
+#[derive(Debug, Clone)]
+pub struct CssDecoders {
+    x: BpOsdDecoder,
+    z: BpOsdDecoder,
+}
+
+impl CssDecoders {
+    pub fn new(
+        hx: ParityCheckMatrix,
+        hz: ParityCheckMatrix,
+        x_channel: ChannelModel,
+        z_channel: ChannelModel,
+        config: DecoderConfig,
+    ) -> Result<Self, DecodeError> {
+        Ok(Self {
+            x: BpOsdDecoder::new(hx, x_channel, config.clone())?,
+            z: BpOsdDecoder::new(hz, z_channel, config)?,
+        })
+    }
+
+    pub fn decode_x(&self, syndrome: &Syndrome) -> Result<DecodeResult, DecodeError> {
+        self.x.decode(syndrome)
+    }
+
+    pub fn decode_z(&self, syndrome: &Syndrome) -> Result<DecodeResult, DecodeError> {
+        self.z.decode(syndrome)
+    }
+}

--- a/rbposd/src/decoder.rs
+++ b/rbposd/src/decoder.rs
@@ -45,6 +45,17 @@ impl BpOsdDecoder {
         }
 
         if syndrome.weight() == 0 {
+            let prior_correction = prior_hard_decision(&self.prior_llrs);
+            if self.pcm.multiply(&prior_correction) == *syndrome {
+                return Ok(DecodeResult {
+                    correction: prior_correction,
+                    converged: true,
+                    bp_iterations: 0,
+                    used_osd: false,
+                    residual_syndrome_weight: 0,
+                });
+            }
+
             return Ok(DecodeResult {
                 correction: Correction::zero(self.pcm.num_bits()),
                 converged: true,
@@ -113,4 +124,8 @@ fn validate_probability(probability: f64) -> Result<f64, DecodeError> {
 
 fn probability_to_llr(probability: f64) -> f64 {
     ((1.0 - probability) / probability).ln()
+}
+
+fn prior_hard_decision(prior_llrs: &[f64]) -> Correction {
+    Correction::from(prior_llrs.iter().map(|&llr| llr < 0.0).collect::<Vec<_>>())
 }

--- a/rbposd/src/decoder.rs
+++ b/rbposd/src/decoder.rs
@@ -55,14 +55,6 @@ impl BpOsdDecoder {
                     residual_syndrome_weight: 0,
                 });
             }
-
-            return Ok(DecodeResult {
-                correction: Correction::zero(self.pcm.num_bits()),
-                converged: true,
-                bp_iterations: 0,
-                used_osd: false,
-                residual_syndrome_weight: 0,
-            });
         }
 
         let snapshot = run_minimum_sum(&self.pcm, syndrome, &self.prior_llrs, &self.config);

--- a/rbposd/src/decoder.rs
+++ b/rbposd/src/decoder.rs
@@ -2,6 +2,7 @@ use crate::bp::run_minimum_sum;
 use crate::config::{ChannelModel, DecoderConfig};
 use crate::error::DecodeError;
 use crate::matrix::ParityCheckMatrix;
+use crate::osd::decode_osd0;
 use crate::vector::{Correction, Syndrome};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,16 +55,24 @@ impl BpOsdDecoder {
         }
 
         let snapshot = run_minimum_sum(&self.pcm, syndrome, &self.prior_llrs, &self.config);
-        if snapshot.residual_weight != 0 {
-            return Err(DecodeError::BpDidNotConverge);
+        if snapshot.residual_weight == 0 {
+            return Ok(DecodeResult {
+                correction: snapshot.hard_decision,
+                converged: snapshot.converged,
+                bp_iterations: snapshot.iterations,
+                used_osd: false,
+                residual_syndrome_weight: snapshot.residual_weight,
+            });
         }
 
+        let correction = decode_osd0(&self.pcm, syndrome, &snapshot.reliability)?;
+
         Ok(DecodeResult {
-            correction: snapshot.hard_decision,
+            correction,
             converged: snapshot.converged,
             bp_iterations: snapshot.iterations,
-            used_osd: false,
-            residual_syndrome_weight: snapshot.residual_weight,
+            used_osd: true,
+            residual_syndrome_weight: 0,
         })
     }
 }

--- a/rbposd/src/decoder.rs
+++ b/rbposd/src/decoder.rs
@@ -1,0 +1,107 @@
+use crate::bp::run_minimum_sum;
+use crate::config::{ChannelModel, DecoderConfig};
+use crate::error::DecodeError;
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::{Correction, Syndrome};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodeResult {
+    pub correction: Correction,
+    pub converged: bool,
+    pub bp_iterations: usize,
+    pub used_osd: bool,
+    pub residual_syndrome_weight: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct BpOsdDecoder {
+    pcm: ParityCheckMatrix,
+    config: DecoderConfig,
+    prior_llrs: Vec<f64>,
+}
+
+impl BpOsdDecoder {
+    pub fn new(
+        pcm: ParityCheckMatrix,
+        channel: ChannelModel,
+        config: DecoderConfig,
+    ) -> Result<Self, DecodeError> {
+        let prior_llrs = compute_prior_llrs(&pcm, &channel)?;
+        Ok(Self {
+            pcm,
+            config,
+            prior_llrs,
+        })
+    }
+
+    pub fn decode(&self, syndrome: &Syndrome) -> Result<DecodeResult, DecodeError> {
+        if syndrome.len() != self.pcm.num_checks() {
+            return Err(DecodeError::DimensionMismatch {
+                what: "syndrome",
+                expected: self.pcm.num_checks(),
+                actual: syndrome.len(),
+            });
+        }
+
+        if syndrome.weight() == 0 {
+            return Ok(DecodeResult {
+                correction: Correction::zero(self.pcm.num_bits()),
+                converged: true,
+                bp_iterations: 0,
+                used_osd: false,
+                residual_syndrome_weight: 0,
+            });
+        }
+
+        let snapshot = run_minimum_sum(&self.pcm, syndrome, &self.prior_llrs, &self.config);
+        if snapshot.residual_weight != 0 {
+            return Err(DecodeError::BpDidNotConverge);
+        }
+
+        Ok(DecodeResult {
+            correction: snapshot.hard_decision,
+            converged: snapshot.converged,
+            bp_iterations: snapshot.iterations,
+            used_osd: false,
+            residual_syndrome_weight: snapshot.residual_weight,
+        })
+    }
+}
+
+fn compute_prior_llrs(
+    pcm: &ParityCheckMatrix,
+    channel: &ChannelModel,
+) -> Result<Vec<f64>, DecodeError> {
+    match channel {
+        ChannelModel::Bsc { error_rate } => {
+            let probability = validate_probability(*error_rate)?;
+            let llr = probability_to_llr(probability);
+            Ok(vec![llr; pcm.num_bits()])
+        }
+        ChannelModel::BitFlipProbabilities(probabilities) => {
+            if probabilities.len() != pcm.num_bits() {
+                return Err(DecodeError::DimensionMismatch {
+                    what: "channel probabilities",
+                    expected: pcm.num_bits(),
+                    actual: probabilities.len(),
+                });
+            }
+
+            probabilities
+                .iter()
+                .map(|&probability| validate_probability(probability).map(probability_to_llr))
+                .collect()
+        }
+    }
+}
+
+fn validate_probability(probability: f64) -> Result<f64, DecodeError> {
+    if !probability.is_finite() || probability <= 0.0 || probability >= 1.0 {
+        return Err(DecodeError::InvalidProbability);
+    }
+    Ok(probability)
+}
+
+fn probability_to_llr(probability: f64) -> f64 {
+    ((1.0 - probability) / probability).ln()
+}

--- a/rbposd/src/error.rs
+++ b/rbposd/src/error.rs
@@ -3,6 +3,7 @@ pub enum DecodeError {
     EmptyMatrix,
     InvalidProbability,
     InvalidColumnIndex { column: usize, num_bits: usize },
+    InvalidRowIndex { row: usize, num_checks: usize },
     DimensionMismatch {
         what: &'static str,
         expected: usize,
@@ -20,7 +21,13 @@ impl core::fmt::Display for DecodeError {
             Self::InvalidColumnIndex { column, num_bits } => {
                 write!(
                     f,
-                    "invalid column index {column} for code with {num_bits} bits"
+                    "column index {column} is out of bounds for code with {num_bits} bits"
+                )
+            }
+            Self::InvalidRowIndex { row, num_checks } => {
+                write!(
+                    f,
+                    "row index {row} is out of bounds for matrix with {num_checks} checks"
                 )
             }
             Self::DimensionMismatch {

--- a/rbposd/src/error.rs
+++ b/rbposd/src/error.rs
@@ -21,7 +21,7 @@ impl core::fmt::Display for DecodeError {
             Self::InvalidColumnIndex { column, num_bits } => {
                 write!(
                     f,
-                    "column index {column} is out of bounds for code with {num_bits} bits"
+                    "column index {column} is out of bounds for {num_bits} bits"
                 )
             }
             Self::InvalidRowIndex { row, num_checks } => {

--- a/rbposd/src/error.rs
+++ b/rbposd/src/error.rs
@@ -9,6 +9,7 @@ pub enum DecodeError {
         expected: usize,
         actual: usize,
     },
+    SingularSystem,
     BpDidNotConverge,
     NoOsdSolution,
 }
@@ -37,6 +38,10 @@ impl core::fmt::Display for DecodeError {
             } => write!(
                 f,
                 "dimension mismatch for {what}: expected {expected}, got {actual}"
+            ),
+            Self::SingularSystem => write!(
+                f,
+                "singular system cannot satisfy the target syndrome"
             ),
             Self::BpDidNotConverge => write!(f, "belief propagation did not converge"),
             Self::NoOsdSolution => write!(f, "no OSD solution found"),

--- a/rbposd/src/error.rs
+++ b/rbposd/src/error.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    EmptyMatrix,
+    InvalidProbability,
+    InvalidColumnIndex { column: usize, num_bits: usize },
+    DimensionMismatch {
+        what: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    BpDidNotConverge,
+    NoOsdSolution,
+}

--- a/rbposd/src/error.rs
+++ b/rbposd/src/error.rs
@@ -11,3 +11,30 @@ pub enum DecodeError {
     BpDidNotConverge,
     NoOsdSolution,
 }
+
+impl core::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::EmptyMatrix => write!(f, "parity-check matrix is empty"),
+            Self::InvalidProbability => write!(f, "invalid probability value"),
+            Self::InvalidColumnIndex { column, num_bits } => {
+                write!(
+                    f,
+                    "invalid column index {column} for code with {num_bits} bits"
+                )
+            }
+            Self::DimensionMismatch {
+                what,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "dimension mismatch for {what}: expected {expected}, got {actual}"
+            ),
+            Self::BpDidNotConverge => write!(f, "belief propagation did not converge"),
+            Self::NoOsdSolution => write!(f, "no OSD solution found"),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}

--- a/rbposd/src/gf2.rs
+++ b/rbposd/src/gf2.rs
@@ -23,7 +23,7 @@ pub(crate) fn solve_with_column_order(
     let mut pivot_columns = Vec::new();
     let mut row = 0usize;
 
-    for &column in column_order {
+    for (pivot_position, &column) in column_order.iter().enumerate() {
         if row == matrix.len() {
             break;
         }
@@ -33,7 +33,7 @@ pub(crate) fn solve_with_column_order(
             rhs.swap(row, pivot_row);
             for other in 0..matrix.len() {
                 if other != row && matrix[other][column] {
-                    for c in column..column_order.len() {
+                    for c in pivot_position..column_order.len() {
                         let physical = column_order[c];
                         matrix[other][physical] ^= matrix[row][physical];
                     }
@@ -80,6 +80,18 @@ mod tests {
             ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap();
         let syndrome = Syndrome::from(vec![true, false]);
         let order = vec![0, 1, 2];
+
+        let correction = solve_with_column_order(&pcm, &syndrome, &order).unwrap();
+
+        assert_eq!(pcm.multiply(&correction), syndrome);
+    }
+
+    #[test]
+    fn solve_with_column_order_reordered_returns_a_valid_solution() {
+        let pcm =
+            ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1, 2], vec![1, 2]]).unwrap();
+        let syndrome = Syndrome::from(vec![false, true]);
+        let order = vec![2, 0, 1];
 
         let correction = solve_with_column_order(&pcm, &syndrome, &order).unwrap();
 

--- a/rbposd/src/gf2.rs
+++ b/rbposd/src/gf2.rs
@@ -1,0 +1,88 @@
+use crate::error::DecodeError;
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::{Correction, Syndrome};
+
+pub(crate) fn sort_columns_by_reliability(scores: &[f64]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..scores.len()).collect();
+    order.sort_by(|&a, &b| {
+        scores[b]
+            .partial_cmp(&scores[a])
+            .unwrap()
+            .then_with(|| a.cmp(&b))
+    });
+    order
+}
+
+pub(crate) fn solve_with_column_order(
+    pcm: &ParityCheckMatrix,
+    syndrome: &Syndrome,
+    column_order: &[usize],
+) -> Result<Correction, DecodeError> {
+    let mut matrix = pcm.dense_rows();
+    let mut rhs = syndrome.as_slice().to_vec();
+    let mut pivot_columns = Vec::new();
+    let mut row = 0usize;
+
+    for &column in column_order {
+        if row == matrix.len() {
+            break;
+        }
+        let pivot = (row..matrix.len()).find(|&candidate| matrix[candidate][column]);
+        if let Some(pivot_row) = pivot {
+            matrix.swap(row, pivot_row);
+            rhs.swap(row, pivot_row);
+            for other in 0..matrix.len() {
+                if other != row && matrix[other][column] {
+                    for c in column..column_order.len() {
+                        let physical = column_order[c];
+                        matrix[other][physical] ^= matrix[row][physical];
+                    }
+                    rhs[other] ^= rhs[row];
+                }
+            }
+            pivot_columns.push(column);
+            row += 1;
+        }
+    }
+
+    if rhs.iter().skip(row).any(|&bit| bit) {
+        return Err(DecodeError::SingularSystem);
+    }
+
+    let mut solution = vec![false; pcm.num_bits()];
+    for (pivot_row, &column) in pivot_columns.iter().enumerate().rev() {
+        let mut value = rhs[pivot_row];
+        for later_column in pivot_columns.iter().skip(pivot_row + 1) {
+            value ^= matrix[pivot_row][*later_column] && solution[*later_column];
+        }
+        solution[column] = value;
+    }
+
+    Ok(Correction::from(solution))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::matrix::ParityCheckMatrix;
+    use crate::vector::Syndrome;
+
+    use super::{solve_with_column_order, sort_columns_by_reliability};
+
+    #[test]
+    fn reliability_sort_is_stable_for_equal_scores() {
+        let order = sort_columns_by_reliability(&[0.9, 0.9, 0.4, 0.9]);
+        assert_eq!(order, vec![0, 1, 3, 2]);
+    }
+
+    #[test]
+    fn solve_with_column_order_returns_a_valid_solution() {
+        let pcm =
+            ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap();
+        let syndrome = Syndrome::from(vec![true, false]);
+        let order = vec![0, 1, 2];
+
+        let correction = solve_with_column_order(&pcm, &syndrome, &order).unwrap();
+
+        assert_eq!(pcm.multiply(&correction), syndrome);
+    }
+}

--- a/rbposd/src/lib.rs
+++ b/rbposd/src/lib.rs
@@ -1,5 +1,9 @@
 pub mod config;
 pub mod error;
+pub mod matrix;
+pub mod vector;
 
 pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
 pub use error::DecodeError;
+pub use matrix::ParityCheckMatrix;
+pub use vector::{Correction, Syndrome};

--- a/rbposd/src/lib.rs
+++ b/rbposd/src/lib.rs
@@ -24,11 +24,13 @@ pub mod matrix;
 pub mod vector;
 
 mod bp;
+mod css;
 mod decoder;
 mod gf2;
 mod osd;
 
 pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use css::CssDecoders;
 pub use decoder::{BpOsdDecoder, DecodeResult};
 pub use error::DecodeError;
 pub use matrix::ParityCheckMatrix;

--- a/rbposd/src/lib.rs
+++ b/rbposd/src/lib.rs
@@ -6,6 +6,7 @@ pub mod vector;
 mod bp;
 mod decoder;
 mod gf2;
+mod osd;
 
 pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
 pub use decoder::{BpOsdDecoder, DecodeResult};

--- a/rbposd/src/lib.rs
+++ b/rbposd/src/lib.rs
@@ -1,0 +1,5 @@
+mod config;
+mod error;
+
+pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use error::DecodeError;

--- a/rbposd/src/lib.rs
+++ b/rbposd/src/lib.rs
@@ -1,5 +1,5 @@
-mod config;
-mod error;
+pub mod config;
+pub mod error;
 
 pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
 pub use error::DecodeError;

--- a/rbposd/src/lib.rs
+++ b/rbposd/src/lib.rs
@@ -1,3 +1,23 @@
+//! ```rust
+//! use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+//!
+//! let pcm = ParityCheckMatrix::from_sparse_rows(
+//!     2,
+//!     3,
+//!     vec![vec![0, 1], vec![1, 2]],
+//! )
+//! .unwrap();
+//! let decoder = BpOsdDecoder::new(
+//!     pcm.clone(),
+//!     ChannelModel::Bsc { error_rate: 0.05 },
+//!     DecoderConfig::default(),
+//! )
+//! .unwrap();
+//! let syndrome = Syndrome::from(vec![true, false]);
+//! let result = decoder.decode(&syndrome).unwrap();
+//! assert_eq!(pcm.multiply(&result.correction), syndrome);
+//! ```
+//!
 pub mod config;
 pub mod error;
 pub mod matrix;

--- a/rbposd/src/lib.rs
+++ b/rbposd/src/lib.rs
@@ -3,6 +3,8 @@ pub mod error;
 pub mod matrix;
 pub mod vector;
 
+mod gf2;
+
 pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
 pub use error::DecodeError;
 pub use matrix::ParityCheckMatrix;

--- a/rbposd/src/lib.rs
+++ b/rbposd/src/lib.rs
@@ -3,9 +3,12 @@ pub mod error;
 pub mod matrix;
 pub mod vector;
 
+mod bp;
+mod decoder;
 mod gf2;
 
 pub use config::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+pub use decoder::{BpOsdDecoder, DecodeResult};
 pub use error::DecodeError;
 pub use matrix::ParityCheckMatrix;
 pub use vector::{Correction, Syndrome};

--- a/rbposd/src/matrix.rs
+++ b/rbposd/src/matrix.rs
@@ -1,0 +1,114 @@
+use crate::error::DecodeError;
+use crate::vector::{Correction, Syndrome};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParityCheckMatrix {
+    num_checks: usize,
+    num_bits: usize,
+    rows: Vec<Vec<usize>>,
+    columns: Vec<Vec<usize>>,
+}
+
+impl ParityCheckMatrix {
+    pub fn from_sparse_rows(
+        num_checks: usize,
+        num_bits: usize,
+        rows: Vec<Vec<usize>>,
+    ) -> Result<Self, DecodeError> {
+        if num_checks == 0 || num_bits == 0 {
+            return Err(DecodeError::EmptyMatrix);
+        }
+        if rows.len() != num_checks {
+            return Err(DecodeError::DimensionMismatch {
+                what: "row count",
+                expected: num_checks,
+                actual: rows.len(),
+            });
+        }
+        let mut columns = vec![Vec::new(); num_bits];
+        for (row_index, cols) in rows.iter().enumerate() {
+            for &column in cols {
+                if column >= num_bits {
+                    return Err(DecodeError::InvalidColumnIndex { column, num_bits });
+                }
+                columns[column].push(row_index);
+            }
+        }
+        Ok(Self {
+            num_checks,
+            num_bits,
+            rows,
+            columns,
+        })
+    }
+
+    pub fn from_sparse_columns(
+        num_checks: usize,
+        num_bits: usize,
+        columns: Vec<Vec<usize>>,
+    ) -> Result<Self, DecodeError> {
+        if num_checks == 0 || num_bits == 0 {
+            return Err(DecodeError::EmptyMatrix);
+        }
+        if columns.len() != num_bits {
+            return Err(DecodeError::DimensionMismatch {
+                what: "column count",
+                expected: num_bits,
+                actual: columns.len(),
+            });
+        }
+        let mut rows = vec![Vec::new(); num_checks];
+        for (column_index, checks) in columns.iter().enumerate() {
+            for &row in checks {
+                if row >= num_checks {
+                    return Err(DecodeError::InvalidRowIndex { row, num_checks });
+                }
+                rows[row].push(column_index);
+            }
+        }
+        Ok(Self {
+            num_checks,
+            num_bits,
+            rows,
+            columns,
+        })
+    }
+
+    pub fn num_checks(&self) -> usize {
+        self.num_checks
+    }
+
+    pub fn num_bits(&self) -> usize {
+        self.num_bits
+    }
+
+    pub fn row_neighbors(&self, check: usize) -> &[usize] {
+        &self.rows[check]
+    }
+
+    pub fn column_neighbors(&self, bit: usize) -> &[usize] {
+        &self.columns[bit]
+    }
+
+    pub fn multiply(&self, correction: &Correction) -> Syndrome {
+        let mut syndrome = vec![false; self.num_checks];
+        for (row_index, cols) in self.rows.iter().enumerate() {
+            let mut parity = false;
+            for &column in cols {
+                parity ^= correction.as_slice()[column];
+            }
+            syndrome[row_index] = parity;
+        }
+        Syndrome::from(syndrome)
+    }
+
+    pub(crate) fn dense_rows(&self) -> Vec<Vec<bool>> {
+        let mut dense = vec![vec![false; self.num_bits]; self.num_checks];
+        for (row_index, cols) in self.rows.iter().enumerate() {
+            for &column in cols {
+                dense[row_index][column] = true;
+            }
+        }
+        dense
+    }
+}

--- a/rbposd/src/osd.rs
+++ b/rbposd/src/osd.rs
@@ -1,0 +1,13 @@
+use crate::error::DecodeError;
+use crate::gf2::{solve_with_column_order, sort_columns_by_reliability};
+use crate::matrix::ParityCheckMatrix;
+use crate::vector::{Correction, Syndrome};
+
+pub(crate) fn decode_osd0(
+    pcm: &ParityCheckMatrix,
+    syndrome: &Syndrome,
+    reliability: &[f64],
+) -> Result<Correction, DecodeError> {
+    let column_order = sort_columns_by_reliability(reliability);
+    solve_with_column_order(pcm, syndrome, &column_order).map_err(|_| DecodeError::NoOsdSolution)
+}

--- a/rbposd/src/vector.rs
+++ b/rbposd/src/vector.rs
@@ -1,0 +1,45 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Syndrome(Vec<bool>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Correction(Vec<bool>);
+
+impl Syndrome {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn as_slice(&self) -> &[bool] {
+        &self.0
+    }
+
+    pub fn weight(&self) -> usize {
+        self.0.iter().filter(|&&bit| bit).count()
+    }
+}
+
+impl Correction {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn as_slice(&self) -> &[bool] {
+        &self.0
+    }
+
+    pub fn zero(len: usize) -> Self {
+        Self(vec![false; len])
+    }
+}
+
+impl From<Vec<bool>> for Syndrome {
+    fn from(bits: Vec<bool>) -> Self {
+        Self(bits)
+    }
+}
+
+impl From<Vec<bool>> for Correction {
+    fn from(bits: Vec<bool>) -> Self {
+        Self(bits)
+    }
+}

--- a/rbposd/tests/bp.rs
+++ b/rbposd/tests/bp.rs
@@ -49,3 +49,24 @@ fn minimum_sum_keeps_a_converged_solution_when_early_stop_is_disabled() {
     assert_eq!(pcm.multiply(&result.correction), syndrome);
     assert_eq!(result.correction, Correction::from(vec![false, false, true]));
 }
+
+#[test]
+fn zero_syndrome_can_return_a_prior_favored_nullspace_correction() {
+    let pcm = ParityCheckMatrix::from_sparse_rows(1, 2, vec![vec![0, 1]]).unwrap();
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::BitFlipProbabilities(vec![0.9, 0.9]),
+        DecoderConfig::default(),
+    )
+    .unwrap();
+
+    let syndrome = Syndrome::from(vec![false]);
+    let result = decoder.decode(&syndrome).unwrap();
+
+    assert!(result.converged);
+    assert!(!result.used_osd);
+    assert_eq!(result.bp_iterations, 0);
+    assert_eq!(result.residual_syndrome_weight, 0);
+    assert_eq!(result.correction, Correction::from(vec![true, true]));
+    assert_eq!(pcm.multiply(&result.correction), syndrome);
+}

--- a/rbposd/tests/bp.rs
+++ b/rbposd/tests/bp.rs
@@ -70,3 +70,23 @@ fn zero_syndrome_can_return_a_prior_favored_nullspace_correction() {
     assert_eq!(result.correction, Correction::from(vec![true, true]));
     assert_eq!(pcm.multiply(&result.correction), syndrome);
 }
+
+#[test]
+fn zero_syndrome_falls_back_to_bp_or_osd_when_hard_decision_is_invalid() {
+    let pcm = ParityCheckMatrix::from_sparse_rows(1, 2, vec![vec![0, 1]]).unwrap();
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::BitFlipProbabilities(vec![0.9, 0.2]),
+        DecoderConfig::default(),
+    )
+    .unwrap();
+
+    let syndrome = Syndrome::from(vec![false]);
+    let result = decoder.decode(&syndrome).unwrap();
+
+    assert!(result.converged);
+    assert!(!result.used_osd);
+    assert_eq!(result.residual_syndrome_weight, 0);
+    assert_eq!(result.correction, Correction::from(vec![true, true]));
+    assert_eq!(pcm.multiply(&result.correction), syndrome);
+}

--- a/rbposd/tests/bp.rs
+++ b/rbposd/tests/bp.rs
@@ -1,4 +1,7 @@
-use rbposd::{BpOsdDecoder, ChannelModel, Correction, DecoderConfig, ParityCheckMatrix, Syndrome};
+use rbposd::{
+    BpOsdDecoder, ChannelModel, Correction, DecodeError, DecoderConfig, ParityCheckMatrix,
+    Syndrome,
+};
 
 fn repetition_pcm() -> ParityCheckMatrix {
     ParityCheckMatrix::from_sparse_rows(4, 5, vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]])
@@ -89,4 +92,61 @@ fn zero_syndrome_falls_back_to_bp_or_osd_when_hard_decision_is_invalid() {
     assert_eq!(result.residual_syndrome_weight, 0);
     assert_eq!(result.correction, Correction::from(vec![true, true]));
     assert_eq!(pcm.multiply(&result.correction), syndrome);
+}
+
+#[test]
+fn decoder_rejects_syndrome_and_channel_dimension_mismatches() {
+    let pcm = ParityCheckMatrix::from_sparse_rows(1, 2, vec![vec![0, 1]]).unwrap();
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )
+    .unwrap();
+
+    let err = decoder.decode(&Syndrome::from(vec![true, false])).unwrap_err();
+    assert_eq!(
+        err,
+        DecodeError::DimensionMismatch {
+            what: "syndrome",
+            expected: 1,
+            actual: 2,
+        }
+    );
+
+    let err = BpOsdDecoder::new(
+        pcm,
+        ChannelModel::BitFlipProbabilities(vec![0.1]),
+        DecoderConfig::default(),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        DecodeError::DimensionMismatch {
+            what: "channel probabilities",
+            expected: 2,
+            actual: 1,
+        }
+    );
+}
+
+#[test]
+fn decoder_rejects_invalid_probability_inputs() {
+    let pcm = ParityCheckMatrix::from_sparse_rows(1, 2, vec![vec![0, 1]]).unwrap();
+
+    let err = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::Bsc { error_rate: 0.0 },
+        DecoderConfig::default(),
+    )
+    .unwrap_err();
+    assert_eq!(err, DecodeError::InvalidProbability);
+
+    let err = BpOsdDecoder::new(
+        pcm,
+        ChannelModel::BitFlipProbabilities(vec![0.1, 1.0]),
+        DecoderConfig::default(),
+    )
+    .unwrap_err();
+    assert_eq!(err, DecodeError::InvalidProbability);
 }

--- a/rbposd/tests/bp.rs
+++ b/rbposd/tests/bp.rs
@@ -1,0 +1,30 @@
+use rbposd::{BpOsdDecoder, ChannelModel, Correction, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+fn repetition_pcm() -> ParityCheckMatrix {
+    ParityCheckMatrix::from_sparse_rows(4, 5, vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]])
+        .unwrap()
+}
+
+#[test]
+fn minimum_sum_decodes_a_single_flip_without_osd() {
+    let pcm = repetition_pcm();
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )
+    .unwrap();
+
+    let syndrome = Syndrome::from(vec![true, false, false, false]);
+    let result = decoder.decode(&syndrome).unwrap();
+
+    assert!(result.converged);
+    assert!(!result.used_osd);
+    assert_eq!(result.bp_iterations > 0, true);
+    assert_eq!(result.residual_syndrome_weight, 0);
+    assert_eq!(pcm.multiply(&result.correction), syndrome);
+    assert_eq!(
+        result.correction,
+        Correction::from(vec![true, false, false, false, false])
+    );
+}

--- a/rbposd/tests/bp.rs
+++ b/rbposd/tests/bp.rs
@@ -28,3 +28,24 @@ fn minimum_sum_decodes_a_single_flip_without_osd() {
         Correction::from(vec![true, false, false, false, false])
     );
 }
+
+#[test]
+fn minimum_sum_keeps_a_converged_solution_when_early_stop_is_disabled() {
+    let pcm =
+        ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![0, 1, 2]]).unwrap();
+    let config = DecoderConfig {
+        early_stop: false,
+        ..DecoderConfig::default()
+    };
+    let decoder = BpOsdDecoder::new(pcm.clone(), ChannelModel::Bsc { error_rate: 0.05 }, config)
+        .unwrap();
+
+    let syndrome = Syndrome::from(vec![false, true]);
+    let result = decoder.decode(&syndrome).unwrap();
+
+    assert!(result.converged);
+    assert!(!result.used_osd);
+    assert_eq!(result.residual_syndrome_weight, 0);
+    assert_eq!(pcm.multiply(&result.correction), syndrome);
+    assert_eq!(result.correction, Correction::from(vec![false, false, true]));
+}

--- a/rbposd/tests/css.rs
+++ b/rbposd/tests/css.rs
@@ -1,0 +1,22 @@
+use rbposd::{ChannelModel, CssDecoders, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+#[test]
+fn css_decoders_route_x_and_z_syndromes_to_different_matrices() {
+    let hx = ParityCheckMatrix::from_sparse_rows(1, 2, vec![vec![0, 1]]).unwrap();
+    let hz = ParityCheckMatrix::from_sparse_rows(1, 2, vec![vec![1]]).unwrap();
+
+    let css = CssDecoders::new(
+        hx.clone(),
+        hz.clone(),
+        ChannelModel::Bsc { error_rate: 0.05 },
+        ChannelModel::Bsc { error_rate: 0.05 },
+        DecoderConfig::default(),
+    )
+    .unwrap();
+
+    let x = css.decode_x(&Syndrome::from(vec![true])).unwrap();
+    let z = css.decode_z(&Syndrome::from(vec![true])).unwrap();
+
+    assert_eq!(hx.multiply(&x.correction), Syndrome::from(vec![true]));
+    assert_eq!(hz.multiply(&z.correction), Syndrome::from(vec![true]));
+}

--- a/rbposd/tests/matrix.rs
+++ b/rbposd/tests/matrix.rs
@@ -1,4 +1,4 @@
-use rbposd::{Correction, ParityCheckMatrix, Syndrome};
+use rbposd::{Correction, DecodeError, ParityCheckMatrix, Syndrome};
 
 #[test]
 fn sparse_rows_reject_an_out_of_bounds_column() {
@@ -30,4 +30,46 @@ fn sparse_columns_reject_an_out_of_bounds_row() {
 
     assert!(err.to_string().contains("row index 2"));
     assert!(err.to_string().contains("out of bounds"));
+}
+
+#[test]
+fn sparse_constructors_reject_empty_and_dimension_mismatches() {
+    let err = ParityCheckMatrix::from_sparse_rows(0, 3, vec![]).unwrap_err();
+    assert_eq!(err, DecodeError::EmptyMatrix);
+    assert_eq!(err.to_string(), "parity-check matrix is empty");
+
+    let err = ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1]]).unwrap_err();
+    assert_eq!(
+        err,
+        DecodeError::DimensionMismatch {
+            what: "row count",
+            expected: 2,
+            actual: 1,
+        }
+    );
+
+    let err = ParityCheckMatrix::from_sparse_columns(2, 0, vec![]).unwrap_err();
+    assert_eq!(err, DecodeError::EmptyMatrix);
+
+    let err = ParityCheckMatrix::from_sparse_columns(2, 3, vec![vec![0], vec![1]]).unwrap_err();
+    assert_eq!(
+        err,
+        DecodeError::DimensionMismatch {
+            what: "column count",
+            expected: 3,
+            actual: 2,
+        }
+    );
+}
+
+#[test]
+fn sparse_matrix_neighbor_accessors_return_expected_indices() {
+    let pcm =
+        ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap();
+
+    assert_eq!(pcm.row_neighbors(0), &[0, 1]);
+    assert_eq!(pcm.row_neighbors(1), &[1, 2]);
+    assert_eq!(pcm.column_neighbors(0), &[0]);
+    assert_eq!(pcm.column_neighbors(1), &[0, 1]);
+    assert_eq!(pcm.column_neighbors(2), &[1]);
 }

--- a/rbposd/tests/matrix.rs
+++ b/rbposd/tests/matrix.rs
@@ -1,0 +1,24 @@
+use rbposd::{Correction, ParityCheckMatrix, Syndrome};
+
+#[test]
+fn sparse_rows_reject_an_out_of_bounds_column() {
+    let err = ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![3]])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("out of bounds"));
+}
+
+#[test]
+fn sparse_columns_and_sparse_rows_encode_the_same_code() {
+    let from_rows =
+        ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap();
+    let from_cols =
+        ParityCheckMatrix::from_sparse_columns(2, 3, vec![vec![0], vec![0, 1], vec![1]])
+            .unwrap();
+
+    let correction = Correction::from(vec![true, false, true]);
+    let expected = Syndrome::from(vec![true, true]);
+
+    assert_eq!(from_rows.multiply(&correction), expected);
+    assert_eq!(from_cols.multiply(&correction), expected);
+}

--- a/rbposd/tests/matrix.rs
+++ b/rbposd/tests/matrix.rs
@@ -22,3 +22,12 @@ fn sparse_columns_and_sparse_rows_encode_the_same_code() {
     assert_eq!(from_rows.multiply(&correction), expected);
     assert_eq!(from_cols.multiply(&correction), expected);
 }
+
+#[test]
+fn sparse_columns_reject_an_out_of_bounds_row() {
+    let err = ParityCheckMatrix::from_sparse_columns(2, 3, vec![vec![0], vec![2], vec![]])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("row index 2"));
+    assert!(err.to_string().contains("out of bounds"));
+}

--- a/rbposd/tests/osd.rs
+++ b/rbposd/tests/osd.rs
@@ -1,0 +1,22 @@
+use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+#[test]
+fn osd0_recovers_a_valid_solution_when_bp_is_disabled() {
+    let pcm = ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap();
+    let mut config = DecoderConfig::default();
+    config.max_bp_iterations = 0;
+
+    let decoder = BpOsdDecoder::new(
+        pcm.clone(),
+        ChannelModel::BitFlipProbabilities(vec![0.1, 0.2, 0.3]),
+        config,
+    )
+    .unwrap();
+
+    let syndrome = Syndrome::from(vec![true, false]);
+    let result = decoder.decode(&syndrome).unwrap();
+
+    assert!(result.used_osd);
+    assert_eq!(result.residual_syndrome_weight, 0);
+    assert_eq!(pcm.multiply(&result.correction), syndrome);
+}

--- a/rbposd/tests/reference.rs
+++ b/rbposd/tests/reference.rs
@@ -1,0 +1,78 @@
+use std::fs;
+use std::path::PathBuf;
+
+use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};
+
+struct ReferenceCase {
+    name: &'static str,
+    pcm: ParityCheckMatrix,
+    channel: ChannelModel,
+    syndrome: Syndrome,
+    expect_osd: bool,
+    max_bp_iterations: Option<usize>,
+}
+
+fn repetition_pcm() -> ParityCheckMatrix {
+    ParityCheckMatrix::from_sparse_rows(4, 5, vec![vec![0, 1], vec![1, 2], vec![2, 3], vec![3, 4]])
+        .unwrap()
+}
+
+fn reference_cases() -> Vec<ReferenceCase> {
+    vec![
+        ReferenceCase {
+            name: "bp repetition single flip",
+            pcm: repetition_pcm(),
+            channel: ChannelModel::Bsc { error_rate: 0.05 },
+            syndrome: Syndrome::from(vec![true, false, false, false]),
+            expect_osd: false,
+            max_bp_iterations: None,
+        },
+        ReferenceCase {
+            name: "osd fallback small sparse code",
+            pcm: ParityCheckMatrix::from_sparse_rows(2, 3, vec![vec![0, 1], vec![1, 2]]).unwrap(),
+            channel: ChannelModel::BitFlipProbabilities(vec![0.1, 0.2, 0.3]),
+            syndrome: Syndrome::from(vec![true, false]),
+            expect_osd: true,
+            max_bp_iterations: Some(0),
+        },
+    ]
+}
+
+#[test]
+fn reference_contract_loop_matches_plan_cases() {
+    for case in reference_cases() {
+        let mut config = DecoderConfig::default();
+        if let Some(max_bp_iterations) = case.max_bp_iterations {
+            config.max_bp_iterations = max_bp_iterations;
+        }
+
+        let decoder = BpOsdDecoder::new(case.pcm.clone(), case.channel.clone(), config).unwrap();
+        let result = decoder.decode(&case.syndrome).unwrap();
+
+        assert_eq!(result.used_osd, case.expect_osd, "case={}", case.name);
+        assert_eq!(
+            case.pcm.multiply(&result.correction),
+            case.syndrome,
+            "case={}",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn task_6_documentation_surfaces_exist() {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let basic_example = crate_root.join("examples/basic_decode.rs");
+    let profile_example = crate_root.join("examples/profile_repetition.rs");
+    let lib_rs = crate_root.join("src/lib.rs");
+
+    assert!(basic_example.exists(), "missing {}", basic_example.display());
+    assert!(profile_example.exists(), "missing {}", profile_example.display());
+
+    let lib_contents = fs::read_to_string(&lib_rs).unwrap();
+    assert!(
+        lib_contents.contains("use rbposd::{BpOsdDecoder, ChannelModel, DecoderConfig, ParityCheckMatrix, Syndrome};"),
+        "missing crate-level usage example in {}",
+        lib_rs.display()
+    );
+}

--- a/rbposd/tests/smoke.rs
+++ b/rbposd/tests/smoke.rs
@@ -28,7 +28,7 @@ fn decode_error_contract() {
     };
     assert_eq!(
         e.to_string(),
-        "invalid column index 7 for code with 5 bits"
+        "column index 7 is out of bounds for 5 bits"
     );
 
     fn takes_std_error(_: &dyn std::error::Error) {}

--- a/rbposd/tests/smoke.rs
+++ b/rbposd/tests/smoke.rs
@@ -1,4 +1,4 @@
-use rbposd::{BpVariant, ChannelModel, DecodeError, DecoderConfig, OsdVariant, Schedule};
+use rbposd::{BpVariant, ChannelModel, Correction, DecodeError, DecoderConfig, OsdVariant, Schedule};
 
 #[test]
 fn decoder_config_default_contract() {
@@ -33,4 +33,41 @@ fn decode_error_contract() {
 
     fn takes_std_error(_: &dyn std::error::Error) {}
     takes_std_error(&e);
+}
+
+#[test]
+fn correction_helpers_and_error_display_cover_remaining_contracts() {
+    let zero = Correction::zero(3);
+    assert_eq!(zero.len(), 3);
+    assert_eq!(zero.as_slice(), &[false, false, false]);
+
+    assert_eq!(
+        DecodeError::EmptyMatrix.to_string(),
+        "parity-check matrix is empty"
+    );
+    assert_eq!(
+        DecodeError::InvalidProbability.to_string(),
+        "invalid probability value"
+    );
+    assert_eq!(
+        DecodeError::DimensionMismatch {
+            what: "syndrome",
+            expected: 2,
+            actual: 3,
+        }
+        .to_string(),
+        "dimension mismatch for syndrome: expected 2, got 3"
+    );
+    assert_eq!(
+        DecodeError::SingularSystem.to_string(),
+        "singular system cannot satisfy the target syndrome"
+    );
+    assert_eq!(
+        DecodeError::BpDidNotConverge.to_string(),
+        "belief propagation did not converge"
+    );
+    assert_eq!(
+        DecodeError::NoOsdSolution.to_string(),
+        "no OSD solution found"
+    );
 }

--- a/rbposd/tests/smoke.rs
+++ b/rbposd/tests/smoke.rs
@@ -1,0 +1,21 @@
+use rbposd::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+
+#[test]
+fn decoder_config_default_contract() {
+    let cfg = DecoderConfig::default();
+
+    assert_eq!(cfg.max_bp_iterations, 30);
+    assert!(cfg.early_stop);
+    assert_eq!(cfg.bp_variant, BpVariant::MinimumSum);
+    assert_eq!(cfg.schedule, Schedule::Parallel);
+    assert_eq!(cfg.osd_variant, OsdVariant::Osd0);
+}
+
+#[test]
+fn channel_model_contract() {
+    let bsc = ChannelModel::Bsc { error_rate: 0.05 };
+    assert_eq!(bsc, ChannelModel::Bsc { error_rate: 0.05 });
+
+    let bit_flips = ChannelModel::BitFlipProbabilities(vec![0.1, 0.2, 0.3]);
+    assert_eq!(bit_flips, ChannelModel::BitFlipProbabilities(vec![0.1, 0.2, 0.3]));
+}

--- a/rbposd/tests/smoke.rs
+++ b/rbposd/tests/smoke.rs
@@ -1,4 +1,4 @@
-use rbposd::{BpVariant, ChannelModel, DecoderConfig, OsdVariant, Schedule};
+use rbposd::{BpVariant, ChannelModel, DecodeError, DecoderConfig, OsdVariant, Schedule};
 
 #[test]
 fn decoder_config_default_contract() {
@@ -18,4 +18,19 @@ fn channel_model_contract() {
 
     let bit_flips = ChannelModel::BitFlipProbabilities(vec![0.1, 0.2, 0.3]);
     assert_eq!(bit_flips, ChannelModel::BitFlipProbabilities(vec![0.1, 0.2, 0.3]));
+}
+
+#[test]
+fn decode_error_contract() {
+    let e = DecodeError::InvalidColumnIndex {
+        column: 7,
+        num_bits: 5,
+    };
+    assert_eq!(
+        e.to_string(),
+        "invalid column index 7 for code with 5 bits"
+    );
+
+    fn takes_std_error(_: &dyn std::error::Error) {}
+    takes_std_error(&e);
 }

--- a/rsinter/Cargo.toml
+++ b/rsinter/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 rstim = { path = "../rstim" }
+rbposd = { path = "../rbposd" }
 rand = "0.8"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }

--- a/rsinter/src/collect.rs
+++ b/rsinter/src/collect.rs
@@ -61,7 +61,7 @@ pub fn collect(
                     .expect("decoder not found")
                     .compile_for_dem(&task.dem);
 
-                let num_dets = task.dem.num_detectors();
+                let num_dets = task.dem.effective_num_detectors();
                 let num_obs = task.dem.num_observables();
                 let obs_bytes_per_shot = (num_obs + 7) / 8;
 

--- a/rsinter/src/decode.rs
+++ b/rsinter/src/decode.rs
@@ -1,5 +1,7 @@
 use rstim::dem::DetectorErrorModel;
 
+pub use crate::rbposd_adapter::RbposdDemDecoder;
+
 pub trait CompiledDecoder: Send {
     /// Decode bit-packed detection events into bit-packed observable predictions.
     /// `dets`: `num_shots * ceil(num_dets/8)` bytes, b8 format.

--- a/rsinter/src/lib.rs
+++ b/rsinter/src/lib.rs
@@ -1,7 +1,9 @@
-pub mod stats;
+mod rbposd_adapter;
+
+pub mod collect;
+pub mod csv_io;
 pub mod decode;
+pub mod plot;
+pub mod stats;
 pub mod task;
 pub mod task_stats;
-pub mod csv_io;
-pub mod collect;
-pub mod plot;

--- a/rsinter/src/rbposd_adapter.rs
+++ b/rsinter/src/rbposd_adapter.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use rbposd::{BpOsdDecoder, ChannelModel, Correction, DecoderConfig, ParityCheckMatrix, Syndrome};
 use rstim::dem::{DemInstruction, DemTarget, DetectorErrorModel};
 
@@ -173,22 +175,43 @@ fn push_error_columns(
     observable_columns: &mut Vec<Vec<usize>>,
     probabilities: &mut Vec<f64>,
 ) {
-    let mut current_dets = Vec::new();
-    let mut current_obs = Vec::new();
+    let mut current_dets = BTreeSet::new();
+    let mut current_obs = BTreeSet::new();
     for target in targets {
         match target {
-            DemTarget::Detector(det) => current_dets.push(detector_offset + det),
-            DemTarget::Observable(obs) => current_obs.push(*obs),
-            DemTarget::Separator => {
-                detector_columns.push(current_dets);
-                observable_columns.push(current_obs);
-                probabilities.push(probability);
-                current_dets = Vec::new();
-                current_obs = Vec::new();
-            }
+            DemTarget::Detector(det) => toggle_target(&mut current_dets, detector_offset + det),
+            DemTarget::Observable(obs) => toggle_target(&mut current_obs, *obs),
+            DemTarget::Separator => {}
         }
     }
-    detector_columns.push(current_dets);
-    observable_columns.push(current_obs);
+    detector_columns.push(current_dets.into_iter().collect());
+    observable_columns.push(current_obs.into_iter().collect());
     probabilities.push(probability);
+}
+
+fn toggle_target(set: &mut BTreeSet<usize>, value: usize) {
+    if !set.insert(value) {
+        set.remove(&value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dem_to_matrix_problem;
+    use rstim::dem::DetectorErrorModel;
+
+    #[test]
+    fn separator_targets_stay_in_one_dem_column() {
+        let dem = DetectorErrorModel::parse("error(0.25) D0 ^ D1 L0\n").unwrap();
+
+        let (pcm, probabilities, observable_columns, num_dets, num_obs) =
+            dem_to_matrix_problem(&dem);
+
+        assert_eq!(num_dets, 2);
+        assert_eq!(num_obs, 1);
+        assert_eq!(pcm.num_bits(), 1);
+        assert_eq!(pcm.column_neighbors(0), &[0, 1]);
+        assert_eq!(probabilities, vec![0.25]);
+        assert_eq!(observable_columns, vec![vec![0]]);
+    }
 }

--- a/rsinter/src/rbposd_adapter.rs
+++ b/rsinter/src/rbposd_adapter.rs
@@ -283,4 +283,21 @@ mod tests {
         assert_eq!(probabilities, vec![0.25]);
         assert_eq!(observable_columns, vec![vec![0]]);
     }
+
+    #[test]
+    fn repeat_shift_and_annotation_instructions_lower_with_offsets() {
+        let dem = DetectorErrorModel::parse(
+            "repeat 2 {\n    error(0.25) D0 D0 D1 D2 L0 L0\n    shift_detectors 3\n    detector(5, 0) D0\n    logical_observable L0\n}\n",
+        )
+        .unwrap();
+
+        let (detector_columns, probabilities, observable_columns, num_dets, num_obs) =
+            dem_to_matrix_problem(&dem);
+
+        assert_eq!(num_dets, 7);
+        assert_eq!(num_obs, 1);
+        assert_eq!(detector_columns, vec![vec![1, 2], vec![4, 5]]);
+        assert_eq!(probabilities, vec![0.25, 0.25]);
+        assert_eq!(observable_columns, vec![Vec::<usize>::new(), Vec::<usize>::new()]);
+    }
 }

--- a/rsinter/src/rbposd_adapter.rs
+++ b/rsinter/src/rbposd_adapter.rs
@@ -1,0 +1,194 @@
+use rbposd::{BpOsdDecoder, ChannelModel, Correction, DecoderConfig, ParityCheckMatrix, Syndrome};
+use rstim::dem::{DemInstruction, DemTarget, DetectorErrorModel};
+
+use crate::decode::{CompiledDecoder, Decoder};
+
+pub struct RbposdDemDecoder {
+    config: DecoderConfig,
+}
+
+impl RbposdDemDecoder {
+    pub fn new(config: DecoderConfig) -> Self {
+        Self { config }
+    }
+}
+
+struct CompiledRbposdDemDecoder {
+    decoder: BpOsdDecoder,
+    num_dets: usize,
+    num_obs: usize,
+    observable_columns: Vec<Vec<usize>>,
+}
+
+impl Decoder for RbposdDemDecoder {
+    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
+        let (pcm, probabilities, observable_columns, num_dets, num_obs) =
+            dem_to_matrix_problem(dem);
+        let decoder = BpOsdDecoder::new(
+            pcm,
+            ChannelModel::BitFlipProbabilities(probabilities),
+            self.config.clone(),
+        )
+        .expect("DEM lowering produced an invalid rbposd problem");
+
+        Box::new(CompiledRbposdDemDecoder {
+            decoder,
+            num_dets,
+            num_obs,
+            observable_columns,
+        })
+    }
+}
+
+impl CompiledDecoder for CompiledRbposdDemDecoder {
+    fn decode_shots_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Vec<u8> {
+        let det_bytes = num_dets.div_ceil(8);
+        let obs_bytes = num_obs.div_ceil(8);
+        let mut out = vec![0u8; num_shots * obs_bytes];
+
+        for shot in 0..num_shots {
+            let det_offset = shot * det_bytes;
+            let mut syndrome_bits = vec![false; self.num_dets];
+            for det in 0..num_dets.min(self.num_dets) {
+                let byte = dets[det_offset + (det / 8)];
+                syndrome_bits[det] = ((byte >> (det % 8)) & 1) != 0;
+            }
+
+            let result = self
+                .decoder
+                .decode(&Syndrome::from(syndrome_bits))
+                .expect("rbposd decode failed");
+            let observable_bits = correction_to_observables(
+                &result.correction,
+                &self.observable_columns,
+                self.num_obs,
+            );
+
+            for obs in 0..num_obs.min(self.num_obs) {
+                if observable_bits[obs] {
+                    out[shot * obs_bytes + (obs / 8)] |= 1 << (obs % 8);
+                }
+            }
+        }
+
+        out
+    }
+}
+
+fn correction_to_observables(
+    correction: &Correction,
+    observable_columns: &[Vec<usize>],
+    num_obs: usize,
+) -> Vec<bool> {
+    let mut observable_bits = vec![false; num_obs];
+    for (column, &enabled) in correction.as_slice().iter().enumerate() {
+        if !enabled {
+            continue;
+        }
+        for &obs in &observable_columns[column] {
+            observable_bits[obs] ^= true;
+        }
+    }
+    observable_bits
+}
+
+fn dem_to_matrix_problem(
+    dem: &DetectorErrorModel,
+) -> (ParityCheckMatrix, Vec<f64>, Vec<Vec<usize>>, usize, usize) {
+    let num_dets = dem.effective_num_detectors();
+    let num_obs = dem.num_observables();
+    let mut detector_columns = Vec::new();
+    let mut observable_columns = Vec::new();
+    let mut probabilities = Vec::new();
+
+    visit_dem(
+        dem.instructions(),
+        0,
+        &mut detector_columns,
+        &mut observable_columns,
+        &mut probabilities,
+    );
+
+    let pcm =
+        ParityCheckMatrix::from_sparse_columns(num_dets, detector_columns.len(), detector_columns)
+            .expect("generated DEM matrix should be valid");
+
+    (pcm, probabilities, observable_columns, num_dets, num_obs)
+}
+
+fn visit_dem(
+    instrs: &[DemInstruction],
+    detector_offset: usize,
+    detector_columns: &mut Vec<Vec<usize>>,
+    observable_columns: &mut Vec<Vec<usize>>,
+    probabilities: &mut Vec<f64>,
+) -> usize {
+    let mut offset = detector_offset;
+    for instr in instrs {
+        match instr {
+            DemInstruction::Error {
+                probability,
+                targets,
+            } => push_error_columns(
+                *probability,
+                targets,
+                offset,
+                detector_columns,
+                observable_columns,
+                probabilities,
+            ),
+            DemInstruction::ShiftDetectors {
+                detector_offset, ..
+            } => {
+                offset += detector_offset;
+            }
+            DemInstruction::Repeat { count, body } => {
+                for _ in 0..*count {
+                    offset = visit_dem(
+                        body.instructions(),
+                        offset,
+                        detector_columns,
+                        observable_columns,
+                        probabilities,
+                    );
+                }
+            }
+            DemInstruction::Detector { .. } | DemInstruction::LogicalObservable { .. } => {}
+        }
+    }
+    offset
+}
+
+fn push_error_columns(
+    probability: f64,
+    targets: &[DemTarget],
+    detector_offset: usize,
+    detector_columns: &mut Vec<Vec<usize>>,
+    observable_columns: &mut Vec<Vec<usize>>,
+    probabilities: &mut Vec<f64>,
+) {
+    let mut current_dets = Vec::new();
+    let mut current_obs = Vec::new();
+    for target in targets {
+        match target {
+            DemTarget::Detector(det) => current_dets.push(detector_offset + det),
+            DemTarget::Observable(obs) => current_obs.push(*obs),
+            DemTarget::Separator => {
+                detector_columns.push(current_dets);
+                observable_columns.push(current_obs);
+                probabilities.push(probability);
+                current_dets = Vec::new();
+                current_obs = Vec::new();
+            }
+        }
+    }
+    detector_columns.push(current_dets);
+    observable_columns.push(current_obs);
+    probabilities.push(probability);
+}

--- a/rsinter/src/rbposd_adapter.rs
+++ b/rsinter/src/rbposd_adapter.rs
@@ -16,28 +16,79 @@ impl RbposdDemDecoder {
 }
 
 struct CompiledRbposdDemDecoder {
-    decoder: BpOsdDecoder,
+    decoder: Option<BpOsdDecoder>,
     num_dets: usize,
     num_obs: usize,
     observable_columns: Vec<Vec<usize>>,
+    forced_syndrome: Vec<bool>,
+    baseline_observables: Vec<bool>,
 }
 
 impl Decoder for RbposdDemDecoder {
     fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
-        let (pcm, probabilities, observable_columns, num_dets, num_obs) =
+        let (detector_columns, probabilities, observable_columns, num_dets, num_obs) =
             dem_to_matrix_problem(dem);
-        let decoder = BpOsdDecoder::new(
-            pcm,
-            ChannelModel::BitFlipProbabilities(probabilities),
-            self.config.clone(),
-        )
-        .expect("DEM lowering produced an invalid rbposd problem");
+
+        let mut filtered_detector_columns = Vec::new();
+        let mut filtered_observable_columns = Vec::new();
+        let mut filtered_probabilities = Vec::new();
+        let mut forced_syndrome = vec![false; num_dets];
+        let mut baseline_observables = vec![false; num_obs];
+
+        for ((detectors, observables), probability) in detector_columns
+            .into_iter()
+            .zip(observable_columns.into_iter())
+            .zip(probabilities.into_iter())
+        {
+            if probability <= 0.0 {
+                continue;
+            }
+
+            if probability >= 1.0 {
+                xor_indices(&mut forced_syndrome, &detectors);
+                xor_indices(&mut baseline_observables, &observables);
+                continue;
+            }
+
+            if detectors.is_empty() {
+                if probability > 0.5 {
+                    xor_indices(&mut baseline_observables, &observables);
+                }
+                continue;
+            }
+
+            filtered_detector_columns.push(detectors);
+            filtered_observable_columns.push(observables);
+            filtered_probabilities.push(probability);
+        }
+
+        let decoder = if filtered_detector_columns.is_empty() {
+            None
+        } else {
+            let pcm = ParityCheckMatrix::from_sparse_columns(
+                num_dets,
+                filtered_detector_columns.len(),
+                filtered_detector_columns,
+            )
+            .expect("generated DEM matrix should be valid");
+
+            Some(
+                BpOsdDecoder::new(
+                    pcm,
+                    ChannelModel::BitFlipProbabilities(filtered_probabilities),
+                    self.config.clone(),
+                )
+                .expect("DEM lowering produced an invalid rbposd problem"),
+            )
+        };
 
         Box::new(CompiledRbposdDemDecoder {
             decoder,
             num_dets,
             num_obs,
-            observable_columns,
+            observable_columns: filtered_observable_columns,
+            forced_syndrome,
+            baseline_observables,
         })
     }
 }
@@ -62,15 +113,20 @@ impl CompiledDecoder for CompiledRbposdDemDecoder {
                 syndrome_bits[det] = ((byte >> (det % 8)) & 1) != 0;
             }
 
-            let result = self
-                .decoder
-                .decode(&Syndrome::from(syndrome_bits))
-                .expect("rbposd decode failed");
-            let observable_bits = correction_to_observables(
-                &result.correction,
-                &self.observable_columns,
-                self.num_obs,
-            );
+            xor_bits(&mut syndrome_bits, &self.forced_syndrome);
+
+            let mut observable_bits = self.baseline_observables.clone();
+            if let Some(decoder) = &self.decoder {
+                let result = decoder
+                    .decode(&Syndrome::from(syndrome_bits))
+                    .expect("rbposd decode failed");
+                let decoded_observables = correction_to_observables(
+                    &result.correction,
+                    &self.observable_columns,
+                    self.num_obs,
+                );
+                xor_bits(&mut observable_bits, &decoded_observables);
+            }
 
             for obs in 0..num_obs.min(self.num_obs) {
                 if observable_bits[obs] {
@@ -102,7 +158,7 @@ fn correction_to_observables(
 
 fn dem_to_matrix_problem(
     dem: &DetectorErrorModel,
-) -> (ParityCheckMatrix, Vec<f64>, Vec<Vec<usize>>, usize, usize) {
+) -> (Vec<Vec<usize>>, Vec<f64>, Vec<Vec<usize>>, usize, usize) {
     let num_dets = dem.effective_num_detectors();
     let num_obs = dem.num_observables();
     let mut detector_columns = Vec::new();
@@ -117,11 +173,13 @@ fn dem_to_matrix_problem(
         &mut probabilities,
     );
 
-    let pcm =
-        ParityCheckMatrix::from_sparse_columns(num_dets, detector_columns.len(), detector_columns)
-            .expect("generated DEM matrix should be valid");
-
-    (pcm, probabilities, observable_columns, num_dets, num_obs)
+    (
+        detector_columns,
+        probabilities,
+        observable_columns,
+        num_dets,
+        num_obs,
+    )
 }
 
 fn visit_dem(
@@ -195,6 +253,18 @@ fn toggle_target(set: &mut BTreeSet<usize>, value: usize) {
     }
 }
 
+fn xor_indices(bits: &mut [bool], indices: &[usize]) {
+    for &index in indices {
+        bits[index] ^= true;
+    }
+}
+
+fn xor_bits(bits: &mut [bool], other: &[bool]) {
+    for (lhs, rhs) in bits.iter_mut().zip(other.iter()) {
+        *lhs ^= *rhs;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::dem_to_matrix_problem;
@@ -204,13 +274,12 @@ mod tests {
     fn separator_targets_stay_in_one_dem_column() {
         let dem = DetectorErrorModel::parse("error(0.25) D0 ^ D1 L0\n").unwrap();
 
-        let (pcm, probabilities, observable_columns, num_dets, num_obs) =
+        let (detector_columns, probabilities, observable_columns, num_dets, num_obs) =
             dem_to_matrix_problem(&dem);
 
         assert_eq!(num_dets, 2);
         assert_eq!(num_obs, 1);
-        assert_eq!(pcm.num_bits(), 1);
-        assert_eq!(pcm.column_neighbors(0), &[0, 1]);
+        assert_eq!(detector_columns, vec![vec![0, 1]]);
         assert_eq!(probabilities, vec![0.25]);
         assert_eq!(observable_columns, vec![vec![0]]);
     }

--- a/rsinter/tests/decode_rbposd.rs
+++ b/rsinter/tests/decode_rbposd.rs
@@ -61,3 +61,25 @@ fn collect_runs_with_the_rbposd_adapter() {
     assert_eq!(results.len(), 1);
     assert!(results[0].shots > 0);
 }
+
+#[test]
+fn rbposd_dem_decoder_handles_observable_only_terms() {
+    let dem = DetectorErrorModel::parse("error(0.75) L0\n").unwrap();
+    let decoder = RbposdDemDecoder::new(DecoderConfig::default());
+    let compiled = decoder.compile_for_dem(&dem);
+
+    let predictions = compiled.decode_shots_bit_packed(&[], 1, 0, 1);
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[test]
+fn rbposd_dem_decoder_handles_exact_probability_terms() {
+    let dem = DetectorErrorModel::parse("error(1) D0 L0\nerror(0) D1\n").unwrap();
+    let decoder = RbposdDemDecoder::new(DecoderConfig::default());
+    let compiled = decoder.compile_for_dem(&dem);
+
+    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}

--- a/rsinter/tests/decode_rbposd.rs
+++ b/rsinter/tests/decode_rbposd.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use rbposd::DecoderConfig;
+use rsinter::collect::{collect, CollectOptions};
+use rsinter::decode::{Decoder, RbposdDemDecoder};
+use rsinter::task::{CollectionOptions, Task};
+use rstim::dem::DetectorErrorModel;
+use rstim::error_analyzer::ErrorAnalyzer;
+use rstim::parser::parse_lines;
+
+#[test]
+fn rbposd_dem_decoder_predicts_a_single_observable_flip() {
+    let dem = DetectorErrorModel::parse("error(0.125) D0 L0\nerror(0.25) D1\n").unwrap();
+    let decoder = RbposdDemDecoder::new(DecoderConfig::default());
+    let compiled = decoder.compile_for_dem(&dem);
+
+    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[test]
+fn collect_runs_with_the_rbposd_adapter() {
+    let circuit =
+        parse_lines("R 0\nX_ERROR(0.05) 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n")
+            .unwrap();
+    let dem = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
+
+    let task = Task {
+        circuit,
+        decoder: "rbposd".into(),
+        dem,
+        metadata: serde_json::json!({"case": "single-qubit"}),
+        collection_options: CollectionOptions {
+            max_shots: Some(32),
+            max_errors: Some(32),
+        },
+    };
+
+    let mut decoders: HashMap<String, Box<dyn Decoder>> = HashMap::new();
+    decoders.insert(
+        "rbposd".into(),
+        Box::new(RbposdDemDecoder::new(DecoderConfig::default())),
+    );
+
+    let results = collect(
+        vec![task],
+        decoders,
+        &CollectOptions {
+            num_workers: 1,
+            max_shots: None,
+            max_errors: None,
+            max_batch_size: Some(32),
+            start_batch_size: 8,
+            save_resume_filepath: None,
+            print_progress: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].shots > 0);
+}

--- a/rsinter/tests/decode_rbposd.rs
+++ b/rsinter/tests/decode_rbposd.rs
@@ -83,3 +83,14 @@ fn rbposd_dem_decoder_handles_exact_probability_terms() {
 
     assert_eq!(predictions, vec![0b0000_0001]);
 }
+
+#[test]
+fn rbposd_dem_decoder_handles_zero_syndrome_map_cases() {
+    let dem = DetectorErrorModel::parse("error(0.9) D0 L0\nerror(0.2) D0\n").unwrap();
+    let decoder = RbposdDemDecoder::new(DecoderConfig::default());
+    let compiled = decoder.compile_for_dem(&dem);
+
+    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0000], 1, 1, 1);
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}

--- a/rstim/doc/getting_started.md
+++ b/rstim/doc/getting_started.md
@@ -239,6 +239,24 @@ Shots with detection events: 837/1000
 Actual observable flips: 103/1000
 ```
 
+## Decode with rbposd through rsinter
+
+When `rbposd` is available in the same workspace, `rsinter` can compile a DEM
+into an in-tree BP+OSD decoder:
+
+```rust
+use std::collections::HashMap;
+
+use rbposd::DecoderConfig;
+use rsinter::decode::RbposdDemDecoder;
+
+let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
+decoders.insert(
+    "rbposd".into(),
+    Box::new(RbposdDemDecoder::new(DecoderConfig::default())),
+);
+```
+
 ## Estimate threshold
 
 A threshold experiment sweeps over code distances and noise rates. Below


### PR DESCRIPTION
## Summary

- add the new rbposd crate with matrix/vector foundations, minimum-sum BP, OSD_0 fallback, CSS helpers, examples, and regression coverage
- integrate rbposd into rsinter with a DEM-backed RbposdDemDecoder, plus handling for shifted/repeated DEMs and valid DEM edge cases
- add design/plan docs and tighten tests around zero-syndrome MAP behavior, separator semantics, and reference/example contracts

## Test Plan

- cargo test -p rbposd -p rsinter
- cargo test -p rsinter --test decode_rbposd -v
- cargo test -p rbposd --test bp -- --nocapture