### PR TITLE
test: cover atom loss boundaries

### DIFF
--- a/rstim/docs/plans/2026-05-10-atom-loss-design.md
+++ b/rstim/docs/plans/2026-05-10-atom-loss-design.md
@@ -1,0 +1,232 @@
+# Atom Loss Sampling Design
+
+**Date:** 2026-05-10
+
+## Goal
+
+Add first-class atom loss support to rstim's circuit execution and sampling path.
+
+The new behavior must support:
+
+1. A loss noise channel that marks qubits as absent with probability `p`
+2. Gate execution that skips only the target groups touching lost qubits
+3. Two measurement modes for lost qubits:
+   - default mode: loss is read as measurement result `1`
+   - loss-visible mode: measurement output explicitly indicates loss
+4. Syndrome sampling from circuits containing loss via the existing `sample` and `detect` flows
+
+## Scope
+
+This design covers the following path only:
+
+- parser / IR
+- tableau executor
+- reference sample generation
+- frame simulator batch sampling
+- sampler and CLI integration
+- tests and user-facing documentation
+
+This design does **not** cover:
+
+- `error_analyzer`
+- `circuit_to_dem`
+- loss-aware detector error models
+- codegen insertion of loss noise
+
+## Instruction Surface
+
+### New noise instruction
+
+Add a new noise instruction:
+
+```text
+LOSS(p) targets...
+```
+
+`LOSS(p)` independently marks each target qubit as lost with probability `p`.
+
+Properties:
+
+- it does not append to the measurement record
+- it does not directly modify the tableau or frame Pauli state
+- it only updates per-qubit loss state
+
+### Default measurement semantics
+
+Existing measurement instructions keep their current names.
+
+For single-qubit measurements and measure-reset instructions:
+
+- `M`, `MX`, `MY`, `MZ`
+- `MR`, `MRX`, `MRY`, `MRZ`
+
+the new rule is:
+
+- if the target qubit is not lost, behavior is unchanged
+- if the target qubit is lost, the measurement result is recorded as `1`
+
+This intentionally makes loss indistinguishable from a physical `1` outcome in the default interface.
+
+### Loss-visible measurement semantics
+
+Add explicit loss-visible variants for the single-qubit measurement family:
+
+- `ML`, `MXL`, `MYL`, `MZL`
+- `MRL`, `MRXL`, `MRYL`, `MRZL`
+
+For each target qubit these instructions append **two** measurement bits:
+
+1. `loss_flag`
+2. `value_bit`
+
+Rules:
+
+- if the qubit is not lost: append `0` then the normal measurement value
+- if the qubit is lost: append `1` then `1`
+
+This preserves compatibility with the default "loss reads as `1`" rule while still exposing loss explicitly when requested.
+
+### Measurement instructions not extended in v1
+
+The following instructions remain available only in their existing form in v1:
+
+- `MPP`
+- `MXX`
+- `MYY`
+- `MZZ`
+
+If any qubit participating in one measured product or pair is lost, that measured group records `1`.
+
+v1 does not add `MPPL`, `MXXL`, `MYYL`, or `MZZL`.
+
+## Execution Model
+
+### Runtime state
+
+Both the tableau executor and the frame simulator gain explicit loss state:
+
+- executor: `Vec<bool> lost`
+- frame simulator: one bitset row per qubit indicating which shots are lost
+
+Loss state is separate from the Pauli / tableau state.
+
+### Single-qubit gates
+
+For single-qubit unitary gates and single-qubit noise channels that act on a target qubit:
+
+- if `lost[q]` is false, behavior is unchanged
+- if `lost[q]` is true, the operation is skipped for that qubit
+
+This applies to Clifford gates, Pauli gates, and noise channels such as `X_ERROR`, `DEPOLARIZE1`, and `PAULI_CHANNEL_1`.
+
+### Multi-qubit gates
+
+Operations are evaluated per natural target group, not per instruction as a whole.
+
+Examples:
+
+- `CX 0 1 2 3` is treated as two pairs: `(0, 1)` and `(2, 3)`
+- `SWAP 0 1 2 3` is treated as two pairs
+- `PAULI_CHANNEL_2` is treated per pair
+- `MPP` is treated per Pauli product
+
+If one group contains any lost qubit, only that group is skipped or forced into loss measurement semantics. Other groups in the same instruction continue to execute.
+
+This is the required behavior for circuits such as:
+
+```text
+CX 0 1 2 3
+```
+
+where loss on qubit `1` skips only `CX 0 1` and still applies `CX 2 3`.
+
+### Reset and recovery
+
+The first version uses reset-based recovery:
+
+- `R`, `RX`, `RY`, `RZ` clear loss state before preparing the target basis state
+- `MR`, `MRX`, `MRY`, `MRZ` first record the measurement result, then clear loss state and reset
+- `MRL`, `MRXL`, `MRYL`, `MRZL` follow the same ordering
+
+This means loss persists until the qubit is explicitly reset or measure-reset.
+
+## Sampling and Syndrome Behavior
+
+### Reference sample
+
+Reference sample generation must understand `LOSS` and the new measurement semantics.
+
+In noiseless reference sampling:
+
+- `LOSS` contributes no loss events because it is a noise instruction
+- loss-visible instructions still append the correct number of measurement bits
+- reference bits for those instructions are all zero because there is no loss in the reference path
+
+This keeps `sample` and `detect` aligned with existing reference-sample machinery.
+
+### Detector sampling
+
+No detector-specific feature is required. Detector behavior follows from the measurement record.
+
+Examples:
+
+- default measurements allow loss to influence syndrome bits implicitly through value `1`
+- loss-visible measurements allow circuits to place detector annotations directly on `loss_flag` bits via `rec[...]`
+
+This is enough to support syndrome sampling on circuits that intentionally expose loss information.
+
+## Testing Plan
+
+Tests should cover four layers.
+
+### Parser / IR
+
+- `LOSS(p)` parses and round-trips
+- new `ML` / `MRL` family parses and round-trips
+- measurement count accounting reflects the extra bits produced by loss-visible instructions
+
+### Executor
+
+- loss is sampled independently per target
+- single-qubit gates skip lost qubits
+- paired gates skip only affected pairs
+- `R/RX/RY/RZ` recover lost qubits
+- default measurements on lost qubits return `1`
+- loss-visible measurements append `(1, 1)` on lost qubits and `(0, normal)` otherwise
+
+### Frame simulator / sampler
+
+- batch sampling matches executor semantics on fixed seeds where applicable
+- loss state survives across instructions until reset
+- detector outputs can reference loss-visible measurement bits
+
+### CLI integration
+
+- `sample` works on circuits containing `LOSS`
+- `detect` works on circuits containing `LOSS`
+- output lengths are correct when `ML`-family instructions add extra measurement bits
+
+## Documentation Requirements
+
+User-facing documentation must explicitly state the current behavior.
+
+It should say all of the following clearly:
+
+- `LOSS(p)` adds loss state but no measurement record output
+- default measurements treat loss as result `1`
+- `ML` / `MRL` family measurements expose loss by emitting a loss flag before the value bit
+- multi-qubit instructions are handled per target group
+- reset instructions recover lost qubits
+- v1 supports execution and sampling only, not DEM extraction or loss-aware error analysis
+
+## Out of Scope for v1
+
+The first version intentionally excludes:
+
+- `HERALDED_LOSS`
+- loss-visible `MPP` / pair-measure variants
+- analyzer / DEM support
+- automatic insertion of loss noise in code generation
+- bespoke semantics for every exotic instruction beyond the common execution and sampling path
+
+If an uncommon instruction cannot be given a clean loss rule inside the sampling path, it is acceptable for v1 to return an explicit unsupported error instead of silently inventing behavior.

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -1443,7 +1443,7 @@ fn count_measurements(instrs: &[StimInstr]) -> usize {
                     count += 2 * targets
                         .iter()
                         .filter(|t| matches!(t, StimTarget::Qubit(_) | StimTarget::QubitInv(_)))
-                        .count();
+                        .count()
                 }
                 "MPAD" => {
                     count += targets.len();
@@ -2036,6 +2036,141 @@ mod internal_branch_tests {
                 DemTarget::Detector(2),
             ]
         );
+    }
+
+    #[test]
+    fn count_qubits_counts_repeat_bodies() {
+        let instrs = vec![StimInstr::Repeat {
+            count: 3,
+            body: vec![StimInstr::new("M", vec![], vec![StimTarget::Qubit(4)])],
+        }];
+
+        assert_eq!(count_qubits(&instrs), 5);
+    }
+
+    #[test]
+    fn count_measurements_counts_loss_visible_measurements() {
+        let instrs = vec![StimInstr::Repeat {
+            count: 2,
+            body: vec![StimInstr::new(
+                "ML",
+                vec![],
+                vec![StimTarget::Qubit(0), StimTarget::QubitInv(1)],
+            )],
+        }];
+
+        assert_eq!(count_measurements(&instrs), 8);
+    }
+
+    #[test]
+    fn count_annotations_counts_repeat_bodies() {
+        let instrs = vec![StimInstr::Repeat {
+            count: 3,
+            body: vec![
+                StimInstr::new("DETECTOR", vec![1.0, 2.0], vec![StimTarget::Rec(-1)]),
+                StimInstr::new("OBSERVABLE_INCLUDE", vec![0.0], vec![StimTarget::Rec(-1)]),
+            ],
+        }];
+
+        assert_eq!(count_annotations(&instrs, "DETECTOR"), 3);
+        assert_eq!(count_annotations(&instrs, "OBSERVABLE_INCLUDE"), 3);
+    }
+
+    #[test]
+    fn collect_detector_annotations_inner_counts_repeat_bodies() {
+        let instrs = vec![StimInstr::Repeat {
+            count: 2,
+            body: vec![
+                StimInstr::new("SHIFT_COORDS", vec![1.0, -2.0], vec![]),
+                StimInstr::new("DETECTOR", vec![0.5], vec![StimTarget::Rec(-1)]),
+            ],
+        }];
+        let mut result = Vec::new();
+        let mut det_index = 0;
+
+        collect_detector_annotations_inner(&instrs, &mut result, &mut det_index);
+
+        assert_eq!(det_index, 2);
+        assert_eq!(
+            result,
+            vec![
+                DemInstruction::ShiftDetectors {
+                    detector_offset: 0,
+                    coord_offsets: vec![1.0, -2.0],
+                },
+                DemInstruction::Detector {
+                    index: 0,
+                    coords: vec![0.5],
+                },
+                DemInstruction::ShiftDetectors {
+                    detector_offset: 0,
+                    coord_offsets: vec![1.0, -2.0],
+                },
+                DemInstruction::Detector {
+                    index: 1,
+                    coords: vec![0.5],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn undo_circuit_repeats_body() {
+        let mut analyzer = make_analyzer(0, 0);
+        let instrs = vec![StimInstr::Repeat {
+            count: 2,
+            body: vec![StimInstr::new("TICK", vec![], vec![])],
+        }];
+
+        analyzer.undo_circuit(&instrs).unwrap();
+        assert!(analyzer.errors.is_empty());
+    }
+
+    #[test]
+    fn decompose_errors_merges_duplicate_rewritten_components() {
+        let mut dem = DetectorErrorModel::new();
+        dem.push(DemInstruction::Error {
+            probability: 0.1,
+            targets: vec![DemTarget::Detector(0), DemTarget::Detector(1)],
+        });
+        dem.push(DemInstruction::Error {
+            probability: 0.2,
+            targets: vec![DemTarget::Detector(2)],
+        });
+        dem.push(DemInstruction::Error {
+            probability: 0.3,
+            targets: vec![
+                DemTarget::Detector(0),
+                DemTarget::Detector(1),
+                DemTarget::Detector(2),
+            ],
+        });
+        dem.push(DemInstruction::Error {
+            probability: 0.4,
+            targets: vec![
+                DemTarget::Detector(0),
+                DemTarget::Detector(1),
+                DemTarget::Detector(2),
+            ],
+        });
+
+        decompose_errors(&mut dem).unwrap();
+
+        let merged_targets = vec![
+            DemTarget::Detector(0),
+            DemTarget::Detector(1),
+            DemTarget::Separator,
+            DemTarget::Detector(2),
+        ];
+        let merged_probability = 0.3 + 0.4 - 2.0 * 0.3 * 0.4;
+        assert!(dem.instructions().iter().any(|instr| {
+            matches!(
+                instr,
+                DemInstruction::Error { probability, targets }
+                    if (*probability - merged_probability).abs() < 1e-12
+                        && *targets == merged_targets
+            )
+        }));
     }
 
     #[test]

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -1439,6 +1439,12 @@ fn count_measurements(instrs: &[StimInstr]) -> usize {
                         .filter(|t| matches!(t, StimTarget::Qubit(_) | StimTarget::QubitInv(_)))
                         .count();
                 }
+                "ML" | "MXL" | "MYL" | "MZL" | "MRL" | "MRXL" | "MRYL" | "MRZL" => {
+                    count += 2 * targets
+                        .iter()
+                        .filter(|t| matches!(t, StimTarget::Qubit(_) | StimTarget::QubitInv(_)))
+                        .count();
+                }
                 "MPAD" => {
                     count += targets.len();
                 }

--- a/rstim/src/executor.rs
+++ b/rstim/src/executor.rs
@@ -25,6 +25,7 @@ impl Executor {
     pub fn run(&mut self, rng: &mut impl Rng) -> Result<ExecOutput, String> {
         let n = max_qubit(&self.instrs)?;
         let mut state = StabilizerState::new(n);
+        let mut lost = vec![false; n];
         let mut recorder = Recorder::default();
         let mut detectors = Vec::new();
         let mut detector_coords = Vec::new();
@@ -37,144 +38,228 @@ impl Executor {
                 StimInstr::Op { name, args, targets, .. } => {
                     match name.as_str() {
                         "I" | "I_ERROR" | "II_ERROR" => {}
-                        "H" => for_each_qubit(targets, |q| state.h(q))?,
-                        "H_XY" => for_each_qubit(targets, |q| state.h_xy(q))?,
-                        "H_YZ" => for_each_qubit(targets, |q| state.h_yz(q))?,
-                        "S" | "SQRT_Z" => for_each_qubit(targets, |q| state.s(q))?,
-                        "S_DAG" | "SQRT_Z_DAG" => for_each_qubit(targets, |q| state.s_dag(q))?,
-                        "SQRT_X" => for_each_qubit(targets, |q| state.sqrt_x(q))?,
-                        "SQRT_X_DAG" => for_each_qubit(targets, |q| state.sqrt_x_dag(q))?,
-                        "SQRT_Y" => for_each_qubit(targets, |q| state.sqrt_y(q))?,
-                        "SQRT_Y_DAG" => for_each_qubit(targets, |q| state.sqrt_y_dag(q))?,
-                        "X" => for_each_qubit(targets, |q| state.x_gate(q))?,
-                        "Y" => for_each_qubit(targets, |q| state.y_gate(q))?,
-                        "Z" => for_each_qubit(targets, |q| state.z_gate(q))?,
-                        "C_XYZ" => for_each_qubit(targets, |q| state.c_xyz(q))?,
-                        "C_ZYX" => for_each_qubit(targets, |q| state.c_zyx(q))?,
-                        "C_NXYZ" => for_each_qubit(targets, |q| state.c_nxyz(q))?,
-                        "C_NZYX" => for_each_qubit(targets, |q| state.c_nzyx(q))?,
-                        "C_XNYZ" => for_each_qubit(targets, |q| state.c_xnyz(q))?,
-                        "C_XYNZ" => for_each_qubit(targets, |q| state.c_xynz(q))?,
-                        "C_ZNYX" => for_each_qubit(targets, |q| state.c_znyx(q))?,
-                        "C_ZYNX" => for_each_qubit(targets, |q| state.c_zynx(q))?,
-                        "H_NXY" => for_each_qubit(targets, |q| state.h_nxy(q))?,
-                        "H_NXZ" => for_each_qubit(targets, |q| state.h_nxz(q))?,
-                        "H_NYZ" => for_each_qubit(targets, |q| state.h_nyz(q))?,
+                        "H" => for_each_present_qubit(targets, &lost, |q| state.h(q))?,
+                        "H_XY" => for_each_present_qubit(targets, &lost, |q| state.h_xy(q))?,
+                        "H_YZ" => for_each_present_qubit(targets, &lost, |q| state.h_yz(q))?,
+                        "S" | "SQRT_Z" => for_each_present_qubit(targets, &lost, |q| state.s(q))?,
+                        "S_DAG" | "SQRT_Z_DAG" => {
+                            for_each_present_qubit(targets, &lost, |q| state.s_dag(q))?
+                        }
+                        "SQRT_X" => for_each_present_qubit(targets, &lost, |q| state.sqrt_x(q))?,
+                        "SQRT_X_DAG" => {
+                            for_each_present_qubit(targets, &lost, |q| state.sqrt_x_dag(q))?
+                        }
+                        "SQRT_Y" => for_each_present_qubit(targets, &lost, |q| state.sqrt_y(q))?,
+                        "SQRT_Y_DAG" => {
+                            for_each_present_qubit(targets, &lost, |q| state.sqrt_y_dag(q))?
+                        }
+                        "X" => for_each_present_qubit(targets, &lost, |q| state.x_gate(q))?,
+                        "Y" => for_each_present_qubit(targets, &lost, |q| state.y_gate(q))?,
+                        "Z" => for_each_present_qubit(targets, &lost, |q| state.z_gate(q))?,
+                        "C_XYZ" => for_each_present_qubit(targets, &lost, |q| state.c_xyz(q))?,
+                        "C_ZYX" => for_each_present_qubit(targets, &lost, |q| state.c_zyx(q))?,
+                        "C_NXYZ" => {
+                            for_each_present_qubit(targets, &lost, |q| state.c_nxyz(q))?
+                        }
+                        "C_NZYX" => {
+                            for_each_present_qubit(targets, &lost, |q| state.c_nzyx(q))?
+                        }
+                        "C_XNYZ" => {
+                            for_each_present_qubit(targets, &lost, |q| state.c_xnyz(q))?
+                        }
+                        "C_XYNZ" => {
+                            for_each_present_qubit(targets, &lost, |q| state.c_xynz(q))?
+                        }
+                        "C_ZNYX" => {
+                            for_each_present_qubit(targets, &lost, |q| state.c_znyx(q))?
+                        }
+                        "C_ZYNX" => {
+                            for_each_present_qubit(targets, &lost, |q| state.c_zynx(q))?
+                        }
+                        "H_NXY" => for_each_present_qubit(targets, &lost, |q| state.h_nxy(q))?,
+                        "H_NXZ" => for_each_present_qubit(targets, &lost, |q| state.h_nxz(q))?,
+                        "H_NYZ" => for_each_present_qubit(targets, &lost, |q| state.h_nyz(q))?,
                         "CX" | "CNOT" | "ZCX" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (c, t) in pairs { state.cx(c, t); }
                         }
                         "CY" | "ZCY" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (c, t) in pairs { state.cy(c, t); }
                         }
                         "CZ" | "ZCZ" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (c, t) in pairs { state.cz(c, t); }
                         }
                         "XCX" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.xcx(a, b); }
                         }
                         "XCY" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.xcy(a, b); }
                         }
                         "XCZ" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.xcz(a, b); }
                         }
                         "YCX" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.ycx(a, b); }
                         }
                         "YCY" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.ycy(a, b); }
                         }
                         "YCZ" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.ycz(a, b); }
                         }
                         "SWAP" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.swap(a, b); }
                         }
                         "ISWAP" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.iswap(a, b); }
                         }
                         "ISWAP_DAG" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.iswap_dag(a, b); }
                         }
                         "CXSWAP" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.cxswap(a, b); }
                         }
                         "SWAPCX" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.swapcx(a, b); }
                         }
                         "CZSWAP" => {
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs { state.czswap(a, b); }
                         }
                         "M" | "MZ" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                let (bit, _) = state.measure_z(q, rng);
-                                let b = (bit == 1) ^ inv;
-                                recorder.push(b);
+                                record_measure_z(&mut state, &lost, q, inv, rng, &mut recorder);
                             }
                         }
                         "MX" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                state.h(q);
-                                let (bit, _) = state.measure_z(q, rng);
-                                state.h(q);
-                                let b = (bit == 1) ^ inv;
-                                recorder.push(b);
+                                record_measure_x(&mut state, &lost, q, inv, rng, &mut recorder);
                             }
                         }
                         "MY" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                state.s_dag(q);
-                                state.h(q);
-                                let (bit, _) = state.measure_z(q, rng);
-                                state.h(q);
-                                state.s(q);
-                                let b = (bit == 1) ^ inv;
-                                recorder.push(b);
+                                record_measure_y(&mut state, &lost, q, inv, rng, &mut recorder);
                             }
                         }
                         "MR" | "MRZ" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                let (bit, _) = state.measure_z(q, rng);
-                                let b = (bit == 1) ^ inv;
-                                recorder.push(b);
-                                if bit == 1 { state.x_gate(q); }
+                                measure_reset_z(
+                                    &mut state,
+                                    &mut lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
                             }
                         }
                         "MRX" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                state.h(q);
-                                let (bit, _) = state.measure_z(q, rng);
-                                let b = (bit == 1) ^ inv;
-                                recorder.push(b);
-                                if bit == 1 { state.x_gate(q); }
-                                state.h(q);
+                                measure_reset_x(
+                                    &mut state,
+                                    &mut lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
                             }
                         }
                         "MRY" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                state.s_dag(q);
-                                state.h(q);
-                                let (bit, _) = state.measure_z(q, rng);
-                                let b = (bit == 1) ^ inv;
-                                recorder.push(b);
-                                if bit == 1 { state.x_gate(q); }
-                                state.h(q);
-                                state.s(q);
+                                measure_reset_y(
+                                    &mut state,
+                                    &mut lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
+                            }
+                        }
+                        "ML" | "MZL" => {
+                            for (q, inv) in qubits_with_inversion(targets)? {
+                                record_loss_visible_measure_z(
+                                    &mut state,
+                                    &lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
+                            }
+                        }
+                        "MXL" => {
+                            for (q, inv) in qubits_with_inversion(targets)? {
+                                record_loss_visible_measure_x(
+                                    &mut state,
+                                    &lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
+                            }
+                        }
+                        "MYL" => {
+                            for (q, inv) in qubits_with_inversion(targets)? {
+                                record_loss_visible_measure_y(
+                                    &mut state,
+                                    &lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
+                            }
+                        }
+                        "MRL" | "MRZL" => {
+                            for (q, inv) in qubits_with_inversion(targets)? {
+                                measure_reset_loss_visible_z(
+                                    &mut state,
+                                    &mut lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
+                            }
+                        }
+                        "MRXL" => {
+                            for (q, inv) in qubits_with_inversion(targets)? {
+                                measure_reset_loss_visible_x(
+                                    &mut state,
+                                    &mut lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
+                            }
+                        }
+                        "MRYL" => {
+                            for (q, inv) in qubits_with_inversion(targets)? {
+                                measure_reset_loss_visible_y(
+                                    &mut state,
+                                    &mut lost,
+                                    q,
+                                    inv,
+                                    rng,
+                                    &mut recorder,
+                                );
                             }
                         }
                         "MPAD" => {
@@ -189,18 +274,35 @@ impl Executor {
                             }
                         }
                         "R" | "RZ" => {
-                            for q in qubits(targets)? { state.reset_z(q, rng); }
+                            for q in qubits(targets)? {
+                                lost[q] = false;
+                                state.reset_z(q, rng);
+                            }
                         }
                         "RX" => {
-                            for q in qubits(targets)? { state.reset_x(q, rng); }
+                            for q in qubits(targets)? {
+                                lost[q] = false;
+                                state.reset_x(q, rng);
+                            }
                         }
                         "RY" => {
-                            for q in qubits(targets)? { state.reset_y(q, rng); }
+                            for q in qubits(targets)? {
+                                lost[q] = false;
+                                state.reset_y(q, rng);
+                            }
+                        }
+                        "LOSS" => {
+                            let p = args.get(0).copied().unwrap_or(0.0);
+                            for q in qubits(targets)? {
+                                if rng.r#gen::<f64>() < p {
+                                    lost[q] = true;
+                                }
+                            }
                         }
                         "X_ERROR" => {
                             let p = args.get(0).copied().unwrap_or(0.0);
                             for q in qubits(targets)? {
-                                if rng.r#gen::<f64>() < p {
+                                if !lost[q] && rng.r#gen::<f64>() < p {
                                     state.x_gate(q);
                                 }
                             }
@@ -208,7 +310,7 @@ impl Executor {
                         "Y_ERROR" => {
                             let p = args.get(0).copied().unwrap_or(0.0);
                             for q in qubits(targets)? {
-                                if rng.r#gen::<f64>() < p {
+                                if !lost[q] && rng.r#gen::<f64>() < p {
                                     state.y_gate(q);
                                 }
                             }
@@ -216,7 +318,7 @@ impl Executor {
                         "Z_ERROR" => {
                             let p = args.get(0).copied().unwrap_or(0.0);
                             for q in qubits(targets)? {
-                                if rng.r#gen::<f64>() < p {
+                                if !lost[q] && rng.r#gen::<f64>() < p {
                                     state.z_gate(q);
                                 }
                             }
@@ -224,7 +326,7 @@ impl Executor {
                         "DEPOLARIZE1" => {
                             let p = args.get(0).copied().unwrap_or(0.0);
                             for q in qubits(targets)? {
-                                if rng.r#gen::<f64>() < p {
+                                if !lost[q] && rng.r#gen::<f64>() < p {
                                     match rng.gen_range(0..3) {
                                         0 => state.x_gate(q),
                                         1 => state.y_gate(q),
@@ -235,7 +337,7 @@ impl Executor {
                         }
                         "DEPOLARIZE2" => {
                             let p = args.get(0).copied().unwrap_or(0.0);
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             for (a, b) in pairs {
                                 if rng.r#gen::<f64>() < p {
                                     let r = rng.gen_range(0..15);
@@ -274,26 +376,58 @@ impl Executor {
                         }
                         "MXX" => {
                             let p = args.first().copied().unwrap_or(0.0);
-                            pair_measure(&mut state, targets, PauliBasis::X, p, rng, &mut recorder)?;
+                            pair_measure(
+                                &mut state,
+                                &lost,
+                                targets,
+                                PauliBasis::X,
+                                p,
+                                rng,
+                                &mut recorder,
+                            )?;
                         }
                         "MYY" => {
                             let p = args.first().copied().unwrap_or(0.0);
-                            pair_measure(&mut state, targets, PauliBasis::Y, p, rng, &mut recorder)?;
+                            pair_measure(
+                                &mut state,
+                                &lost,
+                                targets,
+                                PauliBasis::Y,
+                                p,
+                                rng,
+                                &mut recorder,
+                            )?;
                         }
                         "MZZ" => {
                             let p = args.first().copied().unwrap_or(0.0);
-                            pair_measure(&mut state, targets, PauliBasis::Z, p, rng, &mut recorder)?;
+                            pair_measure(
+                                &mut state,
+                                &lost,
+                                targets,
+                                PauliBasis::Z,
+                                p,
+                                rng,
+                                &mut recorder,
+                            )?;
                         }
                         "MPP" => {
                             let p = args.first().copied().unwrap_or(0.0);
                             let products = split_pauli_products(targets)?;
                             for product in &products {
-                                let mut bit = measure_pauli_product(
-                                    &mut state,
-                                    &product.terms,
-                                    product.inverted,
-                                    rng,
-                                );
+                                let mut bit = if product
+                                    .terms
+                                    .iter()
+                                    .any(|(q, _)| lost[*q])
+                                {
+                                    true
+                                } else {
+                                    measure_pauli_product(
+                                        &mut state,
+                                        &product.terms,
+                                        product.inverted,
+                                        rng,
+                                    )
+                                };
                                 if p > 0.0 && rng.r#gen::<f64>() < p {
                                     bit = !bit;
                                 }
@@ -317,19 +451,21 @@ impl Executor {
                             let py = args.get(1).copied().unwrap_or(0.0);
                             let pz = args.get(2).copied().unwrap_or(0.0);
                             for q in qubits(targets)? {
-                                let r: f64 = rng.r#gen();
-                                if r < px {
-                                    state.x_gate(q);
-                                } else if r < px + py {
-                                    state.y_gate(q);
-                                } else if r < px + py + pz {
-                                    state.z_gate(q);
+                                if !lost[q] {
+                                    let r: f64 = rng.r#gen();
+                                    if r < px {
+                                        state.x_gate(q);
+                                    } else if r < px + py {
+                                        state.y_gate(q);
+                                    } else if r < px + py + pz {
+                                        state.z_gate(q);
+                                    }
                                 }
                             }
                         }
                         "PAULI_CHANNEL_2" => {
                             let probs: Vec<f64> = (0..15).map(|i| args.get(i).copied().unwrap_or(0.0)).collect();
-                            let pairs = qubit_pairs(targets)?;
+                            let pairs = present_qubit_pairs(targets, &lost)?;
                             let paulis: [(u8, u8); 15] = [
                                 (0, 1), (0, 2), (0, 3),
                                 (1, 0), (1, 1), (1, 2), (1, 3),
@@ -451,13 +587,15 @@ pub fn reference_sample_with_sweep_bits(
 ) -> Result<Vec<bool>, String> {
     let n = max_qubit(instrs)?;
     let mut state = StabilizerState::new(n);
+    let mut lost = vec![false; n];
     let mut measurements = Vec::new();
-    ref_sample_instrs(&mut state, &mut measurements, instrs, sweep_bits)?;
+    ref_sample_instrs(&mut state, &mut lost, &mut measurements, instrs, sweep_bits)?;
     Ok(measurements)
 }
 
 fn ref_sample_instrs(
     state: &mut StabilizerState,
+    lost: &mut [bool],
     measurements: &mut Vec<bool>,
     instrs: &[StimInstr],
     sweep_bits: Option<&[bool]>,
@@ -465,11 +603,11 @@ fn ref_sample_instrs(
     for instr in instrs {
         match instr {
             StimInstr::Op { name, args, targets, .. } => {
-                ref_sample_op(state, measurements, name.as_str(), args, targets, sweep_bits)?;
+                ref_sample_op(state, lost, measurements, name.as_str(), args, targets, sweep_bits)?;
             }
             StimInstr::Repeat { count, body } => {
                 for _ in 0..*count {
-                    ref_sample_instrs(state, measurements, body, sweep_bits)?;
+                    ref_sample_instrs(state, lost, measurements, body, sweep_bits)?;
                 }
             }
         }
@@ -479,6 +617,7 @@ fn ref_sample_instrs(
 
 fn ref_sample_op(
     state: &mut StabilizerState,
+    lost: &mut [bool],
     measurements: &mut Vec<bool>,
     name: &str,
     _args: &[f64],
@@ -490,29 +629,29 @@ fn ref_sample_op(
         "I" => {}
 
         // Single-qubit Cliffords
-        "H" => for_each_qubit(targets, |q| state.h(q))?,
-        "H_XY" => for_each_qubit(targets, |q| state.h_xy(q))?,
-        "H_YZ" => for_each_qubit(targets, |q| state.h_yz(q))?,
-        "S" | "SQRT_Z" => for_each_qubit(targets, |q| state.s(q))?,
-        "S_DAG" | "SQRT_Z_DAG" => for_each_qubit(targets, |q| state.s_dag(q))?,
-        "SQRT_X" => for_each_qubit(targets, |q| state.sqrt_x(q))?,
-        "SQRT_X_DAG" => for_each_qubit(targets, |q| state.sqrt_x_dag(q))?,
-        "SQRT_Y" => for_each_qubit(targets, |q| state.sqrt_y(q))?,
-        "SQRT_Y_DAG" => for_each_qubit(targets, |q| state.sqrt_y_dag(q))?,
-        "X" => for_each_qubit(targets, |q| state.x_gate(q))?,
-        "Y" => for_each_qubit(targets, |q| state.y_gate(q))?,
-        "Z" => for_each_qubit(targets, |q| state.z_gate(q))?,
-        "C_XYZ" => for_each_qubit(targets, |q| state.c_xyz(q))?,
-        "C_ZYX" => for_each_qubit(targets, |q| state.c_zyx(q))?,
-        "C_NXYZ" => for_each_qubit(targets, |q| state.c_nxyz(q))?,
-        "C_NZYX" => for_each_qubit(targets, |q| state.c_nzyx(q))?,
-        "C_XNYZ" => for_each_qubit(targets, |q| state.c_xnyz(q))?,
-        "C_XYNZ" => for_each_qubit(targets, |q| state.c_xynz(q))?,
-        "C_ZNYX" => for_each_qubit(targets, |q| state.c_znyx(q))?,
-        "C_ZYNX" => for_each_qubit(targets, |q| state.c_zynx(q))?,
-        "H_NXY" => for_each_qubit(targets, |q| state.h_nxy(q))?,
-        "H_NXZ" => for_each_qubit(targets, |q| state.h_nxz(q))?,
-        "H_NYZ" => for_each_qubit(targets, |q| state.h_nyz(q))?,
+        "H" => for_each_present_qubit(targets, lost, |q| state.h(q))?,
+        "H_XY" => for_each_present_qubit(targets, lost, |q| state.h_xy(q))?,
+        "H_YZ" => for_each_present_qubit(targets, lost, |q| state.h_yz(q))?,
+        "S" | "SQRT_Z" => for_each_present_qubit(targets, lost, |q| state.s(q))?,
+        "S_DAG" | "SQRT_Z_DAG" => for_each_present_qubit(targets, lost, |q| state.s_dag(q))?,
+        "SQRT_X" => for_each_present_qubit(targets, lost, |q| state.sqrt_x(q))?,
+        "SQRT_X_DAG" => for_each_present_qubit(targets, lost, |q| state.sqrt_x_dag(q))?,
+        "SQRT_Y" => for_each_present_qubit(targets, lost, |q| state.sqrt_y(q))?,
+        "SQRT_Y_DAG" => for_each_present_qubit(targets, lost, |q| state.sqrt_y_dag(q))?,
+        "X" => for_each_present_qubit(targets, lost, |q| state.x_gate(q))?,
+        "Y" => for_each_present_qubit(targets, lost, |q| state.y_gate(q))?,
+        "Z" => for_each_present_qubit(targets, lost, |q| state.z_gate(q))?,
+        "C_XYZ" => for_each_present_qubit(targets, lost, |q| state.c_xyz(q))?,
+        "C_ZYX" => for_each_present_qubit(targets, lost, |q| state.c_zyx(q))?,
+        "C_NXYZ" => for_each_present_qubit(targets, lost, |q| state.c_nxyz(q))?,
+        "C_NZYX" => for_each_present_qubit(targets, lost, |q| state.c_nzyx(q))?,
+        "C_XNYZ" => for_each_present_qubit(targets, lost, |q| state.c_xnyz(q))?,
+        "C_XYNZ" => for_each_present_qubit(targets, lost, |q| state.c_xynz(q))?,
+        "C_ZNYX" => for_each_present_qubit(targets, lost, |q| state.c_znyx(q))?,
+        "C_ZYNX" => for_each_present_qubit(targets, lost, |q| state.c_zynx(q))?,
+        "H_NXY" => for_each_present_qubit(targets, lost, |q| state.h_nxy(q))?,
+        "H_NXZ" => for_each_present_qubit(targets, lost, |q| state.h_nxz(q))?,
+        "H_NYZ" => for_each_present_qubit(targets, lost, |q| state.h_nyz(q))?,
 
         // Two-qubit Cliffords
         "CX" | "CNOT" | "ZCX" => {
@@ -525,92 +664,101 @@ fn ref_sample_op(
             apply_reference_controlled_pairs(state, name, targets, sweep_bits)?;
         }
         "XCX" => {
-            for (a, b) in qubit_pairs(targets)? { state.xcx(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.xcx(a, b); }
         }
         "XCY" => {
-            for (a, b) in qubit_pairs(targets)? { state.xcy(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.xcy(a, b); }
         }
         "XCZ" => {
-            for (a, b) in qubit_pairs(targets)? { state.xcz(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.xcz(a, b); }
         }
         "YCX" => {
-            for (a, b) in qubit_pairs(targets)? { state.ycx(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.ycx(a, b); }
         }
         "YCY" => {
-            for (a, b) in qubit_pairs(targets)? { state.ycy(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.ycy(a, b); }
         }
         "YCZ" => {
-            for (a, b) in qubit_pairs(targets)? { state.ycz(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.ycz(a, b); }
         }
         "SWAP" => {
-            for (a, b) in qubit_pairs(targets)? { state.swap(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.swap(a, b); }
         }
         "ISWAP" => {
-            for (a, b) in qubit_pairs(targets)? { state.iswap(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.iswap(a, b); }
         }
         "ISWAP_DAG" => {
-            for (a, b) in qubit_pairs(targets)? { state.iswap_dag(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.iswap_dag(a, b); }
         }
         "CXSWAP" => {
-            for (a, b) in qubit_pairs(targets)? { state.cxswap(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.cxswap(a, b); }
         }
         "SWAPCX" => {
-            for (a, b) in qubit_pairs(targets)? { state.swapcx(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.swapcx(a, b); }
         }
         "CZSWAP" => {
-            for (a, b) in qubit_pairs(targets)? { state.czswap(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? { state.czswap(a, b); }
         }
 
         // Measurements (biased)
         "M" | "MZ" => {
             for (q, inv) in qubits_with_inversion(targets)? {
-                let bit = state.measure_z_biased(q);
-                measurements.push((bit == 1) ^ inv);
+                record_reference_measure_z(state, lost, q, inv, measurements);
             }
         }
         "MX" => {
             for (q, inv) in qubits_with_inversion(targets)? {
-                state.h(q);
-                let bit = state.measure_z_biased(q);
-                state.h(q);
-                measurements.push((bit == 1) ^ inv);
+                record_reference_measure_x(state, lost, q, inv, measurements);
             }
         }
         "MY" => {
             for (q, inv) in qubits_with_inversion(targets)? {
-                state.s_dag(q);
-                state.h(q);
-                let bit = state.measure_z_biased(q);
-                state.h(q);
-                state.s(q);
-                measurements.push((bit == 1) ^ inv);
+                record_reference_measure_y(state, lost, q, inv, measurements);
             }
         }
         "MR" | "MRZ" => {
             for (q, inv) in qubits_with_inversion(targets)? {
-                let bit = state.measure_z_biased(q);
-                measurements.push((bit == 1) ^ inv);
-                if bit == 1 { state.x_gate(q); }
+                reference_measure_reset_z(state, lost, q, inv, measurements);
             }
         }
         "MRX" => {
             for (q, inv) in qubits_with_inversion(targets)? {
-                state.h(q);
-                let bit = state.measure_z_biased(q);
-                measurements.push((bit == 1) ^ inv);
-                if bit == 1 { state.x_gate(q); }
-                state.h(q);
+                reference_measure_reset_x(state, lost, q, inv, measurements);
             }
         }
         "MRY" => {
             for (q, inv) in qubits_with_inversion(targets)? {
-                state.s_dag(q);
-                state.h(q);
-                let bit = state.measure_z_biased(q);
-                measurements.push((bit == 1) ^ inv);
-                if bit == 1 { state.x_gate(q); }
-                state.h(q);
-                state.s(q);
+                reference_measure_reset_y(state, lost, q, inv, measurements);
+            }
+        }
+        "ML" | "MZL" => {
+            for (q, inv) in qubits_with_inversion(targets)? {
+                record_reference_loss_visible_measure_z(state, lost, q, inv, measurements);
+            }
+        }
+        "MXL" => {
+            for (q, inv) in qubits_with_inversion(targets)? {
+                record_reference_loss_visible_measure_x(state, lost, q, inv, measurements);
+            }
+        }
+        "MYL" => {
+            for (q, inv) in qubits_with_inversion(targets)? {
+                record_reference_loss_visible_measure_y(state, lost, q, inv, measurements);
+            }
+        }
+        "MRL" | "MRZL" => {
+            for (q, inv) in qubits_with_inversion(targets)? {
+                reference_measure_reset_loss_visible_z(state, lost, q, inv, measurements);
+            }
+        }
+        "MRXL" => {
+            for (q, inv) in qubits_with_inversion(targets)? {
+                reference_measure_reset_loss_visible_x(state, lost, q, inv, measurements);
+            }
+        }
+        "MRYL" => {
+            for (q, inv) in qubits_with_inversion(targets)? {
+                reference_measure_reset_loss_visible_y(state, lost, q, inv, measurements);
             }
         }
         "MPAD" => {
@@ -622,48 +770,76 @@ fn ref_sample_op(
 
         // Resets (biased)
         "R" | "RZ" => {
-            for q in qubits(targets)? { state.reset_z_biased(q); }
+            for q in qubits(targets)? {
+                lost[q] = false;
+                state.reset_z_biased(q);
+            }
         }
         "RX" => {
-            for q in qubits(targets)? { state.reset_x_biased(q); }
+            for q in qubits(targets)? {
+                lost[q] = false;
+                state.reset_x_biased(q);
+            }
         }
         "RY" => {
-            for q in qubits(targets)? { state.reset_y_biased(q); }
+            for q in qubits(targets)? {
+                lost[q] = false;
+                state.reset_y_biased(q);
+            }
+        }
+        "LOSS" => {
+            for _q in qubits(targets)? {}
         }
 
         // Multi-qubit Pauli measurements (biased)
         "MPP" => {
             let products = split_pauli_products(targets)?;
             for product in &products {
-                let bit = measure_pauli_product_biased(
-                    state,
-                    &product.terms,
-                    product.inverted,
-                );
+                let bit = if product.terms.iter().any(|(q, _)| lost[*q]) {
+                    true
+                } else {
+                    measure_pauli_product_biased(
+                        state,
+                        &product.terms,
+                        product.inverted,
+                    )
+                };
                 measurements.push(bit);
             }
         }
         "MXX" => {
             let pairs = qubits_with_inversion_pairs(targets)?;
             for ((a, inv_a), (b, _)) in pairs {
-                let terms = vec![(a, PauliBasis::X), (b, PauliBasis::X)];
-                let bit = measure_pauli_product_biased(state, &terms, inv_a);
+                let bit = if lost[a] || lost[b] {
+                    true ^ inv_a
+                } else {
+                    let terms = vec![(a, PauliBasis::X), (b, PauliBasis::X)];
+                    measure_pauli_product_biased(state, &terms, inv_a)
+                };
                 measurements.push(bit);
             }
         }
         "MYY" => {
             let pairs = qubits_with_inversion_pairs(targets)?;
             for ((a, inv_a), (b, _)) in pairs {
-                let terms = vec![(a, PauliBasis::Y), (b, PauliBasis::Y)];
-                let bit = measure_pauli_product_biased(state, &terms, inv_a);
+                let bit = if lost[a] || lost[b] {
+                    true ^ inv_a
+                } else {
+                    let terms = vec![(a, PauliBasis::Y), (b, PauliBasis::Y)];
+                    measure_pauli_product_biased(state, &terms, inv_a)
+                };
                 measurements.push(bit);
             }
         }
         "MZZ" => {
             let pairs = qubits_with_inversion_pairs(targets)?;
             for ((a, inv_a), (b, _)) in pairs {
-                let terms = vec![(a, PauliBasis::Z), (b, PauliBasis::Z)];
-                let bit = measure_pauli_product_biased(state, &terms, inv_a);
+                let bit = if lost[a] || lost[b] {
+                    true ^ inv_a
+                } else {
+                    let terms = vec![(a, PauliBasis::Z), (b, PauliBasis::Z)];
+                    measure_pauli_product_biased(state, &terms, inv_a)
+                };
                 measurements.push(bit);
             }
         }
@@ -855,9 +1031,16 @@ fn qubits_with_inversion_pairs(targets: &[StimTarget]) -> Result<Vec<((usize, bo
     Ok(flat.chunks(2).map(|c| (c[0], c[1])).collect())
 }
 
-fn for_each_qubit<F: FnMut(usize)>(targets: &[StimTarget], mut f: F) -> Result<(), String> {
+fn for_each_present_qubit<F: FnMut(usize)>(
+    targets: &[StimTarget],
+    lost: &[bool],
+    mut f: F,
+) -> Result<(), String> {
     for t in targets {
-        f(expect_qubit(t)?);
+        let q = expect_qubit(t)?;
+        if !lost[q] {
+            f(q);
+        }
     }
     Ok(())
 }
@@ -885,6 +1068,13 @@ fn qubit_pairs(targets: &[StimTarget]) -> Result<Vec<(usize, usize)>, String> {
         out.push((expect_qubit(a)?, expect_qubit(b)?));
     }
     Ok(out)
+}
+
+fn present_qubit_pairs(targets: &[StimTarget], lost: &[bool]) -> Result<Vec<(usize, usize)>, String> {
+    Ok(qubit_pairs(targets)?
+        .into_iter()
+        .filter(|(a, b)| !lost[*a] && !lost[*b])
+        .collect())
 }
 
 fn xor_recs(r: &Recorder, targets: &[StimTarget]) -> Result<bool, String> {
@@ -926,6 +1116,384 @@ fn apply_pauli(state: &mut StabilizerState, q: usize, p: u8) {
         3 => state.z_gate(q),
         _ => {}
     }
+}
+
+fn record_measure_z(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    if lost[q] {
+        recorder.push(true ^ inv);
+        return;
+    }
+    let (bit, _) = state.measure_z(q, rng);
+    recorder.push((bit == 1) ^ inv);
+}
+
+fn record_measure_x(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    if lost[q] {
+        recorder.push(true ^ inv);
+        return;
+    }
+    state.h(q);
+    let (bit, _) = state.measure_z(q, rng);
+    state.h(q);
+    recorder.push((bit == 1) ^ inv);
+}
+
+fn record_measure_y(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    if lost[q] {
+        recorder.push(true ^ inv);
+        return;
+    }
+    state.s_dag(q);
+    state.h(q);
+    let (bit, _) = state.measure_z(q, rng);
+    state.h(q);
+    state.s(q);
+    recorder.push((bit == 1) ^ inv);
+}
+
+fn measure_reset_z(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    if lost[q] {
+        recorder.push(true ^ inv);
+        lost[q] = false;
+        state.reset_z(q, rng);
+        return;
+    }
+    let (bit, _) = state.measure_z(q, rng);
+    recorder.push((bit == 1) ^ inv);
+    if bit == 1 {
+        state.x_gate(q);
+    }
+}
+
+fn measure_reset_x(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    if lost[q] {
+        recorder.push(true ^ inv);
+        lost[q] = false;
+        state.reset_x(q, rng);
+        return;
+    }
+    state.h(q);
+    let (bit, _) = state.measure_z(q, rng);
+    recorder.push((bit == 1) ^ inv);
+    if bit == 1 {
+        state.x_gate(q);
+    }
+    state.h(q);
+}
+
+fn measure_reset_y(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    if lost[q] {
+        recorder.push(true ^ inv);
+        lost[q] = false;
+        state.reset_y(q, rng);
+        return;
+    }
+    state.s_dag(q);
+    state.h(q);
+    let (bit, _) = state.measure_z(q, rng);
+    recorder.push((bit == 1) ^ inv);
+    if bit == 1 {
+        state.x_gate(q);
+    }
+    state.h(q);
+    state.s(q);
+}
+
+fn record_loss_visible_measure_z(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    recorder.push(lost[q]);
+    record_measure_z(state, lost, q, inv, rng, recorder);
+}
+
+fn record_loss_visible_measure_x(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    recorder.push(lost[q]);
+    record_measure_x(state, lost, q, inv, rng, recorder);
+}
+
+fn record_loss_visible_measure_y(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    recorder.push(lost[q]);
+    record_measure_y(state, lost, q, inv, rng, recorder);
+}
+
+fn measure_reset_loss_visible_z(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    recorder.push(lost[q]);
+    measure_reset_z(state, lost, q, inv, rng, recorder);
+}
+
+fn measure_reset_loss_visible_x(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    recorder.push(lost[q]);
+    measure_reset_x(state, lost, q, inv, rng, recorder);
+}
+
+fn measure_reset_loss_visible_y(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    rng: &mut impl Rng,
+    recorder: &mut Recorder,
+) {
+    recorder.push(lost[q]);
+    measure_reset_y(state, lost, q, inv, rng, recorder);
+}
+
+fn record_reference_measure_z(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    if lost[q] {
+        measurements.push(true ^ inv);
+        return;
+    }
+    let bit = state.measure_z_biased(q);
+    measurements.push((bit == 1) ^ inv);
+}
+
+fn record_reference_measure_x(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    if lost[q] {
+        measurements.push(true ^ inv);
+        return;
+    }
+    state.h(q);
+    let bit = state.measure_z_biased(q);
+    state.h(q);
+    measurements.push((bit == 1) ^ inv);
+}
+
+fn record_reference_measure_y(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    if lost[q] {
+        measurements.push(true ^ inv);
+        return;
+    }
+    state.s_dag(q);
+    state.h(q);
+    let bit = state.measure_z_biased(q);
+    state.h(q);
+    state.s(q);
+    measurements.push((bit == 1) ^ inv);
+}
+
+fn reference_measure_reset_z(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    if lost[q] {
+        measurements.push(true ^ inv);
+        lost[q] = false;
+        state.reset_z_biased(q);
+        return;
+    }
+    let bit = state.measure_z_biased(q);
+    measurements.push((bit == 1) ^ inv);
+    if bit == 1 {
+        state.x_gate(q);
+    }
+}
+
+fn reference_measure_reset_x(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    if lost[q] {
+        measurements.push(true ^ inv);
+        lost[q] = false;
+        state.reset_x_biased(q);
+        return;
+    }
+    state.h(q);
+    let bit = state.measure_z_biased(q);
+    measurements.push((bit == 1) ^ inv);
+    if bit == 1 {
+        state.x_gate(q);
+    }
+    state.h(q);
+}
+
+fn reference_measure_reset_y(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    if lost[q] {
+        measurements.push(true ^ inv);
+        lost[q] = false;
+        state.reset_y_biased(q);
+        return;
+    }
+    state.s_dag(q);
+    state.h(q);
+    let bit = state.measure_z_biased(q);
+    measurements.push((bit == 1) ^ inv);
+    if bit == 1 {
+        state.x_gate(q);
+    }
+    state.h(q);
+    state.s(q);
+}
+
+fn record_reference_loss_visible_measure_z(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    measurements.push(lost[q]);
+    record_reference_measure_z(state, lost, q, inv, measurements);
+}
+
+fn record_reference_loss_visible_measure_x(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    measurements.push(lost[q]);
+    record_reference_measure_x(state, lost, q, inv, measurements);
+}
+
+fn record_reference_loss_visible_measure_y(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    measurements.push(lost[q]);
+    record_reference_measure_y(state, lost, q, inv, measurements);
+}
+
+fn reference_measure_reset_loss_visible_z(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    measurements.push(lost[q]);
+    reference_measure_reset_z(state, lost, q, inv, measurements);
+}
+
+fn reference_measure_reset_loss_visible_x(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    measurements.push(lost[q]);
+    reference_measure_reset_x(state, lost, q, inv, measurements);
+}
+
+fn reference_measure_reset_loss_visible_y(
+    state: &mut StabilizerState,
+    lost: &mut [bool],
+    q: usize,
+    inv: bool,
+    measurements: &mut Vec<bool>,
+) {
+    measurements.push(lost[q]);
+    reference_measure_reset_y(state, lost, q, inv, measurements);
 }
 
 fn two_qubit_pauli(r: usize) -> (u8, u8) {
@@ -1076,6 +1644,7 @@ fn apply_spp(
 
 fn pair_measure(
     state: &mut StabilizerState,
+    lost: &[bool],
     targets: &[StimTarget],
     basis: PauliBasis,
     noise_p: f64,
@@ -1084,8 +1653,12 @@ fn pair_measure(
 ) -> Result<(), String> {
     let pairs = qubits_with_inversion_pairs(targets)?;
     for ((a, inv_a), (b, _inv_b)) in pairs {
-        let terms = vec![(a, basis), (b, basis)];
-        let mut bit = measure_pauli_product(state, &terms, inv_a, rng);
+        let mut bit = if lost[a] || lost[b] {
+            true ^ inv_a
+        } else {
+            let terms = vec![(a, basis), (b, basis)];
+            measure_pauli_product(state, &terms, inv_a, rng)
+        };
         if noise_p > 0.0 && rng.r#gen::<f64>() < noise_p {
             bit = !bit;
         }

--- a/rstim/src/executor.rs
+++ b/rstim/src/executor.rs
@@ -35,7 +35,12 @@ impl Executor {
 
         for instr in &self.instrs {
             match instr {
-                StimInstr::Op { name, args, targets, .. } => {
+                StimInstr::Op {
+                    name,
+                    args,
+                    targets,
+                    ..
+                } => {
                     match name.as_str() {
                         "I" | "I_ERROR" | "II_ERROR" => {}
                         "H" => for_each_present_qubit(targets, &lost, |q| state.h(q))?,
@@ -58,86 +63,104 @@ impl Executor {
                         "Z" => for_each_present_qubit(targets, &lost, |q| state.z_gate(q))?,
                         "C_XYZ" => for_each_present_qubit(targets, &lost, |q| state.c_xyz(q))?,
                         "C_ZYX" => for_each_present_qubit(targets, &lost, |q| state.c_zyx(q))?,
-                        "C_NXYZ" => {
-                            for_each_present_qubit(targets, &lost, |q| state.c_nxyz(q))?
-                        }
-                        "C_NZYX" => {
-                            for_each_present_qubit(targets, &lost, |q| state.c_nzyx(q))?
-                        }
-                        "C_XNYZ" => {
-                            for_each_present_qubit(targets, &lost, |q| state.c_xnyz(q))?
-                        }
-                        "C_XYNZ" => {
-                            for_each_present_qubit(targets, &lost, |q| state.c_xynz(q))?
-                        }
-                        "C_ZNYX" => {
-                            for_each_present_qubit(targets, &lost, |q| state.c_znyx(q))?
-                        }
-                        "C_ZYNX" => {
-                            for_each_present_qubit(targets, &lost, |q| state.c_zynx(q))?
-                        }
+                        "C_NXYZ" => for_each_present_qubit(targets, &lost, |q| state.c_nxyz(q))?,
+                        "C_NZYX" => for_each_present_qubit(targets, &lost, |q| state.c_nzyx(q))?,
+                        "C_XNYZ" => for_each_present_qubit(targets, &lost, |q| state.c_xnyz(q))?,
+                        "C_XYNZ" => for_each_present_qubit(targets, &lost, |q| state.c_xynz(q))?,
+                        "C_ZNYX" => for_each_present_qubit(targets, &lost, |q| state.c_znyx(q))?,
+                        "C_ZYNX" => for_each_present_qubit(targets, &lost, |q| state.c_zynx(q))?,
                         "H_NXY" => for_each_present_qubit(targets, &lost, |q| state.h_nxy(q))?,
                         "H_NXZ" => for_each_present_qubit(targets, &lost, |q| state.h_nxz(q))?,
                         "H_NYZ" => for_each_present_qubit(targets, &lost, |q| state.h_nyz(q))?,
                         "CX" | "CNOT" | "ZCX" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (c, t) in pairs { state.cx(c, t); }
+                            for (c, t) in pairs {
+                                state.cx(c, t);
+                            }
                         }
                         "CY" | "ZCY" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (c, t) in pairs { state.cy(c, t); }
+                            for (c, t) in pairs {
+                                state.cy(c, t);
+                            }
                         }
                         "CZ" | "ZCZ" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (c, t) in pairs { state.cz(c, t); }
+                            for (c, t) in pairs {
+                                state.cz(c, t);
+                            }
                         }
                         "XCX" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.xcx(a, b); }
+                            for (a, b) in pairs {
+                                state.xcx(a, b);
+                            }
                         }
                         "XCY" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.xcy(a, b); }
+                            for (a, b) in pairs {
+                                state.xcy(a, b);
+                            }
                         }
                         "XCZ" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.xcz(a, b); }
+                            for (a, b) in pairs {
+                                state.xcz(a, b);
+                            }
                         }
                         "YCX" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.ycx(a, b); }
+                            for (a, b) in pairs {
+                                state.ycx(a, b);
+                            }
                         }
                         "YCY" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.ycy(a, b); }
+                            for (a, b) in pairs {
+                                state.ycy(a, b);
+                            }
                         }
                         "YCZ" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.ycz(a, b); }
+                            for (a, b) in pairs {
+                                state.ycz(a, b);
+                            }
                         }
                         "SWAP" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.swap(a, b); }
+                            for (a, b) in pairs {
+                                state.swap(a, b);
+                            }
                         }
                         "ISWAP" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.iswap(a, b); }
+                            for (a, b) in pairs {
+                                state.iswap(a, b);
+                            }
                         }
                         "ISWAP_DAG" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.iswap_dag(a, b); }
+                            for (a, b) in pairs {
+                                state.iswap_dag(a, b);
+                            }
                         }
                         "CXSWAP" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.cxswap(a, b); }
+                            for (a, b) in pairs {
+                                state.cxswap(a, b);
+                            }
                         }
                         "SWAPCX" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.swapcx(a, b); }
+                            for (a, b) in pairs {
+                                state.swapcx(a, b);
+                            }
                         }
                         "CZSWAP" => {
                             let pairs = present_qubit_pairs(targets, &lost)?;
-                            for (a, b) in pairs { state.czswap(a, b); }
+                            for (a, b) in pairs {
+                                state.czswap(a, b);
+                            }
                         }
                         "M" | "MZ" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
@@ -156,38 +179,17 @@ impl Executor {
                         }
                         "MR" | "MRZ" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                measure_reset_z(
-                                    &mut state,
-                                    &mut lost,
-                                    q,
-                                    inv,
-                                    rng,
-                                    &mut recorder,
-                                );
+                                measure_reset_z(&mut state, &mut lost, q, inv, rng, &mut recorder);
                             }
                         }
                         "MRX" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                measure_reset_x(
-                                    &mut state,
-                                    &mut lost,
-                                    q,
-                                    inv,
-                                    rng,
-                                    &mut recorder,
-                                );
+                                measure_reset_x(&mut state, &mut lost, q, inv, rng, &mut recorder);
                             }
                         }
                         "MRY" => {
                             for (q, inv) in qubits_with_inversion(targets)? {
-                                measure_reset_y(
-                                    &mut state,
-                                    &mut lost,
-                                    q,
-                                    inv,
-                                    rng,
-                                    &mut recorder,
-                                );
+                                measure_reset_y(&mut state, &mut lost, q, inv, rng, &mut recorder);
                             }
                         }
                         "ML" | "MZL" => {
@@ -414,11 +416,7 @@ impl Executor {
                             let p = args.first().copied().unwrap_or(0.0);
                             let products = split_pauli_products(targets)?;
                             for product in &products {
-                                let mut bit = if product
-                                    .terms
-                                    .iter()
-                                    .any(|(q, _)| lost[*q])
-                                {
+                                let mut bit = if product.terms.iter().any(|(q, _)| lost[*q]) {
                                     true
                                 } else {
                                     measure_pauli_product(
@@ -464,13 +462,26 @@ impl Executor {
                             }
                         }
                         "PAULI_CHANNEL_2" => {
-                            let probs: Vec<f64> = (0..15).map(|i| args.get(i).copied().unwrap_or(0.0)).collect();
+                            let probs: Vec<f64> = (0..15)
+                                .map(|i| args.get(i).copied().unwrap_or(0.0))
+                                .collect();
                             let pairs = present_qubit_pairs(targets, &lost)?;
                             let paulis: [(u8, u8); 15] = [
-                                (0, 1), (0, 2), (0, 3),
-                                (1, 0), (1, 1), (1, 2), (1, 3),
-                                (2, 0), (2, 1), (2, 2), (2, 3),
-                                (3, 0), (3, 1), (3, 2), (3, 3),
+                                (0, 1),
+                                (0, 2),
+                                (0, 3),
+                                (1, 0),
+                                (1, 1),
+                                (1, 2),
+                                (1, 3),
+                                (2, 0),
+                                (2, 1),
+                                (2, 2),
+                                (2, 3),
+                                (3, 0),
+                                (3, 1),
+                                (3, 2),
+                                (3, 3),
                             ];
                             for (a, b) in pairs {
                                 let r: f64 = rng.r#gen();
@@ -602,8 +613,21 @@ fn ref_sample_instrs(
 ) -> Result<(), String> {
     for instr in instrs {
         match instr {
-            StimInstr::Op { name, args, targets, .. } => {
-                ref_sample_op(state, lost, measurements, name.as_str(), args, targets, sweep_bits)?;
+            StimInstr::Op {
+                name,
+                args,
+                targets,
+                ..
+            } => {
+                ref_sample_op(
+                    state,
+                    lost,
+                    measurements,
+                    name.as_str(),
+                    args,
+                    targets,
+                    sweep_bits,
+                )?;
             }
             StimInstr::Repeat { count, body } => {
                 for _ in 0..*count {
@@ -664,40 +688,64 @@ fn ref_sample_op(
             apply_reference_controlled_pairs(state, name, targets, sweep_bits)?;
         }
         "XCX" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.xcx(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.xcx(a, b);
+            }
         }
         "XCY" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.xcy(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.xcy(a, b);
+            }
         }
         "XCZ" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.xcz(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.xcz(a, b);
+            }
         }
         "YCX" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.ycx(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.ycx(a, b);
+            }
         }
         "YCY" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.ycy(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.ycy(a, b);
+            }
         }
         "YCZ" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.ycz(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.ycz(a, b);
+            }
         }
         "SWAP" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.swap(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.swap(a, b);
+            }
         }
         "ISWAP" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.iswap(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.iswap(a, b);
+            }
         }
         "ISWAP_DAG" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.iswap_dag(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.iswap_dag(a, b);
+            }
         }
         "CXSWAP" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.cxswap(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.cxswap(a, b);
+            }
         }
         "SWAPCX" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.swapcx(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.swapcx(a, b);
+            }
         }
         "CZSWAP" => {
-            for (a, b) in present_qubit_pairs(targets, lost)? { state.czswap(a, b); }
+            for (a, b) in present_qubit_pairs(targets, lost)? {
+                state.czswap(a, b);
+            }
         }
 
         // Measurements (biased)
@@ -787,59 +835,39 @@ fn ref_sample_op(
                 state.reset_y_biased(q);
             }
         }
-        "LOSS" => {
-            for _q in qubits(targets)? {}
-        }
+        "LOSS" => for _q in qubits(targets)? {},
 
         // Multi-qubit Pauli measurements (biased)
         "MPP" => {
             let products = split_pauli_products(targets)?;
             for product in &products {
-                let bit = if product.terms.iter().any(|(q, _)| lost[*q]) {
-                    true
-                } else {
-                    measure_pauli_product_biased(
-                        state,
-                        &product.terms,
-                        product.inverted,
-                    )
-                };
+                let bit = reference_measure_pauli_product_biased(
+                    state,
+                    lost,
+                    &product.terms,
+                    product.inverted,
+                );
                 measurements.push(bit);
             }
         }
         "MXX" => {
             let pairs = qubits_with_inversion_pairs(targets)?;
             for ((a, inv_a), (b, _)) in pairs {
-                let bit = if lost[a] || lost[b] {
-                    true ^ inv_a
-                } else {
-                    let terms = vec![(a, PauliBasis::X), (b, PauliBasis::X)];
-                    measure_pauli_product_biased(state, &terms, inv_a)
-                };
+                let bit = reference_measure_pair_biased(state, lost, a, b, PauliBasis::X, inv_a);
                 measurements.push(bit);
             }
         }
         "MYY" => {
             let pairs = qubits_with_inversion_pairs(targets)?;
             for ((a, inv_a), (b, _)) in pairs {
-                let bit = if lost[a] || lost[b] {
-                    true ^ inv_a
-                } else {
-                    let terms = vec![(a, PauliBasis::Y), (b, PauliBasis::Y)];
-                    measure_pauli_product_biased(state, &terms, inv_a)
-                };
+                let bit = reference_measure_pair_biased(state, lost, a, b, PauliBasis::Y, inv_a);
                 measurements.push(bit);
             }
         }
         "MZZ" => {
             let pairs = qubits_with_inversion_pairs(targets)?;
             for ((a, inv_a), (b, _)) in pairs {
-                let bit = if lost[a] || lost[b] {
-                    true ^ inv_a
-                } else {
-                    let terms = vec![(a, PauliBasis::Z), (b, PauliBasis::Z)];
-                    measure_pauli_product_biased(state, &terms, inv_a)
-                };
+                let bit = reference_measure_pair_biased(state, lost, a, b, PauliBasis::Z, inv_a);
                 measurements.push(bit);
             }
         }
@@ -866,17 +894,28 @@ fn ref_sample_op(
         }
 
         // Noise instructions: skip
-        "X_ERROR" | "Z_ERROR" | "Y_ERROR"
-        | "DEPOLARIZE1" | "DEPOLARIZE2"
-        | "CORRELATED_ERROR" | "E" | "ELSE_CORRELATED_ERROR"
-        | "PAULI_CHANNEL_1" | "PAULI_CHANNEL_2"
-        | "I_ERROR" | "II_ERROR" => {}
+        "X_ERROR"
+        | "Z_ERROR"
+        | "Y_ERROR"
+        | "DEPOLARIZE1"
+        | "DEPOLARIZE2"
+        | "CORRELATED_ERROR"
+        | "E"
+        | "ELSE_CORRELATED_ERROR"
+        | "PAULI_CHANNEL_1"
+        | "PAULI_CHANNEL_2"
+        | "I_ERROR"
+        | "II_ERROR" => {}
 
         // Metadata: skip
-        "TICK" | "QUBIT_COORDS" | "SHIFT_COORDS"
-        | "DETECTOR" | "OBSERVABLE_INCLUDE" => {}
+        "TICK" | "QUBIT_COORDS" | "SHIFT_COORDS" | "DETECTOR" | "OBSERVABLE_INCLUDE" => {}
 
-        _ => return Err(format!("reference_sample: unsupported instruction {}", name)),
+        _ => {
+            return Err(format!(
+                "reference_sample: unsupported instruction {}",
+                name
+            ));
+        }
     }
     Ok(())
 }
@@ -940,7 +979,11 @@ fn measure_pauli_product_biased(
     }
 
     let anchor = terms.last().unwrap().0;
-    let non_anchor: Vec<usize> = terms.iter().map(|&(q, _)| q).filter(|&q| q != anchor).collect();
+    let non_anchor: Vec<usize> = terms
+        .iter()
+        .map(|&(q, _)| q)
+        .filter(|&q| q != anchor)
+        .collect();
     for &q in &non_anchor {
         state.cx(q, anchor);
     }
@@ -961,6 +1004,35 @@ fn measure_pauli_product_biased(
     }
 
     result
+}
+
+fn reference_measure_pauli_product_biased(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    terms: &[(usize, PauliBasis)],
+    inverted: bool,
+) -> bool {
+    if terms.iter().any(|(q, _)| lost[*q]) {
+        true
+    } else {
+        measure_pauli_product_biased(state, terms, inverted)
+    }
+}
+
+fn reference_measure_pair_biased(
+    state: &mut StabilizerState,
+    lost: &[bool],
+    a: usize,
+    b: usize,
+    basis: PauliBasis,
+    inverted: bool,
+) -> bool {
+    if lost[a] || lost[b] {
+        true ^ inverted
+    } else {
+        let terms = [(a, basis), (b, basis)];
+        measure_pauli_product_biased(state, &terms, inverted)
+    }
 }
 
 fn recorder_bits(r: Recorder) -> Vec<bool> {
@@ -1023,7 +1095,9 @@ fn qubits_with_inversion(targets: &[StimTarget]) -> Result<Vec<(usize, bool)>, S
     Ok(out)
 }
 
-fn qubits_with_inversion_pairs(targets: &[StimTarget]) -> Result<Vec<((usize, bool), (usize, bool))>, String> {
+fn qubits_with_inversion_pairs(
+    targets: &[StimTarget],
+) -> Result<Vec<((usize, bool), (usize, bool))>, String> {
     let flat = qubits_with_inversion(targets)?;
     if flat.len() % 2 != 0 {
         return Err("odd number of targets for pair measurement".to_string());
@@ -1048,7 +1122,9 @@ fn for_each_present_qubit<F: FnMut(usize)>(
 fn expect_qubit(t: &StimTarget) -> Result<usize, String> {
     match t {
         StimTarget::Qubit(q) => Ok(*q as usize),
-        StimTarget::QubitInv(_) => Err("inverted qubit target only valid for measurement".to_string()),
+        StimTarget::QubitInv(_) => {
+            Err("inverted qubit target only valid for measurement".to_string())
+        }
         StimTarget::Sweep(_) => Err("sweep[] target unexpected here".to_string()),
         _ => Err("expected qubit target".to_string()),
     }
@@ -1070,7 +1146,10 @@ fn qubit_pairs(targets: &[StimTarget]) -> Result<Vec<(usize, usize)>, String> {
     Ok(out)
 }
 
-fn present_qubit_pairs(targets: &[StimTarget], lost: &[bool]) -> Result<Vec<(usize, usize)>, String> {
+fn present_qubit_pairs(
+    targets: &[StimTarget],
+    lost: &[bool],
+) -> Result<Vec<(usize, usize)>, String> {
     Ok(qubit_pairs(targets)?
         .into_iter()
         .filter(|(a, b)| !lost[*a] && !lost[*b])
@@ -1526,7 +1605,11 @@ fn split_pauli_products(targets: &[StimTarget]) -> Result<Vec<PauliProduct>, Str
 
     for target in targets {
         match target {
-            StimTarget::Pauli { qubit, basis, inverted: inv } => {
+            StimTarget::Pauli {
+                qubit,
+                basis,
+                inverted: inv,
+            } => {
                 if !after_combiner && !current_terms.is_empty() {
                     products.push(PauliProduct {
                         terms: std::mem::take(&mut current_terms),
@@ -1547,7 +1630,10 @@ fn split_pauli_products(targets: &[StimTarget]) -> Result<Vec<PauliProduct>, Str
         }
     }
     if !current_terms.is_empty() {
-        products.push(PauliProduct { terms: current_terms, inverted });
+        products.push(PauliProduct {
+            terms: current_terms,
+            inverted,
+        });
     }
     Ok(products)
 }
@@ -1573,7 +1659,11 @@ fn measure_pauli_product(
 
     // CX fold: chain all qubits' Z parity onto anchor (last qubit)
     let anchor = terms.last().unwrap().0;
-    let non_anchor: Vec<usize> = terms.iter().map(|&(q, _)| q).filter(|&q| q != anchor).collect();
+    let non_anchor: Vec<usize> = terms
+        .iter()
+        .map(|&(q, _)| q)
+        .filter(|&q| q != anchor)
+        .collect();
     for &q in &non_anchor {
         state.cx(q, anchor);
     }
@@ -1618,7 +1708,11 @@ fn apply_spp(
     }
 
     let anchor = terms.last().unwrap().0;
-    let non_anchor: Vec<usize> = terms.iter().map(|&(q, _)| q).filter(|&q| q != anchor).collect();
+    let non_anchor: Vec<usize> = terms
+        .iter()
+        .map(|&(q, _)| q)
+        .filter(|&q| q != anchor)
+        .collect();
     for &q in &non_anchor {
         state.cx(q, anchor);
     }
@@ -1665,4 +1759,101 @@ fn pair_measure(
         recorder.push(bit);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_measurement_helpers_return_one_for_lost_qubits() {
+        let mut state = StabilizerState::new(1);
+        let lost = vec![true];
+        let mut measurements = Vec::new();
+
+        record_reference_measure_z(&mut state, &lost, 0, false, &mut measurements);
+        record_reference_measure_x(&mut state, &lost, 0, true, &mut measurements);
+        record_reference_measure_y(&mut state, &lost, 0, false, &mut measurements);
+
+        assert_eq!(measurements, vec![true, false, true]);
+    }
+
+    #[test]
+    fn reference_measure_reset_helpers_clear_loss_and_reset_state() {
+        let mut state = StabilizerState::new(3);
+        let mut lost = vec![true, true, true];
+        let mut measurements = Vec::new();
+
+        reference_measure_reset_z(&mut state, &mut lost, 0, false, &mut measurements);
+        reference_measure_reset_x(&mut state, &mut lost, 1, true, &mut measurements);
+        reference_measure_reset_y(&mut state, &mut lost, 2, false, &mut measurements);
+
+        assert_eq!(measurements, vec![true, false, true]);
+        assert_eq!(lost, vec![false, false, false]);
+
+        let mut post_reset_measurements = Vec::new();
+        record_reference_measure_z(&mut state, &lost, 0, false, &mut post_reset_measurements);
+        record_reference_measure_x(&mut state, &lost, 1, false, &mut post_reset_measurements);
+        record_reference_measure_y(&mut state, &lost, 2, false, &mut post_reset_measurements);
+        assert_eq!(post_reset_measurements, vec![false, false, false]);
+    }
+
+    #[test]
+    fn reference_measure_reset_x_and_y_correct_one_outcomes() {
+        let mut state = StabilizerState::new(2);
+        let mut lost = vec![false, false];
+        let mut measurements = Vec::new();
+
+        state.h(0);
+        state.z_gate(0);
+        reference_measure_reset_x(&mut state, &mut lost, 0, false, &mut measurements);
+
+        state.h(1);
+        state.s_dag(1);
+        reference_measure_reset_y(&mut state, &mut lost, 1, false, &mut measurements);
+
+        assert_eq!(measurements, vec![true, true]);
+
+        let mut post_reset_measurements = Vec::new();
+        record_reference_measure_x(&mut state, &lost, 0, false, &mut post_reset_measurements);
+        record_reference_measure_y(&mut state, &lost, 1, false, &mut post_reset_measurements);
+        assert_eq!(post_reset_measurements, vec![false, false]);
+    }
+
+    #[test]
+    fn reference_multi_pauli_measurements_report_loss() {
+        let mut state = StabilizerState::new(2);
+        let lost = vec![true, false];
+
+        assert!(reference_measure_pauli_product_biased(
+            &mut state,
+            &lost,
+            &[(0, PauliBasis::X), (1, PauliBasis::Y)],
+            true,
+        ));
+        assert!(reference_measure_pair_biased(
+            &mut state,
+            &lost,
+            0,
+            1,
+            PauliBasis::X,
+            false,
+        ));
+        assert!(!reference_measure_pair_biased(
+            &mut state,
+            &lost,
+            0,
+            1,
+            PauliBasis::Y,
+            true,
+        ));
+        assert!(reference_measure_pair_biased(
+            &mut state,
+            &lost,
+            0,
+            1,
+            PauliBasis::Z,
+            false,
+        ));
+    }
 }

--- a/rstim/src/m2d.rs
+++ b/rstim/src/m2d.rs
@@ -187,6 +187,12 @@ fn count_measurements_op(name: &str, targets: &[StimTarget]) -> usize {
         "M" | "MX" | "MY" | "MR" | "MRX" | "MRY" | "MZ" | "MRZ" => {
             targets.iter().filter(|t| matches!(t, StimTarget::Qubit(_) | StimTarget::QubitInv(_))).count()
         }
+        "ML" | "MXL" | "MYL" | "MZL" | "MRL" | "MRXL" | "MRYL" | "MRZL" => {
+            2 * targets
+                .iter()
+                .filter(|t| matches!(t, StimTarget::Qubit(_) | StimTarget::QubitInv(_)))
+                .count()
+        }
         "MXX" | "MYY" | "MZZ" => targets.len() / 2,
         "MPP" => targets.iter().filter(|t| matches!(t, StimTarget::Combiner)).count() + 1,
         "MPAD" => targets.len(),

--- a/rstim/src/sampler.rs
+++ b/rstim/src/sampler.rs
@@ -101,15 +101,7 @@ fn uses_loss_sampling_fallback(instrs: &[StimInstr]) -> bool {
             StimInstr::Op { name, .. } => {
                 if matches!(
                     name.as_str(),
-                    "LOSS"
-                        | "ML"
-                        | "MXL"
-                        | "MYL"
-                        | "MZL"
-                        | "MRL"
-                        | "MRXL"
-                        | "MRYL"
-                        | "MRZL"
+                    "LOSS" | "ML" | "MXL" | "MYL" | "MZL" | "MRL" | "MRXL" | "MRYL" | "MRZL"
                 ) {
                     return true;
                 }
@@ -122,4 +114,39 @@ fn uses_loss_sampling_fallback(instrs: &[StimInstr]) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    use crate::data_path::ReferenceSampleMode;
+    use crate::ir::StimTarget;
+
+    #[test]
+    fn sample_batch_with_executor_errors_on_reference_sample_mismatch() {
+        let instrs = vec![StimInstr::new("ML", vec![], vec![StimTarget::Sweep(0)])];
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let result = sample_batch_with_executor(
+            &instrs,
+            1,
+            &mut rng,
+            SampleOptions {
+                reference_sample_mode: ReferenceSampleMode::AssumeAllZero,
+            },
+        );
+
+        let err = match result {
+            Ok(_) => panic!("expected reference sample mismatch"),
+            Err(err) => err,
+        };
+
+        assert_eq!(
+            err,
+            "executor produced 0 measurements but reference sample expects 2"
+        );
+    }
 }

--- a/rstim/src/sampler.rs
+++ b/rstim/src/sampler.rs
@@ -1,8 +1,10 @@
 use rand::Rng;
 
 use crate::data_path::build_reference_sample;
+use crate::executor::Executor;
 use crate::executor::max_qubit;
 use crate::ir::StimInstr;
+use crate::m2d::{M2dOptions, measurements_to_detections_with_options};
 use crate::sim::bit_table::BitTable;
 use crate::sim::frame::FrameSimulator;
 
@@ -23,6 +25,10 @@ pub fn sample_batch_with_options(
     rng: &mut impl Rng,
     options: SampleOptions,
 ) -> Result<BatchOutput, String> {
+    if uses_loss_sampling_fallback(instrs) {
+        return sample_batch_with_executor(instrs, n_shots, rng, options);
+    }
+
     let ref_sample = build_reference_sample(instrs, options.reference_sample_mode)?;
     let num_qubits = max_qubit(instrs)?;
     let mut frame = FrameSimulator::new(num_qubits, n_shots);
@@ -45,4 +51,75 @@ pub fn sample_batch(
     rng: &mut impl Rng,
 ) -> Result<BatchOutput, String> {
     sample_batch_with_options(instrs, n_shots, rng, SampleOptions::default())
+}
+
+fn sample_batch_with_executor(
+    instrs: &[StimInstr],
+    n_shots: usize,
+    rng: &mut impl Rng,
+    options: SampleOptions,
+) -> Result<BatchOutput, String> {
+    let ref_sample = build_reference_sample(instrs, options.reference_sample_mode)?;
+    let n_meas = ref_sample.len();
+    let mut measurements = BitTable::new(n_meas, n_shots);
+
+    for shot in 0..n_shots {
+        let mut ex = Executor::from_instrs(instrs.to_vec())?;
+        let out = ex.run(rng)?;
+        if out.measurements.len() != n_meas {
+            return Err(format!(
+                "executor produced {} measurements but reference sample expects {}",
+                out.measurements.len(),
+                n_meas
+            ));
+        }
+        for (m, &bit) in out.measurements.iter().enumerate() {
+            measurements.set(m, shot, bit);
+        }
+    }
+
+    let m2d = measurements_to_detections_with_options(
+        instrs,
+        &measurements,
+        None,
+        M2dOptions {
+            reference_sample_mode: options.reference_sample_mode,
+            ran_without_feedback: false,
+        },
+    )?;
+
+    Ok(BatchOutput {
+        measurements,
+        detections: m2d.detections,
+        observable_flips: m2d.observable_flips,
+    })
+}
+
+fn uses_loss_sampling_fallback(instrs: &[StimInstr]) -> bool {
+    for instr in instrs {
+        match instr {
+            StimInstr::Op { name, .. } => {
+                if matches!(
+                    name.as_str(),
+                    "LOSS"
+                        | "ML"
+                        | "MXL"
+                        | "MYL"
+                        | "MZL"
+                        | "MRL"
+                        | "MRXL"
+                        | "MRYL"
+                        | "MRZL"
+                ) {
+                    return true;
+                }
+            }
+            StimInstr::Repeat { body, .. } => {
+                if uses_loss_sampling_fallback(body) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }

--- a/rstim/src/stats.rs
+++ b/rstim/src/stats.rs
@@ -72,6 +72,7 @@ pub fn num_qubits(instrs: &[StimInstr]) -> usize {
 }
 
 /// Total measurement count. M/MX/MY/MZ/MR/MRX/MRY/MRZ produce 1 per target;
+/// ML/MXL/MYL/MZL/MRL/MRXL/MRYL/MRZL produce 2 per target;
 /// MPP produces 1 per Pauli product; MXX/MYY/MZZ produce 1 per pair;
 /// MPAD produces its arg count; HERALDED_* produce 1 per target.
 pub fn num_measurements(instrs: &[StimInstr]) -> usize {
@@ -86,6 +87,9 @@ pub fn num_measurements(instrs: &[StimInstr]) -> usize {
             } => {
                 count += match name.as_str() {
                     "M" | "MX" | "MY" | "MZ" | "MR" | "MRX" | "MRY" | "MRZ" => targets.len(),
+                    "ML" | "MXL" | "MYL" | "MZL" | "MRL" | "MRXL" | "MRYL" | "MRZL" => {
+                        2 * targets.len()
+                    }
                     "MPP" => targets
                         .split(|t| matches!(t, crate::ir::StimTarget::Combiner))
                         .filter(|g| !g.is_empty())

--- a/rstim/tests/cli_analyze.rs
+++ b/rstim/tests/cli_analyze.rs
@@ -130,6 +130,28 @@ fn analyze_errors_rejects_unsupported_correlated_block() {
 }
 
 #[test]
+fn analyze_errors_rejects_atom_loss_instruction() {
+    let output = run_with_stdin(
+        &["analyze_errors"],
+        "LOSS(0.1) 0\nM 0\nDETECTOR rec[-1]",
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("unsupported instruction LOSS"));
+}
+
+#[test]
+fn analyze_errors_rejects_loss_visible_measurement() {
+    let output = run_with_stdin(
+        &["analyze_errors"],
+        "ML 0\nDETECTOR rec[-2]\nDETECTOR rec[-1]",
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("unsupported instruction ML"));
+}
+
+#[test]
 fn analyze_errors_allow_gauge_detectors_flag_accepts_gauge_circuit() {
     let output = run_with_stdin(
         &["analyze_errors", "--allow_gauge_detectors"],

--- a/rstim/tests/cli_detect.rs
+++ b/rstim/tests/cli_detect.rs
@@ -125,3 +125,13 @@ fn detect_obs_out_and_append_observables_both_work() {
     assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), "11");
     assert_eq!(std::fs::read_to_string(&obs_path).unwrap().trim(), "1");
 }
+
+#[test]
+fn detect_loss_visible_measurement_can_feed_detector() {
+    let output = run_with_stdin(
+        &["detect", "--shots", "1"],
+        "LOSS(1) 0\nML 0\nDETECTOR rec[-2]\n",
+    );
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), "1");
+}

--- a/rstim/tests/cli_sample.rs
+++ b/rstim/tests/cli_sample.rs
@@ -84,3 +84,13 @@ fn sample_skip_reference_sample_matches_default_on_zero_reference() {
     assert!(skipped_out.status.success(), "stderr: {}", String::from_utf8_lossy(&skipped_out.stderr));
     assert_eq!(default_out.stdout, skipped_out.stdout);
 }
+
+#[test]
+fn sample_loss_visible_measurements_expand_output_bits() {
+    let output = run_with_stdin(
+        &["sample", "--shots", "1", "--seed", "42"],
+        "LOSS(1) 0\nML 0\n",
+    );
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), "11");
+}

--- a/rstim/tests/coverage_gaps.rs
+++ b/rstim/tests/coverage_gaps.rs
@@ -1,9 +1,9 @@
 //! Targeted tests for remaining coverage gaps.
-use rstim::parser::parse_lines;
-use rstim::executor::Executor;
-use rstim::sampler::sample_batch;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rstim::executor::Executor;
+use rstim::parser::parse_lines;
+use rstim::sampler::sample_batch;
 
 // --- executor.rs: CZ (lines 72-73) ---
 #[test]
@@ -32,12 +32,14 @@ fn executor_qubit_coords_bad_target() {
     // QUBIT_COORDS with rec target should error
     let result = parse_lines("QUBIT_COORDS(0) rec[-1]");
     // parser may reject this; if not, executor should
-    assert!(result.is_err() || {
-        let instrs = result.unwrap();
-        let mut exec = Executor::from_instrs(instrs).unwrap();
-        let mut rng = StdRng::seed_from_u64(0);
-        exec.run(&mut rng).is_err()
-    });
+    assert!(
+        result.is_err() || {
+            let instrs = result.unwrap();
+            let mut exec = Executor::from_instrs(instrs).unwrap();
+            let mut rng = StdRng::seed_from_u64(0);
+            exec.run(&mut rng).is_err()
+        }
+    );
 }
 
 // --- executor.rs: sweep in qubits() (line 780-781) ---
@@ -91,8 +93,8 @@ fn recorder_edge_cases() {
     use rstim::recorder::Recorder;
     let mut r = Recorder::default();
     r.push(true);
-    assert_eq!(r.rec(1), None);   // positive offset
-    assert_eq!(r.rec(-5), None);  // out of range
+    assert_eq!(r.rec(1), None); // positive offset
+    assert_eq!(r.rec(-5), None); // out of range
     assert_eq!(r.rec(-1), Some(true));
 }
 
@@ -172,8 +174,8 @@ fn frame_sim_detector_with_ref_parity() {
 // --- explain_errors.rs: REPEAT path (lines 64-69) via DEM with repeat ---
 #[test]
 fn explain_errors_dem_with_repeat() {
-    use rstim::explain_errors::explain;
     use rstim::error_analyzer::ErrorAnalyzer;
+    use rstim::explain_errors::explain;
     // Circuit with REPEAT produces DEM with REPEAT block
     let circuit = "REPEAT 2 {\n  X_ERROR(0.1) 0\n  M 0\n  DETECTOR rec[-1]\n}";
     let instrs = parse_lines(circuit).unwrap();
@@ -187,8 +189,8 @@ fn explain_errors_dem_with_repeat() {
 // --- explain_errors.rs: empty DEM (line 28 — None branch) ---
 #[test]
 fn explain_errors_empty_dem() {
-    use rstim::explain_errors::explain;
     use rstim::dem::DetectorErrorModel;
+    use rstim::explain_errors::explain;
     let dem = DetectorErrorModel::new();
     let explanations = explain(&dem, &[0]);
     assert!(explanations.is_empty());
@@ -256,6 +258,123 @@ fn unrotated_surface_code_z_with_noise() {
         matches!(i, StimInstr::Op { name, .. } if name == "DEPOLARIZE1" || name == "DEPOLARIZE2")
     });
     assert!(has_noise);
+}
+
+#[test]
+fn loss_visible_variants_cover_executor_paths() {
+    let circuit = "LOSS(1) 0\n\
+                   MXL 0\n\
+                   LOSS(1) 0\n\
+                   MYL 0\n\
+                   LOSS(1) 0\n\
+                   MRXL 0\n\
+                   LOSS(1) 0\n\
+                   MRYL 0\n\
+                   LOSS(1) 0 1\n\
+                   MPP X0*X1\n\
+                   MXX 0 1\n\
+                   MYY 0 1\n\
+                   MZZ 0 1\n";
+    let instrs = parse_lines(circuit).unwrap();
+
+    let mut exec = Executor::from_instrs(instrs.clone()).unwrap();
+    let mut rng = StdRng::seed_from_u64(0);
+    let out = exec.run(&mut rng).unwrap();
+    assert_eq!(out.measurements.len(), 12);
+    assert!(out.measurements.iter().all(|&b| b));
+}
+
+#[test]
+fn loss_visible_variants_cover_reference_sample_paths() {
+    use rstim::executor::reference_sample;
+
+    let circuit = "H 0\n\
+                   MXL 0\n\
+                   H 0\n\
+                   S 0\n\
+                   MYL 0\n\
+                   H 0\n\
+                   MRXL 0\n\
+                   MRXL 0\n\
+                   H 0\n\
+                   S 0\n\
+                   MRYL 0\n\
+                   MRYL 0\n\
+                   H 0\n\
+                   H 1\n\
+                   MPP X0*X1\n\
+                   H 0\n\
+                   H 1\n\
+                   MXX 0 1\n\
+                   H 0\n\
+                   S 0\n\
+                   H 1\n\
+                   S 1\n\
+                   MYY 0 1\n\
+                   MZZ 0 1\n";
+    let instrs = parse_lines(circuit).unwrap();
+    let ref_sample = reference_sample(&instrs).unwrap();
+    assert_eq!(ref_sample.len(), 16);
+    assert!(ref_sample.iter().all(|&b| !b));
+}
+
+#[test]
+fn sample_batch_recurses_into_loss_visible_repeat() {
+    let instrs = parse_lines("REPEAT 2 {\n  LOSS(1) 0\n  ML 0\n}\n").unwrap();
+    let mut rng = StdRng::seed_from_u64(0);
+    let out = sample_batch(&instrs, 1, &mut rng).unwrap();
+    assert_eq!(out.measurements.num_major(), 4);
+    for m in 0..4 {
+        assert!(out.measurements.get(m, 0));
+    }
+}
+
+#[test]
+fn parser_accepts_empty_arg_lists_with_and_without_tags() {
+    let plain = parse_lines("X_ERROR() 0\n").unwrap();
+    match &plain[0] {
+        rstim::ir::StimInstr::Op {
+            name,
+            args,
+            targets,
+            ..
+        } => {
+            assert_eq!(name, "X_ERROR");
+            assert!(args.is_empty());
+            assert_eq!(targets, &vec![rstim::ir::StimTarget::Qubit(0)]);
+        }
+        _ => panic!("expected Op"),
+    }
+
+    let tagged = parse_lines("X_ERROR[LEAK]() 0\n").unwrap();
+    match &tagged[0] {
+        rstim::ir::StimInstr::Op {
+            name,
+            tag,
+            args,
+            targets,
+            ..
+        } => {
+            assert_eq!(name, "X_ERROR");
+            assert_eq!(tag.as_deref(), Some("LEAK"));
+            assert!(args.is_empty());
+            assert_eq!(targets, &vec![rstim::ir::StimTarget::Qubit(0)]);
+        }
+        _ => panic!("expected Op"),
+    }
+}
+
+#[test]
+fn m2d_detector_ignores_non_rec_targets() {
+    use rstim::m2d::measurements_to_detections;
+    use rstim::sim::bit_table::BitTable;
+
+    let instrs = parse_lines("R 0\nM 0\nDETECTOR rec[-1] 0\n").unwrap();
+    let mut meas = BitTable::new(1, 1);
+    meas.set(0, 0, false);
+    let out = measurements_to_detections(&instrs, &meas).unwrap();
+    assert_eq!(out.detections.num_major(), 1);
+    assert!(!out.detections.get(0, 0));
 }
 
 // --- error_analyzer.rs: empty MPP product (lines 635-636) ---

--- a/rstim/tests/error_analyzer.rs
+++ b/rstim/tests/error_analyzer.rs
@@ -191,6 +191,20 @@ fn repetition_code_style() {
 }
 
 #[test]
+fn atom_loss_instruction_is_rejected_by_error_analyzer() {
+    let result = circuit_to_dem_err("LOSS(0.1) 0\nM 0\nDETECTOR rec[-1]");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("unsupported instruction LOSS"));
+}
+
+#[test]
+fn loss_visible_measurement_is_rejected_by_error_analyzer() {
+    let result = circuit_to_dem_err("ML 0\nDETECTOR rec[-2]\nDETECTOR rec[-1]");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("unsupported instruction ML"));
+}
+
+#[test]
 fn swap_gate_swaps_sensitivities() {
     let dem = circuit_to_dem(
         "R 0 1\nX_ERROR(0.1) 0\nSWAP 0 1\nM 0 1\nDETECTOR rec[-2]\nDETECTOR rec[-1]"

--- a/rstim/tests/frame_sim.rs
+++ b/rstim/tests/frame_sim.rs
@@ -84,6 +84,13 @@ fn reference_sample_reset() {
 }
 
 #[test]
+fn reference_sample_loss_is_noiseless_but_ml_adds_extra_bits() {
+    let instrs = parse_lines("LOSS(1) 0\nML 0\nMRXL 1\n").unwrap();
+    let ref_sample = reference_sample(&instrs).unwrap();
+    assert_eq!(ref_sample, vec![false, false, false, false]);
+}
+
+#[test]
 fn reference_sample_with_sweep_bits_applies_cy_control() {
     let instrs = parse_lines("R 0\nCY sweep[0] 0\nM 0\n").unwrap();
     let inactive = reference_sample_with_sweep_bits(&instrs, Some(&[false])).unwrap();
@@ -326,5 +333,21 @@ fn sample_batch_repeat() {
         for m_idx in 0..3 {
             assert_eq!(out.measurements.get(m_idx, shot), true);
         }
+    }
+}
+
+#[test]
+fn sample_batch_loss_uses_executor_semantics() {
+    let instrs = parse_lines("LOSS(1) 0\nML 0\nMRL 0\nM 0\nDETECTOR rec[-1]\n").unwrap();
+    let mut rng = StdRng::seed_from_u64(42);
+    let out = sample_batch(&instrs, 8, &mut rng).unwrap();
+    assert_eq!(out.measurements.num_major(), 5);
+    for shot in 0..8 {
+        assert_eq!(out.measurements.get(0, shot), true);
+        assert_eq!(out.measurements.get(1, shot), true);
+        assert_eq!(out.measurements.get(2, shot), true);
+        assert_eq!(out.measurements.get(3, shot), true);
+        assert_eq!(out.measurements.get(4, shot), false);
+        assert_eq!(out.detections.get(0, shot), false);
     }
 }

--- a/rstim/tests/m2d.rs
+++ b/rstim/tests/m2d.rs
@@ -147,6 +147,15 @@ fn m2d_ran_without_feedback_compensates_simple_classical_x_feedback() {
 }
 
 #[test]
+fn m2d_counts_loss_visible_measurement_bits() {
+    let instrs = parse_lines("ML 0\nDETECTOR rec[-2]\nDETECTOR rec[-1]\n").unwrap();
+    let meas = single_shot_table(2, &[true, true]);
+    let out = measurements_to_detections(&instrs, &meas).unwrap();
+    assert!(out.detections.get(0, 0));
+    assert!(out.detections.get(1, 0));
+}
+
+#[test]
 fn run_m2d_with_options_matches_default_wrapper() {
     let circuit = "R 0\nM 0\nDETECTOR rec[-1]";
     let data = b"1\n";

--- a/rstim/tests/noise_phase3.rs
+++ b/rstim/tests/noise_phase3.rs
@@ -9,6 +9,13 @@ fn run(program: &str) -> Vec<bool> {
     ex.run(&mut rng).unwrap().measurements
 }
 
+fn run_seed(program: &str, seed: u64) -> Vec<bool> {
+    let instrs = parse_lines(program).unwrap();
+    let mut ex = Executor::from_instrs(instrs).unwrap();
+    let mut rng = StdRng::seed_from_u64(seed);
+    ex.run(&mut rng).unwrap().measurements
+}
+
 #[test]
 fn i_error_is_noop() {
     let m = run("I_ERROR(0.1) 0 1\nM 0 1\n");
@@ -255,6 +262,51 @@ fn heralded_pauli_channel_1_deterministic_y() {
     let mut rng = StdRng::seed_from_u64(42);
     let out = ex.run(&mut rng).unwrap();
     assert_eq!(out.measurements, vec![true, true]); // herald=true, Y|0⟩→|1⟩
+}
+
+#[test]
+fn loss_default_measurement_reads_as_one() {
+    let m = run("LOSS(1) 0\nM 0\n");
+    assert_eq!(m, vec![true]);
+}
+
+#[test]
+fn loss_skips_single_qubit_gate_until_reset() {
+    let m = run("LOSS(1) 0\nX 0\nM 0\nR 0\nX 0\nM 0\n");
+    assert_eq!(m, vec![true, true]);
+}
+
+#[test]
+fn loss_skips_only_affected_pair_in_multi_pair_gate() {
+    let m = run("X 2\nLOSS(1) 1\nCX 0 1 2 3\nM 1 3\n");
+    assert_eq!(m, vec![true, true]);
+}
+
+#[test]
+fn mr_on_lost_qubit_reports_one_and_recovers() {
+    let m = run("LOSS(1) 0\nMR 0\nM 0\n");
+    assert_eq!(m, vec![true, false]);
+}
+
+#[test]
+fn ml_reports_loss_flag_then_value_bit() {
+    let m = run("R 0\nML 0\nLOSS(1) 1\nML 1\n");
+    assert_eq!(m, vec![false, false, true, true]);
+}
+
+#[test]
+fn mrl_reports_loss_and_recovers_for_followup_measurement() {
+    let m = run("LOSS(1) 0\nMRL 0\nM 0\n");
+    assert_eq!(m, vec![true, true, false]);
+}
+
+#[test]
+fn loss_channel_is_seeded_but_independent_per_target() {
+    let a = run_seed("LOSS(0.5) 0 1 2 3\nM 0 1 2 3\n", 7);
+    let b = run_seed("LOSS(0.5) 0 1 2 3\nM 0 1 2 3\n", 7);
+    assert_eq!(a, b);
+    assert!(a.iter().any(|&bit| bit));
+    assert!(a.iter().any(|&bit| !bit));
 }
 
 #[test]

--- a/rstim/tests/parser.rs
+++ b/rstim/tests/parser.rs
@@ -22,3 +22,35 @@ fn parses_detector_with_rec() {
         _ => panic!("expected Op"),
     }
 }
+
+#[test]
+fn parses_loss_instruction() {
+    let instrs = parse_lines("LOSS(0.125) 0 2\n").unwrap();
+    match &instrs[0] {
+        StimInstr::Op { name, args, targets, .. } => {
+            assert_eq!(name, "LOSS");
+            assert_eq!(args, &[0.125]);
+            assert_eq!(targets, &vec![StimTarget::Qubit(0), StimTarget::Qubit(2)]);
+        }
+        _ => panic!("expected Op"),
+    }
+}
+
+#[test]
+fn parses_loss_visible_measurements() {
+    let instrs = parse_lines("ML 0\nMRXL !1\n").unwrap();
+    match &instrs[0] {
+        StimInstr::Op { name, targets, .. } => {
+            assert_eq!(name, "ML");
+            assert_eq!(targets, &vec![StimTarget::Qubit(0)]);
+        }
+        _ => panic!("expected Op"),
+    }
+    match &instrs[1] {
+        StimInstr::Op { name, targets, .. } => {
+            assert_eq!(name, "MRXL");
+            assert_eq!(targets, &vec![StimTarget::QubitInv(1)]);
+        }
+        _ => panic!("expected Op"),
+    }
+}

--- a/rstim/tests/stats.rs
+++ b/rstim/tests/stats.rs
@@ -32,6 +32,18 @@ fn num_measurements_mpp() {
 }
 
 #[test]
+fn num_measurements_loss_visible_single_qubit_family() {
+    let instrs = parse_lines("ML 0\nMRXL 1 2\n").unwrap();
+    assert_eq!(stats::num_measurements(&instrs), 6);
+}
+
+#[test]
+fn loss_does_not_count_as_measurement() {
+    let instrs = parse_lines("LOSS(0.25) 0 1 2\nM 0\n").unwrap();
+    assert_eq!(stats::num_measurements(&instrs), 1);
+}
+
+#[test]
 fn num_detectors_simple() {
     let instrs = parse_lines("M 0\nDETECTOR rec[-1]\nDETECTOR rec[-1]").unwrap();
     assert_eq!(stats::num_detectors(&instrs), 2);

--- a/rstim/tests/stim_circuit.rs
+++ b/rstim/tests/stim_circuit.rs
@@ -237,6 +237,16 @@ fn str_roundtrip_complex() {
     assert_eq!(s, s2);
 }
 
+#[test]
+fn str_roundtrip_atom_loss_sampling_ops() {
+    let input = "LOSS(0.125) 0 2\nML 0\nMRXL !1\nM 2";
+    let instrs = parse_lines(input).unwrap();
+    let s = circuit_to_string(&instrs);
+    let re_parsed = parse_lines(&s).unwrap();
+    let s2 = circuit_to_string(&re_parsed);
+    assert_eq!(s, s2);
+}
+
 // ========== repeat_validation ==========
 
 #[test]


### PR DESCRIPTION
## Summary
- Add round-trip coverage for atom-loss sampling syntax.
- Assert  and loss-visible measurements are rejected by the analyzer and CLI today.
- Keep analyzer record counting aligned so  fails explicitly instead of on a misleading  underflow.

## Test Plan
- cargo test --test stim_circuit --test error_analyzer --test error_analyzer_coverage --test stim_error_analyzer --test cli_analyze