### PR TITLE
docs: publish qp101 schema site

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
+      - name: Set up Typst
+        uses: typst-community/setup-typst@v4
+
       - name: Build site
         run: make build-site
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build site
+        run: make build-site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ cobertura.xml
 
 # Build artifacts
 *.rlib
+/_site/
 
 drafts/
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test check release
+.PHONY: help test check build-site release
 
 DEFAULT_BRANCH ?= master
 
@@ -9,6 +9,7 @@ help:
 	@echo "Available targets:"
 	@echo "  test                 - Run workspace tests"
 	@echo "  check                - Run cargo check for the workspace"
+	@echo "  build-site           - Build the QP101 GitHub Pages site into _site"
 	@echo "  release V=x.y.z      - Bump crate versions, commit, tag, and push a release"
 
 test:
@@ -16,6 +17,15 @@ test:
 
 check:
 	cargo check --workspace
+
+build-site:
+	rm -rf _site
+	mkdir -p _site/examples
+	cp site/index.html site/styles.css site/app.js _site/
+	cp rstim/doc/qp101.schema.json _site/qp101.schema.json
+	cp rstim/doc/QP101-ZY.md _site/QP101-ZY.md
+	cp qp101-viz/examples/basic.qp101.json _site/examples/basic.qp101.json
+	cp qp101-viz/examples/repeat-detector.qp101.json _site/examples/repeat-detector.qp101.json
 
 # Release a new version: make release V=0.2.0
 release:

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,16 @@ check:
 
 build-site:
 	rm -rf _site
-	mkdir -p _site/examples
+	mkdir -p _site/examples _site/gallery
 	cp site/index.html site/styles.css site/app.js _site/
 	cp rstim/doc/qp101.schema.json _site/qp101.schema.json
 	cp rstim/doc/QP101-ZY.md _site/QP101-ZY.md
 	cp qp101-viz/examples/basic.qp101.json _site/examples/basic.qp101.json
 	cp qp101-viz/examples/repeat-detector.qp101.json _site/examples/repeat-detector.qp101.json
+	cp qp101-viz/examples/atom-loss-sample.qp101.json _site/examples/atom-loss-sample.qp101.json
+	typst compile --format svg --root qp101-viz qp101-viz/examples/basic-site.typ _site/gallery/basic-site.svg
+	typst compile --format svg --root qp101-viz qp101-viz/examples/repeat-detector-site.typ _site/gallery/repeat-detector-site.svg
+	typst compile --format svg --root qp101-viz qp101-viz/examples/atom-loss-sample.typ _site/gallery/atom-loss-sample.svg
 
 # Release a new version: make release V=0.2.0
 release:

--- a/docs/plans/2026-05-14-mixed-noise-showcase-design.md
+++ b/docs/plans/2026-05-14-mixed-noise-showcase-design.md
@@ -1,0 +1,286 @@
+# Mixed-Noise QP101 Showcase Design
+
+**Date:** 2026-05-14
+
+## Goal
+
+Turn the current
+`qp101-viz/examples/surface-code-rotated-memory-x-d3-r3-atom-loss.typ`
+workflow into a fixed, reproducible showcase example that demonstrates one
+rotated surface-code memory-X circuit containing both sparse Pauli noise and
+sparse atom loss.
+
+The showcase must answer two separate needs:
+
+1. provide a stable human-facing circuit render in `qp101-viz/examples/`
+2. provide a stable generation path owned by `rstim`, so the committed JSON is
+   produced from code instead of being treated as hand-maintained fixture data
+
+The example is meant for explanation, renderer verification, and debugging. It
+is not meant to be a statistically representative noise model or a generic
+noise-parameter benchmark.
+
+## User-Confirmed Display Contract
+
+The final showcase should follow these constraints:
+
+- keep the base code family as rotated surface-code memory-X
+- use `distance=3`, `rounds=3`
+- include both atom loss and common Pauli-noise-style instructions in the same
+  source circuit
+- keep all error probabilities small; start with `0.01`
+- keep the number of noise sites low enough that the source timeline remains
+  readable
+- keep the sample-shot overlay visually informative by choosing a seed that
+  fires a small number of events instead of increasing the source error rates
+
+The intent is a "mixed noise, but not crowded" circuit.
+
+## Current State
+
+The current
+`qp101-viz/examples/surface-code-rotated-memory-x-d3-r3-atom-loss.typ`
+example reads two committed JSON files:
+
+- a base exported circuit JSON
+- a seeded sample-shot exported JSON
+
+However, the generation process is not packaged as a first-class showcase. The
+source `.stim` file currently injects `LOSS(0.1)` onto every data qubit at the
+start of each round, which is much denser than the desired mixed-noise example.
+
+The repository already has the pieces needed to make this a proper showcase:
+
+- `rstim::codegen::surface_code::rotated_memory_x(3, 3, 0.0)` can generate the
+  clean scaffold circuit
+- `rstim` already exports QP101 JSON through `export_qp101`
+- `rstim` already exports seeded sample overlays through
+  `export_qp101_with_sample_trace`
+- `qp101-viz` already renders `LOSS`, `X_ERROR`, `Z_ERROR`, `DEPOLARIZE1`, and
+  `DEPOLARIZE2`
+
+The missing piece is a single repository-owned workflow that fixes what the
+showcase circuit is and how the committed example artifacts are regenerated.
+
+## Key Design Decision
+
+Do not generate this showcase by turning on uniform codegen noise everywhere.
+
+`NoiseParams::uniform(0.01)` is useful for generic noisy circuits, but it is
+the wrong tool for this showcase. It would inject noise at many positions
+throughout the rotated surface-code circuit, which weakens the main purpose of
+the example:
+
+- the source circuit becomes harder to read
+- the timeline render becomes crowded with low-value repetition
+- the example stops being curated and starts behaving like a generic noisy
+  benchmark circuit
+
+Instead, the showcase should be built from the noiseless rotated-memory-X
+generator output and then patched with a small, fixed set of sparse noise sites.
+This keeps the circuit semantically realistic enough for visualization while
+remaining presentation-friendly.
+
+## Recommended Architecture
+
+The showcase should be split into two ownership layers.
+
+### Layer 1: `rstim` owns generation
+
+`rstim` should define the showcase circuit as code. This layer is responsible
+for:
+
+- generating the clean rotated surface-code scaffold
+- inserting a fixed sparse set of noise instructions
+- producing the committed `.stim` source
+- producing the committed base QP101 JSON
+- producing the committed seeded sample-shot QP101 JSON
+
+This layer defines the truth of the example.
+
+### Layer 2: `qp101-viz` owns rendering
+
+`qp101-viz/examples/` should keep only human-facing render inputs and the Typst
+showcase file. It should not contain hidden logic about how the circuit was
+built. The Typst example simply reads the committed JSON files and renders:
+
+- the source circuit
+- one seeded sample shot
+
+This keeps the visualization package declarative and lets `rstim` remain the
+single source of generation semantics.
+
+## Showcase Circuit Shape
+
+The source circuit should start from:
+
+- `surface_code::rotated_memory_x(3, 3, 0.0)`
+
+Then it should receive a small set of manually chosen noise insertions. The
+goal is representation, not coverage. The recommended instruction families are:
+
+- `LOSS(0.01)`
+- `X_ERROR(0.01)`
+- `Z_ERROR(0.01)`
+- `DEPOLARIZE1(0.01)`
+- `DEPOLARIZE2(0.01)`
+
+The insertion pattern should stay sparse:
+
+- atom loss only on one or two data qubits per round, not all data qubits
+- one or very few `DEPOLARIZE1` sites at round boundaries or idle-like moments
+- one or very few `DEPOLARIZE2` sites after representative two-qubit layers
+- one or very few `X_ERROR` sites before measurement-sensitive moments
+- one or very few `Z_ERROR` sites in an X-basis-sensitive region
+
+This is intentionally not a symmetric or exhaustive noise layout. It is a
+curated showcase whose job is to make the visualization readable while still
+showing the main supported noise families together in one circuit.
+
+## Sample-Shot Strategy
+
+The source error rates should stay at `0.01`, but the sample-shot visualization
+must still be visually informative.
+
+The correct way to satisfy both goals is to separate source semantics from
+sample visibility:
+
+- do not raise the source error rates just to make the sample look busy
+- instead, search a small set of deterministic seeds and choose one that causes
+  a few visible events
+
+The accepted seed should produce a sample with roughly:
+
+- a small number of fired noise annotations
+- at least one visible consequence on a measurement or detector when possible
+- no overwhelming burst of unrelated noise markers
+
+The seed becomes part of the committed showcase contract and should be recorded
+in the documentation and regeneration command.
+
+## File and Naming Plan
+
+The showcase should remain easy to discover from the existing example tree.
+
+Recommended artifact set:
+
+- one committed `.stim` file in `qp101-viz/examples/`
+- one committed base `.qp101.json` file in `qp101-viz/examples/`
+- one committed sample `.qp101.json` file in `qp101-viz/examples/`
+- one `.typ` file in `qp101-viz/examples/` that renders both JSON files
+
+The existing file names may either be updated in place or renamed to reflect
+"mixed noise" instead of pure atom loss. Renaming is preferred if it keeps the
+example meaning honest, but preserving the existing file location is acceptable
+if avoiding churn is more important.
+
+On the `rstim` side, the showcase generation helper should live near the
+existing showcase support, such as `rstim/src/showcase.rs` or a closely related
+module. It does not need a generic public API beyond what is required to
+regenerate the committed example artifacts and test them.
+
+## Regeneration Flow
+
+The repository should expose one clear regeneration path for this example.
+
+Recommended flow:
+
+1. generate the mixed-noise rotated-memory-X circuit text from `rstim`
+2. write the `.stim` artifact
+3. export the base QP101 JSON from the same circuit
+4. run one seeded sample shot on the same circuit
+5. export the sample-overlay QP101 JSON
+
+The design does not require a new general-purpose CLI command. A focused helper
+used by tests or a small dedicated example binary is enough, as long as the
+regeneration steps are deterministic and documented in README text.
+
+The committed artifacts should never be edited manually unless the showcase
+definition changes intentionally.
+
+## Testing Strategy
+
+Verification should happen in three layers.
+
+### 1. Circuit-content test
+
+Add a test that asserts the generated showcase circuit contains:
+
+- `LOSS(0.01)`
+- `X_ERROR(0.01)`
+- `Z_ERROR(0.01)`
+- `DEPOLARIZE1(0.01)`
+- `DEPOLARIZE2(0.01)`
+
+This test should also guard against obvious density regressions, such as loss
+being inserted on every data qubit every round again.
+
+### 2. Export fixture test
+
+Add a fixture-style test that regenerates the base QP101 document and compares
+it against the committed JSON artifact. This guards the "source circuit render"
+contract.
+
+### 3. Sample fixture test
+
+Add a second fixture-style test that regenerates the seeded sample-shot QP101
+document and compares it against the committed sample JSON artifact. This
+guards the "sample overlay render" contract.
+
+Together, these tests make the showcase useful as a renderer regression case,
+not just as README decoration.
+
+## Documentation Plan
+
+At minimum, both of these locations should mention the new showcase workflow:
+
+- root `README.md`
+- `qp101-viz/README.md`
+
+The docs should explain:
+
+- what the showcase demonstrates
+- that it contains both sparse Pauli noise and sparse atom loss
+- how to regenerate the `.stim`, base JSON, and sample JSON artifacts
+- which seed was chosen for the sample-shot example
+
+The documentation should describe the workflow as code-generated and committed,
+not hand-authored JSON.
+
+## Failure Modes and Guardrails
+
+The main risks are:
+
+1. sample seed produces no meaningful visible events
+2. noise insertion becomes too dense over time
+3. artifact regeneration drifts away from the committed files without a clear
+   workflow
+4. the example name suggests pure atom loss when the contents are now mixed
+   noise
+
+The design addresses these with:
+
+- explicit seed selection as part of the contract
+- sparse, fixed insertion sites instead of uniform noise parameters
+- fixture comparisons for both base and sample exports
+- documentation and optional renaming to keep semantics honest
+
+## Out of Scope
+
+This showcase does not attempt to:
+
+- model a production-quality mixed-noise process
+- introduce a new general mixed-noise codegen API for all circuits
+- compare `rstim` against `stim` on this custom loss-enabled circuit
+- render multi-shot summaries
+- add new visualization primitives beyond the already supported noise families
+
+Those are separate tasks and should not be bundled into this showcase cleanup.
+
+## Next Step
+
+If implementation continues, the first step should be to create the
+`rstim`-side helper that builds the sparse mixed-noise circuit from the clean
+rotated-memory-X scaffold. Once that circuit shape is stable, regenerate the
+committed `qp101-viz/examples/` artifacts, add fixture tests, and then update
+the README text around the example.

--- a/docs/plans/2026-05-21-qp101-schema-site-design.md
+++ b/docs/plans/2026-05-21-qp101-schema-site-design.md
@@ -1,0 +1,55 @@
+# QP101 Schema Site Design
+
+## Goal
+
+Publish QP101-ZY as a small, downloadable, and browsable web asset without changing the current Rust exporter shape.
+
+## Scope
+
+This work updates the QP101 documentation layer only. It adds a JSON Schema for the existing draft format, links that schema from the protocol document, and creates a static GitHub Pages site that introduces QP101-ZY and visualizes the schema.
+
+It does not change `rstim/src/qp101.rs`, the CLI `export_json` output, or the Typst renderer behavior.
+
+## Architecture
+
+The repository will carry three publishable assets:
+
+- `rstim/doc/qp101.schema.json`: structural JSON Schema for QP101-ZY draft v1.0.
+- `site/`: static source files for the GitHub Pages page.
+- `_site/`: generated build output produced by `make build-site`.
+
+The site is plain HTML, CSS, and JavaScript. It uses relative URLs so it works under a GitHub Pages project path such as `/rstim/`. The JavaScript fetches the schema and renders a compact browser over the top-level document, operation definitions, target-reference definitions, and annotation definitions.
+
+## Schema Boundary
+
+The schema validates the stable draft surface described in `rstim/doc/QP101-ZY.md`:
+
+- top-level fields: `standard`, `version`, `num_qubits`, `operations`, `metadata`, and `extensions`
+- operation types: `gate`, `repeat`, `tick`, `qubit_coords`, `shift_coords`, `detector`, `observable_include`, `noise`, and `annotation`
+- target-reference kinds: `qubit`, `rec`, `pauli`, `combiner`, and `sweep`
+- operation-local annotations and annotation styles
+
+The schema remains extensible. It allows additional fields on protocol objects and treats `metadata`, `extensions`, `annotation.context`, and other tool-specific payloads as ordinary JSON objects. It captures structural requirements but does not attempt semantic validation that JSON Schema cannot express cleanly, such as checking a qubit index against top-level `num_qubits`.
+
+## Web Page
+
+The page is a single tool-style document, not a marketing landing page. The first viewport introduces QP101-ZY, gives the schema download action, and links to the protocol document. The main page sections are:
+
+- schema browser with a navigation list and field details
+- operation type table with concise usage descriptions
+- example JSON snippets for a minimal gate circuit and a Stim-style repeat/detector circuit
+
+The schema browser should remain useful if JavaScript loads successfully and graceful if it fails: show an error message and keep the schema download link visible.
+
+## Build And Deploy
+
+`make build-site` generates `_site/` by copying static files from `site/`, the schema from `rstim/doc/`, the protocol markdown, and selected QP101 examples. The GitHub Actions workflow mirrors the TDAA-Go Pages approach: build `_site/`, upload it with `actions/upload-pages-artifact`, and publish it with `actions/deploy-pages`.
+
+## Verification
+
+Verification should include:
+
+- `make build-site`
+- schema validation against at least one committed `.qp101.json` example
+- local static serving smoke check for `_site/index.html`
+- confirmation that `_site/qp101.schema.json` exists and can be downloaded as a standalone asset

--- a/docs/plans/2026-05-21-qp101-schema-site-implementation.md
+++ b/docs/plans/2026-05-21-qp101-schema-site-implementation.md
@@ -1,0 +1,183 @@
+# QP101 Schema Site Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a downloadable QP101-ZY JSON Schema and a static GitHub Pages site that explains and visualizes it.
+
+**Architecture:** Keep the Rust exporter unchanged. Add a structural schema under `rstim/doc/`, a plain static site under `site/`, a `make build-site` target that emits `_site/`, and a GitHub Pages workflow that deploys `_site/`.
+
+**Tech Stack:** JSON Schema draft 2020-12, HTML, CSS, vanilla JavaScript, Make, GitHub Actions Pages.
+
+---
+
+### Task 1: Add The QP101 JSON Schema
+
+**Files:**
+- Create: `rstim/doc/qp101.schema.json`
+
+**Step 1: Write schema asset**
+
+Create `rstim/doc/qp101.schema.json` with:
+
+- `$schema`: `https://json-schema.org/draft/2020-12/schema`
+- `$id`: `https://nzy1997.github.io/rstim/qp101.schema.json`
+- top-level required fields: `standard`, `version`, `num_qubits`, `operations`
+- `$defs` for `operation`, each operation type, `targetRef`, each target-ref kind, `annotation`, `annotationStyle`, `display`, `metadata`, and `jsonValue`
+- `additionalProperties: true` on protocol objects so tool extensions remain legal
+
+**Step 2: Verify JSON syntax**
+
+Run: `python3 -m json.tool rstim/doc/qp101.schema.json >/tmp/qp101.schema.pretty.json`
+
+Expected: exit 0.
+
+**Step 3: Validate an example fixture**
+
+Run: `python3 tools/validate_qp101_schema.py rstim/doc/qp101.schema.json qp101-viz/examples/basic.qp101.json`
+
+Expected: exit 0.
+
+### Task 2: Link The Schema From QP101 Documentation
+
+**Files:**
+- Modify: `rstim/doc/QP101-ZY.md`
+
+**Step 1: Add schema availability text**
+
+Add a short section after the top-level field list explaining:
+
+- `qp101.schema.json` is the machine-readable structural schema for draft v1.0
+- it is intended for download and automated validation
+- semantic validation rules remain in the markdown specification
+
+**Step 2: Re-read the edited section**
+
+Run: `sed -n '40,120p' rstim/doc/QP101-ZY.md`
+
+Expected: section mentions `qp101.schema.json` and does not claim the schema validates cross-document semantic rules.
+
+### Task 3: Add Static Site Source
+
+**Files:**
+- Create: `site/index.html`
+- Create: `site/styles.css`
+- Create: `site/app.js`
+
+**Step 1: Build the HTML**
+
+Create a single-page document with:
+
+- header title `QP101-ZY`
+- schema download link to `qp101.schema.json`
+- protocol link to `QP101-ZY.md`
+- schema browser container
+- operation type table
+- two example blocks
+
+**Step 2: Build the CSS**
+
+Use a quiet documentation/tool style. Avoid heavy decorative gradients. Ensure:
+
+- responsive two-column schema browser on desktop
+- single-column layout on mobile
+- text wraps inside controls and code blocks
+- buttons use stable dimensions and readable contrast
+
+**Step 3: Build the JavaScript**
+
+Implement:
+
+- fetch `qp101.schema.json`
+- collect browser nodes from top-level `properties` and `$defs`
+- render navigation buttons
+- render selected node type, required fields, properties, enum/const values, and description
+- show an inline error if schema loading fails
+
+### Task 4: Add Site Build Target
+
+**Files:**
+- Modify: `Makefile`
+
+**Step 1: Add phony target**
+
+Add `build-site` to `.PHONY` and help output.
+
+**Step 2: Implement build-site**
+
+The target should:
+
+- remove `_site`
+- create `_site/examples`
+- copy `site/index.html`, `site/styles.css`, and `site/app.js`
+- copy `rstim/doc/qp101.schema.json` to `_site/qp101.schema.json`
+- copy `rstim/doc/QP101-ZY.md` to `_site/QP101-ZY.md`
+- copy `qp101-viz/examples/basic.qp101.json` and `qp101-viz/examples/repeat-detector.qp101.json` to `_site/examples/`
+
+**Step 3: Run the target**
+
+Run: `make build-site`
+
+Expected: exit 0 and `_site/index.html`, `_site/qp101.schema.json`, `_site/QP101-ZY.md`, and `_site/examples/basic.qp101.json` exist.
+
+### Task 5: Add GitHub Pages Deployment Workflow
+
+**Files:**
+- Create: `.github/workflows/deploy-pages.yml`
+
+**Step 1: Add workflow**
+
+Create a workflow triggered by:
+
+- push to `master`
+- manual `workflow_dispatch`
+
+Use:
+
+- `actions/checkout@v4`
+- `actions/configure-pages@v5`
+- `make build-site`
+- `actions/upload-pages-artifact@v3` with path `_site`
+- `actions/deploy-pages@v4`
+
+Set permissions:
+
+- `contents: read`
+- `pages: write`
+- `id-token: write`
+
+**Step 2: Inspect workflow syntax**
+
+Run: `sed -n '1,220p' .github/workflows/deploy-pages.yml`
+
+Expected: workflow includes the build, upload, and deploy steps.
+
+### Task 6: Verify The Site Locally
+
+**Files:**
+- Test generated output under `_site/`
+
+**Step 1: Build the site**
+
+Run: `make build-site`
+
+Expected: exit 0.
+
+**Step 2: Validate copied schema JSON**
+
+Run: `python3 -m json.tool _site/qp101.schema.json >/tmp/qp101-site-schema.pretty.json`
+
+Expected: exit 0.
+
+**Step 3: Validate examples against copied schema**
+
+Run: `python3 tools/validate_qp101_schema.py _site/qp101.schema.json _site/examples/basic.qp101.json _site/examples/repeat-detector.qp101.json`
+
+Expected: exit 0.
+
+**Step 4: Smoke test static serving**
+
+Run: `python3 -m http.server 8765 --directory _site`
+
+Expected: server starts. In a separate command run `curl -fsSL http://127.0.0.1:8765/ >/tmp/qp101-site.html` and `curl -fsSL http://127.0.0.1:8765/qp101.schema.json >/tmp/qp101-site.schema.json`, then stop the server.
+
+Expected: both curl commands exit 0.

--- a/docs/plans/2026-05-22-qp101-circuit-gallery-design.md
+++ b/docs/plans/2026-05-22-qp101-circuit-gallery-design.md
@@ -1,0 +1,44 @@
+# QP101 Circuit Gallery Design
+
+## Goal
+
+Add rendered circuit diagrams from `qp101-viz` to the QP101 website so the page shows concrete visual output in addition to schema and raw JSON examples.
+
+## Scope
+
+This change extends the static GitHub Pages site already added for QP101. It does not change the QP101 schema, the Rust exporter, or the `qp101-viz` renderer logic. It only reuses existing renderer entrypoints to generate static SVGs during site build.
+
+## Chosen Direction
+
+The site will embed three rendered examples:
+
+- `basic`
+- `repeat-detector`
+- `atom-loss-sample`
+
+The diagrams will be generated as SVG with Typst during `make build-site`. This keeps the website aligned with the current `qp101-viz` output instead of creating a second browser-side renderer.
+
+## Asset Layout
+
+Two tiny site-specific Typst wrappers will be added under `qp101-viz/examples/`:
+
+- `basic-site.typ`
+- `repeat-detector-site.typ`
+
+`atom-loss-sample.typ` already exists and can be reused directly. The site build places the generated SVGs into `_site/gallery/`.
+
+## Web Layout
+
+The website will add a `Circuit Gallery` section before the JSON examples section. Each gallery item includes:
+
+- title
+- one-sentence explanation
+- static SVG preview
+- link to the corresponding `.qp101.json`
+- link to the renderer source wrapper
+
+This keeps the page narrative ordered: protocol summary, schema browser, rendered circuits, then downloadable example JSON.
+
+## Build Impact
+
+`make build-site` will now require Typst. The GitHub Pages workflow must therefore install Typst before running the build step.

--- a/docs/plans/2026-05-22-qp101-circuit-gallery-implementation.md
+++ b/docs/plans/2026-05-22-qp101-circuit-gallery-implementation.md
@@ -1,0 +1,149 @@
+# QP101 Circuit Gallery Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add three `qp101-viz` circuit renders to the QP101 website and generate them automatically during `make build-site`.
+
+**Architecture:** Reuse `qp101-viz` Typst entrypoints to render SVGs into `_site/gallery/`, then add a static gallery section in the site HTML that references those generated assets and their matching example JSON files.
+
+**Tech Stack:** Typst SVG export, HTML, CSS, Make, GitHub Actions Pages.
+
+---
+
+### Task 1: Add Missing Typst Wrappers
+
+**Files:**
+- Create: `qp101-viz/examples/basic-site.typ`
+- Create: `qp101-viz/examples/repeat-detector-site.typ`
+
+**Step 1: Write the failing check**
+
+Run: `test -f qp101-viz/examples/basic-site.typ`
+
+Expected: FAIL because the site-specific wrapper does not exist yet.
+
+**Step 2: Add minimal wrappers**
+
+Create two tiny Typst files that import `../lib.typ`, set auto-sized page output, and render:
+
+- `examples/basic.qp101.json`
+- `examples/repeat-detector.qp101.json`
+
+**Step 3: Verify the wrappers compile**
+
+Run:
+
+- `typst compile --format svg --root qp101-viz qp101-viz/examples/basic-site.typ /tmp/basic-site.svg`
+- `typst compile --format svg --root qp101-viz qp101-viz/examples/repeat-detector-site.typ /tmp/repeat-detector-site.svg`
+
+Expected: both commands exit 0.
+
+### Task 2: Extend Site Build Output
+
+**Files:**
+- Modify: `Makefile`
+- Modify: `.github/workflows/deploy-pages.yml`
+
+**Step 1: Write the failing check**
+
+Run:
+
+- `make build-site`
+- `test -f _site/gallery/basic-site.svg`
+
+Expected: first command succeeds, second command fails because gallery assets are not built.
+
+**Step 2: Implement build-site gallery generation**
+
+Update `build-site` to:
+
+- create `_site/gallery`
+- copy `qp101-viz/examples/atom-loss-sample.qp101.json` to `_site/examples/`
+- run `typst compile --format svg` for:
+  - `qp101-viz/examples/basic-site.typ`
+  - `qp101-viz/examples/repeat-detector-site.typ`
+  - `qp101-viz/examples/atom-loss-sample.typ`
+- write outputs to `_site/gallery/basic-site.svg`, `_site/gallery/repeat-detector-site.svg`, and `_site/gallery/atom-loss-sample.svg`
+
+**Step 3: Install Typst in Pages workflow**
+
+Add a workflow step before `make build-site` that installs Typst in GitHub Actions.
+
+**Step 4: Verify the build passes**
+
+Run:
+
+- `make build-site`
+- `find _site/gallery -maxdepth 1 -type f -print`
+
+Expected: the three SVG files exist.
+
+### Task 3: Add The Gallery Section To The Website
+
+**Files:**
+- Modify: `site/index.html`
+- Modify: `site/styles.css`
+
+**Step 1: Write the failing check**
+
+Run: `rg -n "Circuit Gallery|gallery/basic-site.svg|gallery/repeat-detector-site.svg|gallery/atom-loss-sample.svg" site/index.html`
+
+Expected: FAIL because the gallery markup is not present yet.
+
+**Step 2: Add gallery markup**
+
+Insert a `Circuit Gallery` section before `Examples` with three cards:
+
+- basic
+- repeat-detector
+- atom-loss-sample
+
+Each card should include preview image, short explanation, and links to example JSON plus Typst source.
+
+**Step 3: Add gallery styling**
+
+Add CSS for:
+
+- responsive gallery layout
+- framed SVG preview surface
+- image sizing that preserves aspect ratio and prevents overflow
+- compact metadata links
+
+**Step 4: Verify the source now references the gallery**
+
+Run: `rg -n "Circuit Gallery|gallery/basic-site.svg|gallery/repeat-detector-site.svg|gallery/atom-loss-sample.svg" site/index.html`
+
+Expected: PASS.
+
+### Task 4: Verify End-To-End Site Output
+
+**Files:**
+- Test generated `_site/`
+
+**Step 1: Build the site**
+
+Run: `make build-site`
+
+Expected: exit 0.
+
+**Step 2: Confirm generated assets**
+
+Run:
+
+- `find _site/gallery -maxdepth 1 -type f -print`
+- `python3 tools/validate_qp101_schema.py _site/qp101.schema.json _site/examples/basic.qp101.json _site/examples/repeat-detector.qp101.json _site/examples/atom-loss-sample.qp101.json`
+
+Expected: the three SVGs exist and the example JSON files still validate.
+
+**Step 3: Smoke test local serving**
+
+Run: `python3 -m http.server 8765 --directory _site`
+
+In separate commands:
+
+- `curl -fsSL http://127.0.0.1:8765/ >/tmp/qp101-site.html`
+- `curl -fsSL http://127.0.0.1:8765/gallery/basic-site.svg >/tmp/basic-site.svg`
+- `curl -fsSL http://127.0.0.1:8765/gallery/repeat-detector-site.svg >/tmp/repeat-detector-site.svg`
+- `curl -fsSL http://127.0.0.1:8765/gallery/atom-loss-sample.svg >/tmp/atom-loss-sample.svg`
+
+Expected: all commands exit 0.

--- a/qp101-viz/examples/basic-site.typ
+++ b/qp101-viz/examples/basic-site.typ
@@ -1,0 +1,10 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= Basic QP101 Circuit
+
+#qp101-timeline-file(
+  "examples/basic.qp101.json",
+  theme: timeline-theme(step_width: 5.8em, lane_width: 4.8em),
+)

--- a/qp101-viz/examples/repeat-detector-site.typ
+++ b/qp101-viz/examples/repeat-detector-site.typ
@@ -1,0 +1,10 @@
+#import "../lib.typ": qp101-timeline-file, timeline-theme
+
+#set page(width: auto, height: auto, margin: 10pt)
+
+= Repeat Detector Circuit
+
+#qp101-timeline-file(
+  "examples/repeat-detector.qp101.json",
+  theme: timeline-theme(step_width: 5.8em, lane_width: 5.1em),
+)

--- a/rstim/doc/QP101-ZY.md
+++ b/rstim/doc/QP101-ZY.md
@@ -68,6 +68,18 @@ The top-level `gates` array used by earlier draft text is not part of this draft
 
 Execution order lives in `operations`. Non-sequential or auxiliary data belongs in `metadata` or `extensions`.
 
+### Machine-Readable Schema
+
+This draft includes a structural JSON Schema at
+[`qp101.schema.json`](qp101.schema.json). The schema is intended for download,
+editor integration, and automated validation of the core document shape.
+
+The schema intentionally remains extension-friendly: tool-specific fields may
+appear in protocol objects, and `metadata`, `extensions`, and annotation
+`context` values may carry arbitrary JSON objects. Semantic rules that depend
+on whole-document context, such as checking qubit indices against
+`num_qubits`, remain part of this markdown specification's validation rules.
+
 ## Operation Model
 
 Each item in `operations` MUST contain a string `type` field. The protocol defines one generic core operation and a set of standard extension operations.

--- a/rstim/doc/qp101.schema.json
+++ b/rstim/doc/qp101.schema.json
@@ -1,0 +1,462 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nzy1997.github.io/rstim/qp101.schema.json",
+  "title": "QP101-ZY Quantum Circuit JSON Format",
+  "description": "Structural JSON Schema for QP101-ZY draft v1.0 quantum circuit documents. Semantic validation rules remain in the QP101-ZY markdown specification.",
+  "type": "object",
+  "required": ["standard", "version", "num_qubits", "operations"],
+  "additionalProperties": true,
+  "properties": {
+    "standard": {
+      "const": "QP101-ZY",
+      "description": "Protocol identifier."
+    },
+    "version": {
+      "const": "1.0",
+      "description": "Protocol version string for this draft."
+    },
+    "num_qubits": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Total number of qubits in the circuit."
+    },
+    "operations": {
+      "type": "array",
+      "description": "Ordered operation stream preserving execution order.",
+      "items": {
+        "$ref": "#/$defs/operation"
+      }
+    },
+    "metadata": {
+      "$ref": "#/$defs/objectValue",
+      "description": "Framework-neutral metadata such as source tool, generator info, description, or authoring notes."
+    },
+    "extensions": {
+      "$ref": "#/$defs/objectValue",
+      "description": "Non-sequential extension data for rendering, interoperability, or future domains."
+    }
+  },
+  "$defs": {
+    "jsonValue": {
+      "description": "Any JSON value.",
+      "oneOf": [
+        { "type": "null" },
+        { "type": "boolean" },
+        { "type": "number" },
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        }
+      ]
+    },
+    "objectValue": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/jsonValue"
+      }
+    },
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "numberArray": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "qubitIndexArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonNegativeInteger"
+      }
+    },
+    "operation": {
+      "description": "One ordered QP101-ZY operation.",
+      "oneOf": [
+        { "$ref": "#/$defs/gateOperation" },
+        { "$ref": "#/$defs/repeatOperation" },
+        { "$ref": "#/$defs/tickOperation" },
+        { "$ref": "#/$defs/qubitCoordsOperation" },
+        { "$ref": "#/$defs/shiftCoordsOperation" },
+        { "$ref": "#/$defs/detectorOperation" },
+        { "$ref": "#/$defs/observableIncludeOperation" },
+        { "$ref": "#/$defs/noiseOperation" },
+        { "$ref": "#/$defs/annotationOperation" }
+      ]
+    },
+    "operationAnnotations": {
+      "type": "array",
+      "description": "Renderer hints, analysis overlays, query results, or other optional markings attached to this operation.",
+      "items": {
+        "$ref": "#/$defs/annotation"
+      }
+    },
+    "gateOperation": {
+      "type": "object",
+      "description": "Generic circuit gate operation.",
+      "required": ["type", "gate"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "gate" },
+        "gate": {
+          "type": "string",
+          "minLength": 1
+        },
+        "targets": {
+          "$ref": "#/$defs/qubitIndexArray"
+        },
+        "controls": {
+          "$ref": "#/$defs/qubitIndexArray"
+        },
+        "control_configs": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "params": {
+          "$ref": "#/$defs/numberArray"
+        },
+        "raw_targets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/targetRef"
+          }
+        },
+        "display": {
+          "$ref": "#/$defs/display"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["targets"],
+          "properties": {
+            "targets": {
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "required": ["controls"],
+          "properties": {
+            "controls": {
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "required": ["raw_targets"],
+          "properties": {
+            "raw_targets": {
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+    "repeatOperation": {
+      "type": "object",
+      "description": "Nested repeat block preserving hierarchical circuit structure.",
+      "required": ["type", "count", "body"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "repeat" },
+        "count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "body": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/operation"
+          }
+        },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      }
+    },
+    "tickOperation": {
+      "type": "object",
+      "description": "Explicit execution marker.",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "tick" },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      }
+    },
+    "qubitCoordsOperation": {
+      "type": "object",
+      "description": "Coordinate declaration for one or more qubits.",
+      "required": ["type", "coords", "targets"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "qubit_coords" },
+        "coords": {
+          "$ref": "#/$defs/numberArray"
+        },
+        "targets": {
+          "$ref": "#/$defs/qubitIndexArray"
+        },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      }
+    },
+    "shiftCoordsOperation": {
+      "type": "object",
+      "description": "Coordinate offset marker.",
+      "required": ["type", "delta"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "shift_coords" },
+        "delta": {
+          "$ref": "#/$defs/numberArray"
+        },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      }
+    },
+    "detectorOperation": {
+      "type": "object",
+      "description": "Detector annotation over measurement record sources.",
+      "required": ["type", "sources"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "detector" },
+        "coords": {
+          "$ref": "#/$defs/numberArray"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/targetRef"
+          }
+        },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      }
+    },
+    "observableIncludeOperation": {
+      "type": "object",
+      "description": "Logical observable include annotation over measurement record sources.",
+      "required": ["type", "index", "sources"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "observable_include" },
+        "index": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/targetRef"
+          }
+        },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      }
+    },
+    "noiseOperation": {
+      "type": "object",
+      "description": "Noise or fault operator.",
+      "required": ["type", "gate", "raw_targets"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "noise" },
+        "gate": {
+          "type": "string",
+          "minLength": 1
+        },
+        "params": {
+          "$ref": "#/$defs/numberArray"
+        },
+        "raw_targets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/targetRef"
+          }
+        },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      }
+    },
+    "annotationOperation": {
+      "type": "object",
+      "description": "Human-readable annotation operation inside the ordered stream.",
+      "required": ["type", "kind", "text"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "const": "annotation" },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "text": {
+          "type": "string"
+        },
+        "annotations": {
+          "$ref": "#/$defs/operationAnnotations"
+        }
+      }
+    },
+    "targetRef": {
+      "description": "Raw target or source-reference object.",
+      "oneOf": [
+        { "$ref": "#/$defs/qubitTargetRef" },
+        { "$ref": "#/$defs/recTargetRef" },
+        { "$ref": "#/$defs/pauliTargetRef" },
+        { "$ref": "#/$defs/combinerTargetRef" },
+        { "$ref": "#/$defs/sweepTargetRef" }
+      ]
+    },
+    "qubitTargetRef": {
+      "type": "object",
+      "required": ["kind", "index"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": { "const": "qubit" },
+        "index": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "inverted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "recTargetRef": {
+      "type": "object",
+      "required": ["kind", "offset"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": { "const": "rec" },
+        "offset": {
+          "type": "integer"
+        }
+      }
+    },
+    "pauliTargetRef": {
+      "type": "object",
+      "required": ["kind", "basis", "qubit"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": { "const": "pauli" },
+        "basis": {
+          "enum": ["X", "Y", "Z"]
+        },
+        "qubit": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "inverted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "combinerTargetRef": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": { "const": "combiner" }
+      }
+    },
+    "sweepTargetRef": {
+      "type": "object",
+      "required": ["kind", "index"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": { "const": "sweep" },
+        "index": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        }
+      }
+    },
+    "display": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "annotation": {
+      "type": "object",
+      "description": "Operation-local renderer hint, analysis overlay, or query result marker.",
+      "required": ["kind"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target_slots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonNegativeInteger"
+          }
+        },
+        "label": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "style": {
+          "$ref": "#/$defs/annotationStyle"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context": {
+          "$ref": "#/$defs/objectValue"
+        }
+      }
+    },
+    "annotationStyle": {
+      "type": "object",
+      "description": "Generic style hints for operation-local annotations.",
+      "additionalProperties": true,
+      "properties": {
+        "preset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "highlight": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,249 @@
+(function () {
+  const navList = document.getElementById("schema-nav-list");
+  const detail = document.getElementById("schema-detail");
+  const status = document.getElementById("schema-status");
+
+  const groups = [
+    {
+      label: "Document",
+      nodes: [{ id: "document", label: "QP101 document", schemaPath: [] }],
+    },
+    {
+      label: "Operations",
+      defs: [
+        "gateOperation",
+        "repeatOperation",
+        "tickOperation",
+        "qubitCoordsOperation",
+        "shiftCoordsOperation",
+        "detectorOperation",
+        "observableIncludeOperation",
+        "noiseOperation",
+        "annotationOperation",
+      ],
+    },
+    {
+      label: "Target references",
+      defs: [
+        "qubitTargetRef",
+        "recTargetRef",
+        "pauliTargetRef",
+        "combinerTargetRef",
+        "sweepTargetRef",
+      ],
+    },
+    {
+      label: "Shared definitions",
+      defs: ["annotation", "annotationStyle", "display", "operation", "targetRef"],
+    },
+  ];
+
+  function resolveRef(schema, ref) {
+    if (!ref || !ref.startsWith("#/")) {
+      return null;
+    }
+    return ref
+      .slice(2)
+      .split("/")
+      .reduce((current, part) => {
+        if (!current) {
+          return null;
+        }
+        return current[part.replace(/~1/g, "/").replace(/~0/g, "~")];
+      }, schema);
+  }
+
+  function schemaType(schema) {
+    if (!schema) {
+      return "unknown";
+    }
+    if (schema.const !== undefined) {
+      return `const ${JSON.stringify(schema.const)}`;
+    }
+    if (schema.enum) {
+      return `enum ${schema.enum.join(" | ")}`;
+    }
+    if (schema.type) {
+      return Array.isArray(schema.type) ? schema.type.join(" | ") : schema.type;
+    }
+    if (schema.$ref) {
+      return schema.$ref.replace("#/$defs/", "");
+    }
+    if (schema.oneOf) {
+      return "oneOf";
+    }
+    if (schema.anyOf) {
+      return "anyOf";
+    }
+    return "schema";
+  }
+
+  function titleFromKey(key) {
+    return key
+      .replace(/Operation$/, " operation")
+      .replace(/TargetRef$/, " target")
+      .replace(/([a-z])([A-Z])/g, "$1 $2")
+      .replace(/^./, (char) => char.toUpperCase());
+  }
+
+  function collectNodes(schema) {
+    return groups.map((group) => {
+      if (group.nodes) {
+        return group;
+      }
+
+      return {
+        label: group.label,
+        nodes: group.defs.map((defName) => ({
+          id: defName,
+          label: titleFromKey(defName),
+          schemaPath: ["$defs", defName],
+          schema: schema.$defs[defName],
+        })),
+      };
+    });
+  }
+
+  function nodeSchema(root, node) {
+    if (node.schema) {
+      return node.schema;
+    }
+    if (node.schemaPath.length === 0) {
+      return root;
+    }
+    return node.schemaPath.reduce((current, part) => current && current[part], root);
+  }
+
+  function renderMeta(schema, root) {
+    const badges = [];
+    badges.push(`<span class="badge">${escapeHtml(schemaType(schema))}</span>`);
+    if (schema.required && schema.required.length) {
+      badges.push(`<span class="badge">${schema.required.length} required</span>`);
+    }
+    if (schema.properties) {
+      badges.push(`<span class="badge">${Object.keys(schema.properties).length} fields</span>`);
+    }
+    if (schema.oneOf) {
+      badges.push(`<span class="badge">${schema.oneOf.length} variants</span>`);
+    }
+    if (schema.anyOf) {
+      badges.push(`<span class="badge">${schema.anyOf.length} alternatives</span>`);
+    }
+    if (schema.$ref) {
+      const resolved = resolveRef(root, schema.$ref);
+      badges.push(`<span class="badge">ref ${escapeHtml(schemaType(resolved))}</span>`);
+    }
+    return `<div class="schema-meta">${badges.join("")}</div>`;
+  }
+
+  function renderVariantList(schema) {
+    const variants = schema.oneOf || schema.anyOf;
+    if (!variants) {
+      return "";
+    }
+    const items = variants
+      .map((variant) => {
+        const label = variant.$ref ? variant.$ref.replace("#/$defs/", "") : schemaType(variant);
+        return `<li><code>${escapeHtml(label)}</code></li>`;
+      })
+      .join("");
+    return `<h4>Variants</h4><ul>${items}</ul>`;
+  }
+
+  function renderFields(schema, root) {
+    if (!schema.properties) {
+      return "";
+    }
+
+    const required = new Set(schema.required || []);
+    const rows = Object.entries(schema.properties)
+      .map(([name, property]) => {
+        const resolved = property.$ref ? resolveRef(root, property.$ref) : property;
+        const description = property.description || (resolved && resolved.description) || "";
+        const requiredBadge = required.has(name)
+          ? '<span class="badge">required</span>'
+          : '<span class="badge">optional</span>';
+        return `
+          <div class="field">
+            <div class="field-name">
+              <code>${escapeHtml(name)}</code>
+              ${requiredBadge}
+              <span class="badge">${escapeHtml(schemaType(property))}</span>
+            </div>
+            ${description ? `<p class="field-description">${escapeHtml(description)}</p>` : ""}
+          </div>
+        `;
+      })
+      .join("");
+    return `<h4>Fields</h4><div class="field-list">${rows}</div>`;
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function renderDetail(root, node) {
+    const schema = nodeSchema(root, node);
+    detail.innerHTML = `
+      <h3>${escapeHtml(node.label)}</h3>
+      ${renderMeta(schema, root)}
+      ${schema.description ? `<p>${escapeHtml(schema.description)}</p>` : ""}
+      ${renderFields(schema, root)}
+      ${renderVariantList(schema)}
+    `;
+  }
+
+  function renderNav(root, groupedNodes) {
+    navList.innerHTML = "";
+    const allButtons = [];
+
+    groupedNodes.forEach((group) => {
+      const label = document.createElement("div");
+      label.className = "group-label";
+      label.textContent = group.label;
+      navList.appendChild(label);
+
+      group.nodes.forEach((node) => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.textContent = node.label;
+        button.addEventListener("click", () => {
+          allButtons.forEach((item) => item.classList.remove("active"));
+          button.classList.add("active");
+          renderDetail(root, node);
+        });
+        navList.appendChild(button);
+        allButtons.push(button);
+      });
+    });
+
+    if (allButtons.length) {
+      allButtons[0].click();
+    }
+  }
+
+  fetch("qp101.schema.json")
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((schema) => {
+      status.textContent = "Loaded";
+      renderNav(schema, collectNodes(schema));
+    })
+    .catch((error) => {
+      status.textContent = "Error";
+      detail.classList.add("error");
+      detail.innerHTML = `
+        <h3>Schema could not be loaded</h3>
+        <p>${escapeHtml(error.message)}</p>
+        <p><a href="qp101.schema.json" download>Download qp101.schema.json</a></p>
+      `;
+    });
+})();

--- a/site/index.html
+++ b/site/index.html
@@ -15,6 +15,7 @@
       <nav class="top-nav" aria-label="Primary">
         <a href="#schema-browser">Schema</a>
         <a href="#operations">Operations</a>
+        <a href="#gallery">Gallery</a>
         <a href="#examples">Examples</a>
       </nav>
       <div class="hero">
@@ -147,6 +148,81 @@
               </tr>
             </tbody>
           </table>
+        </div>
+      </section>
+
+      <section id="gallery">
+        <div class="section-heading">
+          <p class="eyebrow">Rendered with qp101-viz</p>
+          <h2>Circuit Gallery</h2>
+        </div>
+        <div class="gallery-grid">
+          <article class="gallery-card">
+            <div class="gallery-copy">
+              <div class="example-heading">
+                <h3>Basic Circuit</h3>
+                <a href="examples/basic.qp101.json">JSON</a>
+              </div>
+              <p>
+                Minimal gate, control, tick, and measurement structure rendered
+                from the same QP101 example shipped with the site.
+              </p>
+              <div class="gallery-links">
+                <a href="examples/basic.qp101.json">Example JSON</a>
+                <a href="https://github.com/nzy1997/rstim/blob/master/qp101-viz/examples/basic-site.typ">Typst source</a>
+              </div>
+            </div>
+            <div class="gallery-preview">
+              <img
+                src="gallery/basic-site.svg"
+                alt="Rendered basic QP101 circuit with H, controlled X, tick, and measurement"
+              >
+            </div>
+          </article>
+          <article class="gallery-card">
+            <div class="gallery-copy">
+              <div class="example-heading">
+                <h3>Repeat Detector</h3>
+                <a href="examples/repeat-detector.qp101.json">JSON</a>
+              </div>
+              <p>
+                A compact QEC-style example showing repeat structure,
+                measurement anchors, and detector semantics.
+              </p>
+              <div class="gallery-links">
+                <a href="examples/repeat-detector.qp101.json">Example JSON</a>
+                <a href="https://github.com/nzy1997/rstim/blob/master/qp101-viz/examples/repeat-detector-site.typ">Typst source</a>
+              </div>
+            </div>
+            <div class="gallery-preview">
+              <img
+                src="gallery/repeat-detector-site.svg"
+                alt="Rendered repeated QP101 detector circuit with CX, measurement, and detector box"
+              >
+            </div>
+          </article>
+          <article class="gallery-card">
+            <div class="gallery-copy">
+              <div class="example-heading">
+                <h3>Atom Loss Sample</h3>
+                <a href="examples/atom-loss-sample.qp101.json">JSON</a>
+              </div>
+              <p>
+                Sample-trace annotations rendered inline, including atom loss,
+                measurement results, and detector flips.
+              </p>
+              <div class="gallery-links">
+                <a href="examples/atom-loss-sample.qp101.json">Example JSON</a>
+                <a href="https://github.com/nzy1997/rstim/blob/master/qp101-viz/examples/atom-loss-sample.typ">Typst source</a>
+              </div>
+            </div>
+            <div class="gallery-preview">
+              <img
+                src="gallery/atom-loss-sample.svg"
+                alt="Rendered atom loss sample circuit with inline noise and detector annotations"
+              >
+            </div>
+          </article>
         </div>
       </section>
 

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>QP101-ZY Schema Browser</title>
+    <meta
+      name="description"
+      content="Download and browse the QP101-ZY quantum circuit JSON Schema."
+    >
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="top-nav" aria-label="Primary">
+        <a href="#schema-browser">Schema</a>
+        <a href="#operations">Operations</a>
+        <a href="#examples">Examples</a>
+      </nav>
+      <div class="hero">
+        <p class="eyebrow">Quantum circuit interchange</p>
+        <h1>QP101-ZY</h1>
+        <p class="hero-copy">
+          A JSON format for ordered quantum circuits, repeat blocks, detector
+          annotations, noise events, and visualization metadata used by
+          <code>rstim</code> and <code>qp101-viz</code>.
+        </p>
+        <div class="actions" aria-label="QP101 resources">
+          <a class="button primary" href="qp101.schema.json" download>
+            Download JSON Schema
+          </a>
+          <a class="button" href="QP101-ZY.md">Read Protocol Draft</a>
+          <a class="button" href="examples/basic.qp101.json">View Example</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="intro-grid" aria-label="QP101 summary">
+        <article>
+          <h2>Core Model</h2>
+          <p>
+            QP101 documents keep execution order in an <code>operations</code>
+            stream instead of flattening everything into gates. The schema
+            covers gates, ticks, repeats, coordinates, detectors, observables,
+            noise, and annotations.
+          </p>
+        </article>
+        <article>
+          <h2>Extensible By Design</h2>
+          <p>
+            Tool-specific data belongs in <code>metadata</code>,
+            <code>extensions</code>, or operation-local annotations. The schema
+            validates the stable structure while keeping room for downstream
+            renderers and analysis tools.
+          </p>
+        </article>
+        <article>
+          <h2>Validation Boundary</h2>
+          <p>
+            The schema checks document shape. Whole-document semantic rules,
+            such as comparing target indices with <code>num_qubits</code>, stay
+            in the protocol draft.
+          </p>
+        </article>
+      </section>
+
+      <section id="schema-browser" class="panel">
+        <div class="section-heading">
+          <p class="eyebrow">Interactive reference</p>
+          <h2>Schema Browser</h2>
+        </div>
+        <div class="schema-shell">
+          <aside class="schema-nav" aria-label="Schema navigation">
+            <div class="schema-nav-header">
+              <span>Definitions</span>
+              <span id="schema-status" class="status">Loading</span>
+            </div>
+            <div id="schema-nav-list" class="schema-nav-list"></div>
+          </aside>
+          <article id="schema-detail" class="schema-detail" aria-live="polite">
+            <h3>Loading schema</h3>
+            <p>Fetching <code>qp101.schema.json</code>.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="operations">
+        <div class="section-heading">
+          <p class="eyebrow">Ordered operation stream</p>
+          <h2>Operation Types</h2>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th>Purpose</th>
+                <th>Core Fields</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>gate</code></td>
+                <td>Generic quantum gate or measurement operation.</td>
+                <td><code>gate</code>, <code>targets</code>, <code>controls</code>, <code>raw_targets</code></td>
+              </tr>
+              <tr>
+                <td><code>repeat</code></td>
+                <td>Nested block that preserves repeated circuit structure.</td>
+                <td><code>count</code>, <code>body</code></td>
+              </tr>
+              <tr>
+                <td><code>tick</code></td>
+                <td>Explicit timing separator.</td>
+                <td><code>type</code></td>
+              </tr>
+              <tr>
+                <td><code>qubit_coords</code></td>
+                <td>Coordinate declaration for one or more qubits.</td>
+                <td><code>coords</code>, <code>targets</code></td>
+              </tr>
+              <tr>
+                <td><code>shift_coords</code></td>
+                <td>Coordinate offset marker.</td>
+                <td><code>delta</code></td>
+              </tr>
+              <tr>
+                <td><code>detector</code></td>
+                <td>Detector annotation over measurement record sources.</td>
+                <td><code>coords</code>, <code>sources</code></td>
+              </tr>
+              <tr>
+                <td><code>observable_include</code></td>
+                <td>Logical observable include annotation.</td>
+                <td><code>index</code>, <code>sources</code></td>
+              </tr>
+              <tr>
+                <td><code>noise</code></td>
+                <td>Noise or fault operator preserving raw targets.</td>
+                <td><code>gate</code>, <code>params</code>, <code>raw_targets</code></td>
+              </tr>
+              <tr>
+                <td><code>annotation</code></td>
+                <td>Human-readable stream annotation.</td>
+                <td><code>kind</code>, <code>text</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="examples">
+        <div class="section-heading">
+          <p class="eyebrow">Concrete documents</p>
+          <h2>Examples</h2>
+        </div>
+        <div class="example-grid">
+          <article>
+            <div class="example-heading">
+              <h3>Minimal Gate Circuit</h3>
+              <a href="examples/basic.qp101.json">Download</a>
+            </div>
+            <pre><code>{
+  "standard": "QP101-ZY",
+  "version": "1.0",
+  "num_qubits": 2,
+  "operations": [
+    { "type": "gate", "gate": "H", "targets": [0] },
+    {
+      "type": "gate",
+      "gate": "X",
+      "targets": [1],
+      "controls": [0],
+      "control_configs": [true]
+    },
+    { "type": "tick" },
+    { "type": "gate", "gate": "M", "targets": [0, 1] }
+  ]
+}</code></pre>
+          </article>
+          <article>
+            <div class="example-heading">
+              <h3>Repeat And Detector</h3>
+              <a href="examples/repeat-detector.qp101.json">Download</a>
+            </div>
+            <pre><code>{
+  "type": "repeat",
+  "count": 2,
+  "body": [
+    { "type": "gate", "gate": "CX", "targets": [0, 1] },
+    { "type": "tick" },
+    { "type": "gate", "gate": "M", "targets": [1] },
+    {
+      "type": "detector",
+      "coords": [1.0, 0.0, 0.0],
+      "sources": [
+        { "kind": "rec", "offset": -1 }
+      ]
+    }
+  ]
+}</code></pre>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <span>QP101-ZY draft v1.0</span>
+      <a href="https://github.com/nzy1997/rstim">Repository</a>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -304,6 +304,57 @@ section {
   box-shadow: var(--shadow);
 }
 
+.gallery-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.gallery-card {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  padding: 1rem;
+}
+
+.gallery-copy p {
+  margin: 0.65rem 0 0;
+  color: var(--muted);
+}
+
+.gallery-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.gallery-links a {
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.gallery-preview {
+  min-width: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fbfcfd;
+  padding: 0.9rem;
+}
+
+.gallery-preview img {
+  display: block;
+  width: 100%;
+  height: auto;
+  min-width: 580px;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -403,6 +454,10 @@ pre code {
   .intro-grid,
   .example-grid,
   .schema-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .gallery-card {
     grid-template-columns: 1fr;
   }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,437 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fa;
+  --surface: #ffffff;
+  --surface-muted: #eef2f5;
+  --text: #172026;
+  --muted: #53616b;
+  --border: #d7dde2;
+  --accent: #1b6f7a;
+  --accent-dark: #10535d;
+  --code-bg: #111820;
+  --code-text: #edf4f7;
+  --shadow: 0 16px 42px rgba(23, 32, 38, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.55;
+}
+
+a {
+  color: var(--accent-dark);
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.94em;
+}
+
+.site-header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.top-nav {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 1rem 1.25rem 0;
+}
+
+.top-nav a {
+  color: var(--muted);
+  font-size: 0.95rem;
+  text-decoration: none;
+}
+
+.top-nav a:hover {
+  color: var(--text);
+}
+
+.hero {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 5rem 1.25rem 4.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: var(--accent-dark);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  line-height: 1.16;
+}
+
+h1 {
+  max-width: 14ch;
+  font-size: 5.5rem;
+  letter-spacing: 0;
+}
+
+h2 {
+  font-size: 2.35rem;
+  letter-spacing: 0;
+}
+
+h3 {
+  font-size: 1.12rem;
+  letter-spacing: 0;
+}
+
+.hero-copy {
+  max-width: 760px;
+  margin: 1.25rem 0 0;
+  color: var(--muted);
+  font-size: 1.15rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.72rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 700;
+  text-decoration: none;
+  white-space: normal;
+}
+
+.button.primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+main {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 4rem;
+}
+
+.intro-grid,
+.example-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.intro-grid article,
+.example-grid article {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.intro-grid article {
+  padding: 1.25rem;
+}
+
+.intro-grid p,
+.schema-detail p {
+  color: var(--muted);
+}
+
+section {
+  margin-top: 3.5rem;
+}
+
+.section-heading {
+  margin-bottom: 1rem;
+}
+
+.panel {
+  padding: 0;
+}
+
+.schema-shell {
+  display: grid;
+  grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.schema-nav,
+.schema-detail {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fbfcfd;
+}
+
+.schema-nav-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 0.9rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.status {
+  color: var(--accent-dark);
+}
+
+.schema-nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 34rem;
+  overflow: auto;
+  padding: 0.65rem;
+}
+
+.schema-nav button {
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.schema-nav button:hover,
+.schema-nav button.active {
+  border-color: var(--border);
+  background: var(--surface-muted);
+}
+
+.schema-nav .group-label {
+  padding: 0.8rem 0.65rem 0.25rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.schema-detail {
+  padding: 1rem;
+}
+
+.schema-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0.75rem 0 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.7rem;
+  padding: 0.22rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.field-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 1rem 0 0;
+}
+
+.field {
+  padding: 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+}
+
+.field-name {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 700;
+}
+
+.field-description {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.8rem 0.9rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: #edf2f4;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.example-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.example-grid article {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.example-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.example-heading a {
+  font-weight: 700;
+  text-decoration: none;
+}
+
+pre {
+  margin: 0;
+  max-height: 28rem;
+  overflow: auto;
+  background: var(--code-bg);
+  color: var(--code-text);
+}
+
+pre code {
+  display: block;
+  min-width: 100%;
+  padding: 1rem;
+  white-space: pre;
+}
+
+.error {
+  border-color: #b23b3b;
+  background: #fff7f5;
+  color: #6f1d1d;
+}
+
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+}
+
+@media (max-width: 820px) {
+  .top-nav {
+    justify-content: flex-start;
+  }
+
+  .hero {
+    padding-top: 3.5rem;
+  }
+
+  h1 {
+    font-size: 3.75rem;
+  }
+
+  h2 {
+    font-size: 2rem;
+  }
+
+  .intro-grid,
+  .example-grid,
+  .schema-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .schema-nav-list {
+    max-height: 18rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .top-nav,
+  .actions,
+  .site-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  h1 {
+    font-size: 3rem;
+  }
+
+  h2 {
+    font-size: 1.75rem;
+  }
+
+  .panel {
+    padding: 0;
+  }
+}

--- a/tools/validate_qp101_schema.py
+++ b/tools/validate_qp101_schema.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate QP101 JSON documents against the repository schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import jsonschema
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate one or more QP101 JSON documents against a JSON Schema."
+    )
+    parser.add_argument("schema", type=Path, help="Path to qp101.schema.json")
+    parser.add_argument(
+        "documents",
+        type=Path,
+        nargs="+",
+        help="QP101 JSON document paths to validate",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> object:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    args = parse_args()
+    schema = load_json(args.schema)
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+
+    failed = False
+    for document in args.documents:
+        data = load_json(document)
+        errors = sorted(validator.iter_errors(data), key=lambda err: list(err.path))
+        if not errors:
+            print(f"ok: {document}")
+            continue
+
+        failed = True
+        print(f"error: {document}", file=sys.stderr)
+        for error in errors:
+            location = "/".join(str(part) for part in error.absolute_path) or "<root>"
+            print(f"  {location}: {error.message}", file=sys.stderr)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a QP101-ZY JSON Schema and link it from the protocol draft
- add a static GitHub Pages schema browser and a `build-site` target
- add a Pages deployment workflow and a repo-local schema validator

## Test Plan
- cargo test --workspace
- make build-site
- python3 tools/validate_qp101_schema.py rstim/doc/qp101.schema.json qp101-viz/examples/*.qp101.json qp101-viz/checks/*.qp101.json rstim/tests/fixtures/qp101/*.json
- python3 -m http.server 8765 --directory _site
- curl -fsSL http://127.0.0.1:8765/
- curl -fsSL http://127.0.0.1:8765/qp101.schema.json