### PR TITLE
Build performance parity foundation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: 80%
+        target: 95%

--- a/docs/superpowers/specs/2026-05-25-performance-parity-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-25-performance-parity-foundation-design.md
@@ -1,0 +1,516 @@
+# Performance Parity Foundation Design
+
+Date: 2026-05-25
+Status: Proposed
+Scope: `rstim` crate performance architecture, benchmarking, and staged rollout
+
+## Summary
+
+This design defines the next major project for the repository:
+`performance parity foundation`.
+
+The goal is not to keep adding isolated Stim features. The goal is to build a
+shared performance foundation that lets `rstim` move meaningfully closer to
+Stim on the two workloads where the current architecture is weakest:
+
+- high-shot `sample` and `detect`
+- large-`REPEAT` `analyze_errors`
+
+The design is benchmark-first. Phase completion is defined by measured gains on
+fixed workloads, not by landing a large new abstraction.
+
+The project will introduce:
+
+- a reproducible benchmark harness
+- a shared compiled intermediate layer between `StimInstr` and hot-path
+  execution or analysis
+- a compiled sampler path for `sample` and `detect`
+- a loop-aware analyzer path that avoids flattening large `REPEAT` structures
+
+The design explicitly preserves the current semantic AST as the source of
+truth, and it explicitly allows conservative fallback to existing slower paths
+for workflows such as atom loss, tracked provenance, and sample traces.
+
+## Goals
+
+- Establish a benchmark suite that compares current `rstim`, improved `rstim`,
+  and upstream Stim on fixed workloads.
+- Improve `sample` and `detect` throughput by compiling once and reusing the
+  compiled representation across many shots.
+- Improve `analyze_errors` on large repeated circuits by avoiding eager global
+  flattening of `REPEAT` blocks.
+- Share structural compilation work between the sampling and analysis paths
+  without forcing both paths into one executor implementation.
+- Preserve current semantics and correctness across existing parity and
+  regression tests.
+- Preserve current differentiated workflows such as atom loss, QP101 export,
+  sample trace annotations, and tracked DEM provenance by allowing explicit
+  fallback to conservative paths.
+
+## Non-Goals
+
+- Do not promise full Stim performance parity in one phase.
+- Do not rewrite the parser or replace `StimInstr` as the source semantic
+  representation.
+- Do not force atom-loss-aware sampling, tracked provenance, and QP101-focused
+  workflows into the first compiled path.
+- Do not require that the first loop-aware analyzer replicate every detail of
+  Stim's loop folding implementation.
+- Do not broaden this project into general CLI feature parity such as `diagram`
+  or `repl`.
+
+## Current State
+
+The current codebase already has partial ingredients for a faster design, but
+the hot paths are still dominated by interpretation and eager expansion.
+
+- [`rstim/src/sampler.rs`](/Users/nzy/rcode/rstim/rstim/src/sampler.rs)
+  already uses a reference-sample approach and routes non-loss circuits into
+  the frame simulator. However, the frame simulator is built fresh per call and
+  the circuit itself is not compiled into a reusable hot-path representation.
+- [`rstim/src/sim/frame.rs`](/Users/nzy/rcode/rstim/rstim/src/sim/frame.rs)
+  performs batch-oriented frame simulation, but still walks the instruction
+  tree directly and handles `REPEAT` by recursively re-running the body for
+  each iteration.
+- [`rstim/src/error_analyzer.rs`](/Users/nzy/rcode/rstim/rstim/src/error_analyzer.rs)
+  currently flattens any circuit containing `REPEAT` before the main DEM
+  analysis path, which makes large repeated circuits structurally expensive.
+- The repository already contains parity-oriented tests and comparisons against
+  Stim, including:
+  [`rstim/tests/stim_parity_showcase.rs`](/Users/nzy/rcode/rstim/rstim/tests/stim_parity_showcase.rs),
+  Stim-derived regression suites under
+  [`rstim/tests/`](/Users/nzy/rcode/rstim/rstim/tests),
+  and DEM cross-validation coverage.
+
+The result is that `rstim` has strong semantic momentum but lacks the compile
+and loop-reuse layers that define Stim's strongest performance characteristics.
+
+## Reference Target
+
+The performance comparison target for this design is current upstream Stim,
+specifically the 1.x line represented by Stim `v1.16.0`, released on
+2026-05-22.
+
+This does not imply complete command or feature parity. It defines the external
+reference point for benchmark expectations and architectural direction.
+
+## Decision Summary
+
+The chosen direction is:
+
+- prioritize performance work over additional feature matching
+- treat the project as a large engineering effort, not a quick optimization
+- cover both hot paths:
+  `sample`/`detect` and `analyze_errors`
+- lead with benchmark discipline instead of architecture-first implementation
+- build one shared compile layer, then let sampler and analyzer consume it in
+  different ways
+
+## Alternatives Considered
+
+### 1. Sampling-only project
+
+This option focuses entirely on a compiled sampler for `sample` and `detect`.
+
+Benefits:
+
+- fastest path to visible throughput gains
+- aligns directly with Stim's most famous strength
+
+Costs:
+
+- leaves `analyze_errors` structurally behind
+- risks creating a second performance project later with a separate repeat
+  model
+
+### 2. Analyzer-only project
+
+This option focuses entirely on loop-aware `analyze_errors`.
+
+Benefits:
+
+- isolates the flattening bottleneck cleanly
+- gives a narrower first implementation target
+
+Costs:
+
+- does not improve the most common high-shot workflows
+- does not establish a shared base for sampling
+
+### 3. Shared compile layer with staged dual-track rollout
+
+This option introduces a compile layer shared by the sampler and analyzer,
+while still allowing each consumer to evolve independently.
+
+Benefits:
+
+- creates one place to encode repeat structure, spans, and feature flags
+- keeps the sampler and analyzer aligned on circuit structure
+- lets Phase 1 target the sampler first without orphaning analyzer work
+
+Costs:
+
+- larger up-front design burden
+- requires stricter scope control to avoid over-generalizing the compile layer
+
+This is the recommended option.
+
+## Success Criteria
+
+This section defines success for the first complete performance milestone, not
+for the internal numbering of the rollout phases below.
+
+The first complete performance milestone is defined by benchmarked improvement,
+not by abstraction count.
+
+The benchmark suite must cover:
+
+- commands:
+  `sample`, `detect`, `analyze_errors`
+- circuit families:
+  repetition code, surface code, and color code generator outputs
+- structural stress:
+  at least one high-shot case and at least one large-`REPEAT` case
+- protection cases:
+  at least one atom-loss or QP101-adjacent circuit to ensure the new routing
+  logic does not break differentiated workflows
+
+Each benchmark record must capture:
+
+- circuit label
+- qubit count
+- measurement count
+- detector count
+- observable count
+- repeat depth
+- repeat count or effective iteration count
+- shot count when applicable
+- wall time
+- peak memory
+- tool variant:
+  current `rstim`, new-path `rstim`, and Stim
+
+The first delivery is successful only if all of the following are true:
+
+- `sample` or `detect` shows a clear multi-case throughput improvement over the
+  current `rstim` baseline on fixed large-shot workloads
+- `analyze_errors` no longer scales by eager global repeat expansion on at
+  least one large-`REPEAT` benchmark
+- existing semantic parity and regression tests remain green
+- differentiated workflows still behave correctly through explicit fallback or
+  through unchanged existing paths
+
+## Recommended Architecture
+
+The architecture should be split into three layers.
+
+### Layer 1: Source Semantics
+
+The existing `StimInstr` AST remains the semantic source of truth.
+
+This layer continues to own:
+
+- parsing
+- round-trip formatting
+- current semantic validation
+- QP101 export
+- sample trace integration
+- atom loss semantics
+- tracked provenance semantics
+
+This avoids the highest-risk failure mode of the project: redefining semantics
+inside the performance layer.
+
+### Layer 2: Shared Compile Layer
+
+Add a new internal module, for example `rstim/src/compiled/`, responsible for
+converting `StimInstr` into a reusable structural representation.
+
+Suggested core types:
+
+- `CompiledCircuit`
+- `CompiledBlock`
+- `CompiledRepeatRegion`
+- `CompiledOpBatch` or an equivalent linear instruction segment type
+- `CompiledFeatureFlags`
+
+The compile layer should precompute information such as:
+
+- operation batches suitable for hot-path execution
+- repeat region boundaries and nesting
+- qubit, measurement, detector, and observable spans
+- feature flags such as `has_loss`, `has_feedback`, and
+  `needs_tracked_provenance`
+- metadata needed by path routing and benchmark labeling
+
+The compile layer is not itself an executor or analyzer. Its job is to turn the
+semantic tree into a reusable performance-oriented structural form.
+
+### Layer 3: Consumer Paths
+
+There are two primary consumers of the compiled layer.
+
+#### Compiled Sampler
+
+The compiled sampler serves `sample` and `detect`.
+
+Responsibilities:
+
+- consume `CompiledCircuit`
+- reuse compiled structure across many shots
+- reduce opcode dispatch and recursive AST traversal overhead
+- reuse repeat-body structure instead of interpreting each loop iteration from
+  the original AST
+- preserve the current reference-sample framing model where applicable
+
+The first implementation does not need to fully replicate Stim's final compiled
+sampler design. It must, however, establish compile-once and execute-many
+behavior.
+
+#### Loop-Aware Analyzer
+
+The loop-aware analyzer serves `analyze_errors`.
+
+Responsibilities:
+
+- consume compiled repeat structure instead of flattening the full circuit
+- analyze repeat bodies in structured form
+- compose safe summaries across repeated regions
+- avoid cost proportional to full eager repeat expansion where possible
+
+The first implementation should optimize for safety and correctness before it
+optimizes for the most aggressive possible loop folding.
+
+## Fast Path And Fallback Strategy
+
+The project must not force every workflow into the new performance paths on day
+one.
+
+Routing should be explicit:
+
+- common circuits without advanced semantic requirements use compiled paths
+- circuits that require unsupported compiled behavior fall back to the current
+  implementations
+
+The conservative path should remain the default fallback for:
+
+- atom-loss-aware sampling
+- sample trace generation
+- tracked DEM provenance
+- any workflow that depends on semantics not yet modeled by the compiled layer
+
+Fallback must be correct and intentional. Silent wrong behavior is not allowed.
+
+## Data Flow
+
+The steady-state data flow should be:
+
+`parse_lines -> StimInstr -> compile() -> CompiledCircuit -> consumer`
+
+Sampler path:
+
+`StimInstr -> CompiledCircuit -> CompiledSampler::run(shots)`
+
+Analyzer path:
+
+`StimInstr -> CompiledCircuit -> LoopAwareAnalyzer::analyze()`
+
+This keeps the high-level source stable while giving hot paths reusable,
+structured input.
+
+## Phased Rollout
+
+### Phase 0: Benchmark Harness
+
+Build the benchmark harness before major architectural changes.
+
+Deliverables:
+
+- reproducible benchmark cases
+- machine-readable output format
+- comparison support for current `rstim`, improved `rstim`, and Stim
+- fixed seeds and fixed workload parameters
+- documentation for how to rerun the benchmark suite
+
+This phase exists to prevent architecture work from drifting away from measured
+benefit.
+
+### Phase 1: Shared Compile Layer
+
+Introduce `CompiledCircuit` and related structural types.
+
+Deliverables:
+
+- compile entry point from `StimInstr`
+- repeat-region representation
+- feature flags for path selection
+- metadata used by benchmark reporting and routing
+- tests proving compiled structure preserves source ordering and structure
+
+This phase does not need to provide the full speedup yet. It establishes the
+base that later phases consume.
+
+### Phase 2: Compiled Sampler And Detect Path
+
+Add a compiled execution path for `sample` and `detect`.
+
+Deliverables:
+
+- compile-once execution path for non-fallback circuits
+- repeat-aware execution reuse
+- benchmarked throughput improvements on fixed high-shot workloads
+- path routing and fallback tests
+
+The first version should optimize away repeated AST interpretation and repeated
+loop-tree traversal before attempting more ambitious sampling tricks.
+
+### Phase 3: Loop-Aware Analyze Errors
+
+Replace eager repeat flattening in the main analysis path with compiled repeat
+structure and safe summary reuse.
+
+Deliverables:
+
+- no mandatory full flattening for supported repeated circuits
+- benchmarked improvement on large-`REPEAT` analyzer workloads
+- dedicated repeat-boundary correctness tests
+- documented unsupported structures that still require fallback
+
+This phase should first eliminate the structural flattening bottleneck safely.
+It does not need to implement every detail of Stim-style loop folding on the
+first pass.
+
+## Benchmark Design
+
+The benchmark suite should be stored in-repo and should be runnable on demand.
+
+The benchmark set should include:
+
+- generated repetition-code memory circuits
+- generated rotated and unrotated surface-code memory circuits
+- generated color-code memory circuits
+- one or more large-shot sampling cases
+- one or more large-repeat analyzer cases
+- one protection case that exercises differentiated semantics
+
+The benchmark output should be designed for later regression checks and for
+human-readable summaries in docs or release notes.
+
+At minimum, the benchmark system should support:
+
+- raw records
+- stable labels
+- grouped summary tables
+- comparison against previous `rstim` baseline runs
+
+## Risks
+
+### Dual-Path Semantic Drift
+
+If the compiled path and the conservative path encode semantics differently,
+the project will create a second implementation that slowly diverges.
+
+Mitigation:
+
+- keep `StimInstr` as the source semantic layer
+- keep compile as structural lowering, not semantic reinterpretation
+- require parity-style regression coverage across both paths
+
+### Incorrect Repeat Summaries
+
+`analyze_errors` is especially sensitive to detector and observable influence
+that crosses repeat boundaries.
+
+Mitigation:
+
+- make the first analyzer summary model intentionally conservative
+- prefer partial reuse over unsafe aggressive folding
+- add repeat-boundary correctness tests before broadening optimization scope
+
+### Benchmark Noise
+
+Poorly controlled benchmark inputs can turn the project into a sequence of
+inconclusive runs.
+
+Mitigation:
+
+- fixed inputs
+- fixed seeds
+- fixed shot and repeat parameters
+- persistent result files
+- summary by median or similarly stable aggregate
+
+### Scope Collapse Into Differentiated Features
+
+If atom loss, tracked provenance, and QP101-focused workflows are pulled into
+the first compiled path, the project will likely stall.
+
+Mitigation:
+
+- explicit fast-path and fallback-path routing
+- no requirement that differentiated workflows use the compiled path in the
+  first performance phase
+
+## Testing Strategy
+
+### 1. Semantic Regression
+
+Reuse and extend the existing Stim-derived test suites and parity tests to
+ensure the new paths do not change accepted semantics.
+
+### 2. Routing Tests
+
+Add direct tests proving that:
+
+- supported common circuits take the compiled path
+- unsupported or high-risk circuits take the fallback path
+- fallback behavior is explicit and deterministic
+
+### 3. Repeat-Specific Correctness
+
+Add tests focused on:
+
+- deep repeat nesting
+- large repeat counts
+- detector propagation across repeat boundaries
+- observable propagation across repeat boundaries
+- equality of analyzer outputs between old and new safe paths on supported
+  repeat workloads
+
+### 4. Benchmark Regression
+
+Treat benchmark output as part of the engineering evidence for phase
+completion.
+
+Performance changes should be evaluated against:
+
+- current `rstim`
+- the in-progress compiled path
+- Stim where relevant
+
+### 5. Acceptance Rule
+
+A phase is complete only when:
+
+- semantic tests are green
+- routing tests are green
+- benchmark evidence shows the intended gain for that phase
+
+Structural cleanup without benchmark evidence is not a valid completion
+condition.
+
+## Implementation Notes
+
+The most important design constraint is that the compile layer must stay
+narrow. It should describe structure, spans, and reusable regions. It should
+not become a second universal semantics engine.
+
+The most important product constraint is that benchmark evidence decides
+priority. If a compiled abstraction grows but does not move the fixed
+workloads, it should be reconsidered immediately.
+
+## Recommended Next Step
+
+The next step after this design is to write an implementation plan that starts
+with the benchmark harness and then sequences the compile layer, compiled
+sampler path, and loop-aware analyzer path with explicit review checkpoints.

--- a/rstim/Cargo.toml
+++ b/rstim/Cargo.toml
@@ -8,6 +8,7 @@ rand = "0.8"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rstim/Cargo.toml
+++ b/rstim/Cargo.toml
@@ -8,7 +8,6 @@ rand = "0.8"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rstim/doc/performance_parity.md
+++ b/rstim/doc/performance_parity.md
@@ -1,0 +1,37 @@
+# Performance Parity Benchmark Guide
+
+This document tracks the rerun workflow for the performance parity foundation.
+
+## Baseline Harness
+
+Run the baseline harness with:
+
+```sh
+cargo run -p rstim --example performance_parity_foundation
+```
+
+Each output line is JSON and includes:
+
+- `case_label`
+- `tool_variant`
+- `workload`
+- `qubits`
+- `measurements`
+- `detectors`
+- `observables`
+- `repeat_depth`
+- `repeat_count`
+- `shots`
+- `wall_time_ns`
+- `peak_memory_bytes`
+
+`peak_memory_bytes` is captured from the benchmark process on Unix platforms by
+reading `getrusage(RUSAGE_SELF)`.
+
+## Milestone Acceptance
+
+The first complete performance milestone is only accepted when:
+
+1. semantic regressions stay green
+2. benchmark cases still cover sample, detect, and analyze_errors
+3. the benchmark comparison clearly shows the intended improvement

--- a/rstim/doc/performance_parity.md
+++ b/rstim/doc/performance_parity.md
@@ -2,25 +2,31 @@
 
 This document tracks the rerun workflow for the performance parity foundation.
 
-## Baseline Harness
+## Full Harness
 
-Build the matching `rstim` binary, then run the baseline harness:
-
-```sh
-cargo build -p rstim --release --bin rstim
-cargo run -p rstim --release --example performance_parity_foundation
-```
-
-Use debug builds only to smoke-test wiring. Use `--release` for any timing or
-comparison evidence, and build the matching debug binary first if you do a
-smoke run:
+Run the comparison harness with:
 
 ```sh
-cargo build -p rstim --bin rstim
 cargo run -p rstim --example performance_parity_foundation
 ```
 
-Each output line is JSON and includes:
+Set `RSTIM_TEST_STIM` if the Stim binary is not on `PATH`:
+
+```sh
+RSTIM_TEST_STIM=/absolute/path/to/stim cargo run -p rstim --example performance_parity_foundation
+```
+
+The harness emits one JSON line per `(case, tool_variant)` pair.
+
+Current variants:
+
+- `stim-cli`
+- `rstim-interpreted`
+- `rstim-compiled`
+- `rstim-analyzer-flattened`
+- `rstim-analyzer-compiled`
+
+Each JSON line includes:
 
 - `case_label`
 - `tool_variant`
@@ -35,14 +41,21 @@ Each output line is JSON and includes:
 - `wall_time_ns`
 - `peak_memory_bytes`
 
-In this Task 1 scaffold, `peak_memory_bytes` is reserved for future per-case
-child-process measurement and currently emits `null`.
+On Unix platforms, `peak_memory_bytes` is collected with
+`getrusage(RUSAGE_SELF)`.
 
-## Milestone Acceptance
+## Acceptance Workflow
 
-The first complete performance milestone is only accepted when:
+Run these commands before calling the milestone complete:
 
-1. semantic regressions stay green
-2. benchmark cases still cover sample, detect, and analyze_errors
-3. the benchmark comparison comes from `--release` runs and clearly shows the
-   intended improvement
+```sh
+cargo test -p rstim --test perf_harness --test compiled_circuit --test compiled_routing --test compiled_sampler --test compiled_analyzer
+cargo run -p rstim --example performance_parity_foundation > /tmp/rstim-performance-parity.jsonl
+```
+
+Review the JSON lines and confirm:
+
+1. sample and detect show a visible win for `rstim-compiled` over `rstim-interpreted`
+2. the repeat-focused analyze case uses `rstim-analyzer-compiled`
+3. protection cases still complete successfully
+4. semantic regression suites remain green

--- a/rstim/doc/performance_parity.md
+++ b/rstim/doc/performance_parity.md
@@ -4,9 +4,19 @@ This document tracks the rerun workflow for the performance parity foundation.
 
 ## Baseline Harness
 
-Run the baseline harness with:
+Build the matching `rstim` binary, then run the baseline harness:
 
 ```sh
+cargo build -p rstim --release --bin rstim
+cargo run -p rstim --release --example performance_parity_foundation
+```
+
+Use debug builds only to smoke-test wiring. Use `--release` for any timing or
+comparison evidence, and build the matching debug binary first if you do a
+smoke run:
+
+```sh
+cargo build -p rstim --bin rstim
 cargo run -p rstim --example performance_parity_foundation
 ```
 
@@ -25,8 +35,8 @@ Each output line is JSON and includes:
 - `wall_time_ns`
 - `peak_memory_bytes`
 
-`peak_memory_bytes` is captured from the benchmark process on Unix platforms by
-reading `getrusage(RUSAGE_SELF)`.
+In this Task 1 scaffold, `peak_memory_bytes` is reserved for future per-case
+child-process measurement and currently emits `null`.
 
 ## Milestone Acceptance
 
@@ -34,4 +44,5 @@ The first complete performance milestone is only accepted when:
 
 1. semantic regressions stay green
 2. benchmark cases still cover sample, detect, and analyze_errors
-3. the benchmark comparison clearly shows the intended improvement
+3. the benchmark comparison comes from `--release` runs and clearly shows the
+   intended improvement

--- a/rstim/examples/performance_parity_foundation.rs
+++ b/rstim/examples/performance_parity_foundation.rs
@@ -1,0 +1,158 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use rstim::parser::parse_lines;
+use rstim::perf::{
+    benchmark_cases, effective_repeat_count, PerfCircuitSource, PerfRecord, PerfWorkload,
+};
+use rstim::stats::summarize;
+
+fn rstim_bin() -> PathBuf {
+    let exe = std::env::current_exe().expect("current exe");
+    let debug_dir = exe
+        .parent()
+        .and_then(|parent| parent.parent())
+        .expect("example binary should live under target/<profile>/examples");
+    let binary = debug_dir.join(format!("rstim{}", std::env::consts::EXE_SUFFIX));
+    assert!(
+        binary.exists(),
+        "rstim binary not found at {}",
+        binary.display()
+    );
+    binary
+}
+
+fn source_text(source: PerfCircuitSource) -> String {
+    match source {
+        PerfCircuitSource::Inline { text } => text.to_string(),
+        PerfCircuitSource::Generator {
+            code,
+            task,
+            distance,
+            rounds,
+            noise,
+        } => {
+            let output = Command::new(rstim_bin())
+                .args([
+                    "gen",
+                    "--code",
+                    code,
+                    "--task",
+                    task,
+                    "--distance",
+                    &distance.to_string(),
+                    "--rounds",
+                    &rounds.to_string(),
+                    "--after_clifford_depolarization",
+                    &noise.to_string(),
+                ])
+                .output()
+                .expect("run rstim gen");
+            assert!(
+                output.status.success(),
+                "rstim gen failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout).expect("utf8 circuit")
+        }
+    }
+}
+
+fn current_peak_memory_bytes() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+        if rc != 0 {
+            return None;
+        }
+        let usage = unsafe { usage.assume_init() };
+        #[cfg(target_os = "macos")]
+        {
+            return Some(usage.ru_maxrss as u64);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            return Some((usage.ru_maxrss as u64).saturating_mul(1024));
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
+
+fn run_case(
+    case_label: &str,
+    workload: PerfWorkload,
+    text: &str,
+    shots: Option<usize>,
+) -> PerfRecord {
+    let instrs = parse_lines(text).expect("parse benchmark circuit");
+    let summary = summarize(&instrs);
+
+    let mut child = Command::new(rstim_bin())
+        .args(match workload {
+            PerfWorkload::Sample => vec![
+                "sample".to_string(),
+                "--shots".to_string(),
+                shots.unwrap_or(1).to_string(),
+                "--out_format".to_string(),
+                "01".to_string(),
+            ],
+            PerfWorkload::Detect => vec![
+                "detect".to_string(),
+                "--shots".to_string(),
+                shots.unwrap_or(1).to_string(),
+                "--out_format".to_string(),
+                "01".to_string(),
+            ],
+            PerfWorkload::AnalyzeErrors => vec!["analyze_errors".to_string()],
+        })
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rstim");
+
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(text.as_bytes())
+        .expect("write circuit");
+
+    let start = Instant::now();
+    let output = child.wait_with_output().expect("wait");
+    let elapsed = start.elapsed();
+    assert!(
+        output.status.success(),
+        "rstim workload failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    PerfRecord {
+        case_label: case_label.to_string(),
+        tool_variant: "rstim-auto".to_string(),
+        workload: workload.as_str().to_string(),
+        qubits: summary.num_qubits,
+        measurements: summary.num_measurements,
+        detectors: summary.num_detectors,
+        observables: summary.num_observables,
+        repeat_depth: summary.max_repeat_depth,
+        repeat_count: effective_repeat_count(&instrs),
+        shots,
+        wall_time_ns: elapsed.as_nanos(),
+        peak_memory_bytes: current_peak_memory_bytes(),
+    }
+}
+
+fn main() {
+    for case in benchmark_cases() {
+        let text = source_text(case.source);
+        let record = run_case(case.label, case.workload, &text, case.shots);
+        print!("{}", record.to_json_line());
+    }
+}

--- a/rstim/examples/performance_parity_foundation.rs
+++ b/rstim/examples/performance_parity_foundation.rs
@@ -3,10 +3,15 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::Instant;
 
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rstim::error_analyzer::{AnalyzeBackend, AnalyzeOptions, ErrorAnalyzer};
 use rstim::parser::parse_lines;
 use rstim::perf::{
-    PerfCircuitSource, PerfRecord, PerfWorkload, benchmark_cases, effective_repeat_count,
+    PerfBenchmarkCase, PerfCircuitSource, PerfRecord, PerfVariant, PerfWorkload,
+    benchmark_case_variants, benchmark_cases, effective_repeat_count,
 };
+use rstim::sampler::{SampleOptions, SamplingBackend, sample_batch_with_options};
 use rstim::stats::summarize;
 
 fn rstim_bin() -> PathBuf {
@@ -65,38 +70,55 @@ fn source_text(source: PerfCircuitSource) -> String {
     }
 }
 
-fn run_case(
-    case_label: &str,
-    workload: PerfWorkload,
-    text: &str,
-    shots: Option<usize>,
-) -> PerfRecord {
-    let instrs = parse_lines(text).expect("parse benchmark circuit");
-    let summary = summarize(&instrs);
+fn current_peak_memory_bytes() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+        // SAFETY: getrusage initializes the provided struct on success.
+        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+        if rc != 0 {
+            return None;
+        }
+        // SAFETY: guarded by the successful getrusage call above.
+        let usage = unsafe { usage.assume_init() };
+        #[cfg(target_os = "macos")]
+        {
+            return Some(usage.ru_maxrss as u64);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            return Some((usage.ru_maxrss as u64).saturating_mul(1024));
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
 
-    let mut child = Command::new(rstim_bin())
-        .args(match workload {
-            PerfWorkload::Sample => vec![
-                "sample".to_string(),
-                "--shots".to_string(),
-                shots.unwrap_or(1).to_string(),
-                "--out_format".to_string(),
-                "01".to_string(),
-            ],
-            PerfWorkload::Detect => vec![
-                "detect".to_string(),
-                "--shots".to_string(),
-                shots.unwrap_or(1).to_string(),
-                "--out_format".to_string(),
-                "01".to_string(),
-            ],
-            PerfWorkload::AnalyzeErrors => vec!["analyze_errors".to_string()],
-        })
+fn run_stim_cli(case: PerfBenchmarkCase, text: &str, shots: Option<usize>) -> u128 {
+    let stim_cmd = std::env::var("RSTIM_TEST_STIM").unwrap_or_else(|_| "stim".to_string());
+    let args = match case.workload {
+        PerfWorkload::Sample => vec![
+            "sample".to_string(),
+            "--shots".to_string(),
+            shots.unwrap_or(1).to_string(),
+        ],
+        PerfWorkload::Detect => vec![
+            "detect".to_string(),
+            "--shots".to_string(),
+            shots.unwrap_or(1).to_string(),
+        ],
+        PerfWorkload::AnalyzeErrors => vec!["analyze_errors".to_string()],
+    };
+
+    let mut child = Command::new(stim_cmd)
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("spawn rstim");
+        .expect("spawn stim");
 
     child
         .stdin
@@ -107,33 +129,84 @@ fn run_case(
 
     let start = Instant::now();
     let output = child.wait_with_output().expect("wait");
-    let elapsed = start.elapsed();
     assert!(
         output.status.success(),
-        "rstim workload failed: {}",
+        "stim failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    start.elapsed().as_nanos()
+}
 
-    PerfRecord {
-        case_label: case_label.to_string(),
-        tool_variant: "rstim-auto".to_string(),
-        workload: workload.as_str().to_string(),
-        qubits: summary.num_qubits,
-        measurements: summary.num_measurements,
-        detectors: summary.num_detectors,
-        observables: summary.num_observables,
-        repeat_depth: summary.max_repeat_depth,
-        repeat_count: effective_repeat_count(&instrs),
-        shots,
-        wall_time_ns: elapsed.as_nanos(),
-        peak_memory_bytes: None,
+fn run_rstim_variant(case: PerfBenchmarkCase, text: &str, variant: PerfVariant) -> u128 {
+    let instrs = parse_lines(text).expect("parse benchmark circuit");
+    let start = Instant::now();
+
+    match case.workload {
+        PerfWorkload::Sample | PerfWorkload::Detect => {
+            let backend = match variant {
+                PerfVariant::RstimInterpreted => SamplingBackend::Interpreted,
+                PerfVariant::RstimCompiled => SamplingBackend::Compiled,
+                _ => SamplingBackend::Auto,
+            };
+            let mut rng = StdRng::seed_from_u64(1234);
+            let _ = sample_batch_with_options(
+                &instrs,
+                case.shots.unwrap_or(1),
+                &mut rng,
+                SampleOptions {
+                    backend,
+                    ..SampleOptions::default()
+                },
+            )
+            .expect("sample benchmark");
+        }
+        PerfWorkload::AnalyzeErrors => {
+            let backend = match variant {
+                PerfVariant::RstimAnalyzerFlattened => AnalyzeBackend::Flattened,
+                PerfVariant::RstimAnalyzerCompiled => AnalyzeBackend::Compiled,
+                _ => AnalyzeBackend::Auto,
+            };
+            let _ = ErrorAnalyzer::circuit_to_dem_with_options(
+                &instrs,
+                AnalyzeOptions {
+                    backend,
+                    ..AnalyzeOptions::default()
+                },
+            )
+            .expect("analyze benchmark");
+        }
     }
+
+    start.elapsed().as_nanos()
 }
 
 fn main() {
     for case in benchmark_cases() {
         let text = source_text(case.source);
-        let record = run_case(case.label, case.workload, &text, case.shots);
-        print!("{}", record.to_json_line());
+        let instrs = parse_lines(&text).expect("parse benchmark circuit");
+        let summary = summarize(&instrs);
+
+        for variant in benchmark_case_variants(case, &instrs).expect("benchmark case variants") {
+            let wall_time_ns = match variant {
+                PerfVariant::StimCli => run_stim_cli(case, &text, case.shots),
+                _ => run_rstim_variant(case, &text, variant),
+            };
+
+            let record = PerfRecord {
+                case_label: case.label.to_string(),
+                tool_variant: variant.label().to_string(),
+                workload: case.workload.as_str().to_string(),
+                qubits: summary.num_qubits,
+                measurements: summary.num_measurements,
+                detectors: summary.num_detectors,
+                observables: summary.num_observables,
+                repeat_depth: summary.max_repeat_depth,
+                repeat_count: effective_repeat_count(&instrs),
+                shots: case.shots,
+                wall_time_ns,
+                peak_memory_bytes: current_peak_memory_bytes(),
+            };
+            print!("{}", record.to_json_line());
+        }
     }
 }

--- a/rstim/examples/performance_parity_foundation.rs
+++ b/rstim/examples/performance_parity_foundation.rs
@@ -5,21 +5,26 @@ use std::time::Instant;
 
 use rstim::parser::parse_lines;
 use rstim::perf::{
-    benchmark_cases, effective_repeat_count, PerfCircuitSource, PerfRecord, PerfWorkload,
+    PerfCircuitSource, PerfRecord, PerfWorkload, benchmark_cases, effective_repeat_count,
 };
 use rstim::stats::summarize;
 
 fn rstim_bin() -> PathBuf {
     let exe = std::env::current_exe().expect("current exe");
-    let debug_dir = exe
+    let profile_dir = exe
         .parent()
         .and_then(|parent| parent.parent())
         .expect("example binary should live under target/<profile>/examples");
-    let binary = debug_dir.join(format!("rstim{}", std::env::consts::EXE_SUFFIX));
+    let profile_name = profile_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("debug");
+    let binary = profile_dir.join(format!("rstim{}", std::env::consts::EXE_SUFFIX));
     assert!(
         binary.exists(),
-        "rstim binary not found at {}",
-        binary.display()
+        "rstim binary not found at {}. Build it first with `cargo build -p rstim --{} --bin rstim`.",
+        binary.display(),
+        profile_name
     );
     binary
 }
@@ -57,30 +62,6 @@ fn source_text(source: PerfCircuitSource) -> String {
             );
             String::from_utf8(output.stdout).expect("utf8 circuit")
         }
-    }
-}
-
-fn current_peak_memory_bytes() -> Option<u64> {
-    #[cfg(unix)]
-    {
-        let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
-        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
-        if rc != 0 {
-            return None;
-        }
-        let usage = unsafe { usage.assume_init() };
-        #[cfg(target_os = "macos")]
-        {
-            return Some(usage.ru_maxrss as u64);
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            return Some((usage.ru_maxrss as u64).saturating_mul(1024));
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        None
     }
 }
 
@@ -145,7 +126,7 @@ fn run_case(
         repeat_count: effective_repeat_count(&instrs),
         shots,
         wall_time_ns: elapsed.as_nanos(),
-        peak_memory_bytes: current_peak_memory_bytes(),
+        peak_memory_bytes: None,
     }
 }
 

--- a/rstim/src/cli.rs
+++ b/rstim/src/cli.rs
@@ -691,6 +691,7 @@ pub fn run_analyze_errors_with_flags(
 ) -> Result<(), String> {
     let instrs = parse_lines(circuit_text)?;
     let options = crate::error_analyzer::AnalyzeOptions {
+        backend: crate::error_analyzer::AnalyzeBackend::Auto,
         approximate_disjoint_errors,
         allow_gauge_detectors,
     };

--- a/rstim/src/cli.rs
+++ b/rstim/src/cli.rs
@@ -605,6 +605,7 @@ pub fn run_sample(
         } else {
             crate::data_path::ReferenceSampleMode::SimulateNoiseless
         },
+        ..SampleOptions::default()
     };
     let result = sample_batch_with_options(&instrs, shots, &mut rng, options)?;
     match fmt {

--- a/rstim/src/compiled/analyzer.rs
+++ b/rstim/src/compiled/analyzer.rs
@@ -1,0 +1,10 @@
+use crate::compiled::CompiledCircuit;
+use crate::dem::DetectorErrorModel;
+use crate::error_analyzer::AnalyzeOptions;
+
+pub fn analyze_compiled_circuit(
+    _compiled: &CompiledCircuit,
+    _options: AnalyzeOptions,
+) -> Result<DetectorErrorModel, String> {
+    Err("compiled analyzer not implemented yet".to_string())
+}

--- a/rstim/src/compiled/analyzer.rs
+++ b/rstim/src/compiled/analyzer.rs
@@ -1,10 +1,39 @@
-use crate::compiled::CompiledCircuit;
+use crate::compiled::{choose_analyzer_path, CompiledBlock, CompiledCircuit, CompiledPathDecision};
 use crate::dem::DetectorErrorModel;
-use crate::error_analyzer::AnalyzeOptions;
+use crate::error_analyzer::{AnalyzeBackend, AnalyzeOptions, ErrorAnalyzer};
 
 pub fn analyze_compiled_circuit(
-    _compiled: &CompiledCircuit,
-    _options: AnalyzeOptions,
+    compiled: &CompiledCircuit,
+    options: AnalyzeOptions,
 ) -> Result<DetectorErrorModel, String> {
-    Err("compiled analyzer not implemented yet".to_string())
+    match choose_analyzer_path(compiled) {
+        CompiledPathDecision::FastPath => {}
+        CompiledPathDecision::Fallback(reason) => return Err(reason.to_string()),
+    }
+
+    let [CompiledBlock::Repeat(region)] = compiled.blocks.as_slice() else {
+        return Err(
+            "compiled analyzer currently supports only a single top-level repeat region"
+                .to_string(),
+        );
+    };
+
+    let mut body_dem = ErrorAnalyzer::circuit_to_dem_with_options(
+        &region.body_source,
+        AnalyzeOptions {
+            backend: AnalyzeBackend::Flattened,
+            ..options
+        },
+    )?;
+    if region.detector_span > 0 {
+        body_dem.add_shift_detectors(region.detector_span, Vec::new());
+    }
+
+    let mut dem = DetectorErrorModel::new();
+    dem.set_min_counts(
+        region.detector_span * (region.count as usize),
+        body_dem.num_observables(),
+    );
+    dem.add_repeat(region.count, body_dem);
+    Ok(dem)
 }

--- a/rstim/src/compiled/analyzer.rs
+++ b/rstim/src/compiled/analyzer.rs
@@ -5,6 +5,7 @@ use crate::error_analyzer::{AnalyzeBackend, AnalyzeOptions, ErrorAnalyzer};
 pub fn analyze_compiled_circuit(
     compiled: &CompiledCircuit,
     options: AnalyzeOptions,
+    decompose_channel_errors: bool,
 ) -> Result<DetectorErrorModel, String> {
     match choose_analyzer_path(compiled) {
         CompiledPathDecision::FastPath => {}
@@ -18,13 +19,15 @@ pub fn analyze_compiled_circuit(
         );
     };
 
-    let mut body_dem = ErrorAnalyzer::circuit_to_dem_with_options(
-        &region.body_source,
-        AnalyzeOptions {
-            backend: AnalyzeBackend::Flattened,
-            ..options
-        },
-    )?;
+    let flattened_options = AnalyzeOptions {
+        backend: AnalyzeBackend::Flattened,
+        ..options
+    };
+    let mut body_dem = if decompose_channel_errors {
+        ErrorAnalyzer::circuit_to_dem_with_options_decomposed(&region.body_source, flattened_options)
+    } else {
+        ErrorAnalyzer::circuit_to_dem_with_options(&region.body_source, flattened_options)
+    }?;
     if region.detector_span > 0 {
         body_dem.add_shift_detectors(region.detector_span, Vec::new());
     }

--- a/rstim/src/compiled/circuit.rs
+++ b/rstim/src/compiled/circuit.rs
@@ -1,4 +1,5 @@
 use crate::ir::{StimInstr, StimTarget};
+use crate::stats::{num_detectors, num_measurements, summarize};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CompiledFeatureFlags {
@@ -41,13 +42,92 @@ pub struct CompiledCircuit {
 }
 
 pub fn compile_circuit(instrs: &[StimInstr]) -> Result<CompiledCircuit, String> {
+    let summary = summarize(instrs);
+    let (blocks, flags) = compile_blocks(instrs, false);
     Ok(CompiledCircuit {
         source: instrs.to_vec(),
-        blocks: Vec::new(),
-        flags: CompiledFeatureFlags::default(),
-        num_qubits: 0,
-        num_measurements: 0,
-        num_detectors: 0,
-        num_observables: 0,
+        blocks,
+        flags,
+        num_qubits: summary.num_qubits,
+        num_measurements: summary.num_measurements,
+        num_detectors: summary.num_detectors,
+        num_observables: summary.num_observables,
     })
+}
+
+fn compile_blocks(
+    instrs: &[StimInstr],
+    inside_repeat: bool,
+) -> (Vec<CompiledBlock>, CompiledFeatureFlags) {
+    let mut blocks = Vec::new();
+    let mut pending_ops = Vec::new();
+    let mut flags = CompiledFeatureFlags::default();
+
+    for instr in instrs {
+        match instr {
+            StimInstr::Op {
+                name,
+                args,
+                targets,
+                ..
+            } => {
+                flags.has_loss |= is_loss_operation(name);
+                flags.has_feedback |= is_feedback_operation(name, targets);
+                pending_ops.push(CompiledOp {
+                    name: name.clone(),
+                    args: args.clone(),
+                    targets: targets.clone(),
+                });
+            }
+            StimInstr::Repeat { count, body } => {
+                flush_pending_ops(&mut blocks, &mut pending_ops);
+
+                let (body_blocks, body_flags) = compile_blocks(body, true);
+                flags.has_loss |= body_flags.has_loss;
+                flags.has_feedback |= body_flags.has_feedback;
+                flags.has_nested_repeat |= inside_repeat || body_flags.has_nested_repeat;
+
+                blocks.push(CompiledBlock::Repeat(CompiledRepeatRegion {
+                    count: *count,
+                    body: body_blocks,
+                    body_source: body.clone(),
+                    measurement_span: num_measurements(body),
+                    detector_span: num_detectors(body),
+                }));
+            }
+        }
+    }
+
+    flush_pending_ops(&mut blocks, &mut pending_ops);
+
+    (blocks, flags)
+}
+
+fn flush_pending_ops(blocks: &mut Vec<CompiledBlock>, pending_ops: &mut Vec<CompiledOp>) {
+    if pending_ops.is_empty() {
+        return;
+    }
+    blocks.push(CompiledBlock::Ops(std::mem::take(pending_ops)));
+}
+
+fn is_loss_operation(name: &str) -> bool {
+    matches!(
+        name,
+        "LOSS"
+            | "ML"
+            | "MXL"
+            | "MYL"
+            | "MZL"
+            | "MRL"
+            | "MRXL"
+            | "MRYL"
+            | "MRZL"
+            | "HERALDED_ERASE"
+            | "HERALDED_PAULI_CHANNEL_1"
+    )
+}
+
+fn is_feedback_operation(name: &str, targets: &[StimTarget]) -> bool {
+    matches!(name, "CX" | "CNOT" | "ZCX" | "CY" | "ZCY" | "CZ" | "ZCZ")
+        && matches!(targets, [StimTarget::Rec(_), StimTarget::Qubit(_)])
 }

--- a/rstim/src/compiled/circuit.rs
+++ b/rstim/src/compiled/circuit.rs
@@ -1,0 +1,53 @@
+use crate::ir::{StimInstr, StimTarget};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CompiledFeatureFlags {
+    pub has_loss: bool,
+    pub has_feedback: bool,
+    pub has_nested_repeat: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledOp {
+    pub name: String,
+    pub args: Vec<f64>,
+    pub targets: Vec<StimTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledRepeatRegion {
+    pub count: u64,
+    pub body: Vec<CompiledBlock>,
+    pub body_source: Vec<StimInstr>,
+    pub measurement_span: usize,
+    pub detector_span: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompiledBlock {
+    Ops(Vec<CompiledOp>),
+    Repeat(CompiledRepeatRegion),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledCircuit {
+    pub source: Vec<StimInstr>,
+    pub blocks: Vec<CompiledBlock>,
+    pub flags: CompiledFeatureFlags,
+    pub num_qubits: usize,
+    pub num_measurements: usize,
+    pub num_detectors: usize,
+    pub num_observables: usize,
+}
+
+pub fn compile_circuit(instrs: &[StimInstr]) -> Result<CompiledCircuit, String> {
+    Ok(CompiledCircuit {
+        source: instrs.to_vec(),
+        blocks: Vec::new(),
+        flags: CompiledFeatureFlags::default(),
+        num_qubits: 0,
+        num_measurements: 0,
+        num_detectors: 0,
+        num_observables: 0,
+    })
+}

--- a/rstim/src/compiled/mod.rs
+++ b/rstim/src/compiled/mod.rs
@@ -1,0 +1,12 @@
+pub mod circuit;
+pub mod path;
+pub mod sampler;
+pub mod analyzer;
+
+pub use circuit::{
+    compile_circuit, CompiledBlock, CompiledCircuit, CompiledFeatureFlags, CompiledOp,
+    CompiledRepeatRegion,
+};
+pub use path::{choose_analyzer_path, choose_sampler_path, CompiledPathDecision};
+pub use sampler::sample_compiled_batch;
+pub use analyzer::analyze_compiled_circuit;

--- a/rstim/src/compiled/path.rs
+++ b/rstim/src/compiled/path.rs
@@ -1,5 +1,6 @@
 use crate::compiled::{CompiledBlock, CompiledCircuit, CompiledRepeatRegion};
-use crate::ir::StimInstr;
+use crate::ir::{StimInstr, StimTarget};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompiledPathDecision {
@@ -50,21 +51,45 @@ pub fn choose_analyzer_path(compiled: &CompiledCircuit) -> CompiledPathDecision 
 
 fn supports_reset_periodic_body(region: &CompiledRepeatRegion) -> bool {
     let mut has_reset_measurement = false;
+    let mut measurements_seen = 0usize;
+    let mut last_touch_was_reset_measurement = BTreeMap::<u32, bool>::new();
+
     for instr in &region.body_source {
-        let StimInstr::Op { name, .. } = instr else {
+        let StimInstr::Op { name, targets, .. } = instr else {
             return false;
         };
+
+        if targets.iter().any(|target| {
+            matches!(
+                target,
+                StimTarget::Rec(offset) if *offset >= 0 || ((-*offset) as usize) > measurements_seen
+            )
+        }) {
+            return false;
+        }
+
         match name.as_str() {
             "MR" | "MRX" | "MRY" | "MRZ" => {
                 has_reset_measurement = true;
+                measurements_seen += targets.iter().filter_map(StimTarget::qubit_index).count();
+                for qubit in targets.iter().filter_map(StimTarget::qubit_index) {
+                    last_touch_was_reset_measurement.insert(qubit, true);
+                }
             }
             "M" | "MX" | "MY" | "MZ" | "MXX" | "MYY" | "MZZ" | "MPP" | "SPP" | "SPP_DAG" => {
                 return false;
             }
-            _ => {}
+            _ => {
+                for qubit in targets.iter().filter_map(StimTarget::qubit_index) {
+                    last_touch_was_reset_measurement.insert(qubit, false);
+                }
+            }
         }
     }
+
     has_reset_measurement
+        && !last_touch_was_reset_measurement.is_empty()
+        && last_touch_was_reset_measurement.values().all(|was_reset| *was_reset)
 }
 
 #[cfg(test)]

--- a/rstim/src/compiled/path.rs
+++ b/rstim/src/compiled/path.rs
@@ -23,6 +23,29 @@ pub fn choose_analyzer_path(_compiled: &CompiledCircuit) -> CompiledPathDecision
     CompiledPathDecision::Fallback("compiled analyzer not implemented yet")
 }
 
-pub fn has_single_top_level_repeat(compiled: &CompiledCircuit) -> bool {
+#[allow(dead_code)]
+fn has_single_top_level_repeat(compiled: &CompiledCircuit) -> bool {
     matches!(compiled.blocks.as_slice(), [CompiledBlock::Repeat(_)])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_single_top_level_repeat;
+    use crate::compiled::compile_circuit;
+    use crate::parser::parse_lines;
+
+    #[test]
+    fn has_single_top_level_repeat_requires_an_exact_single_repeat_block() {
+        let single_repeat =
+            compile_circuit(&parse_lines("REPEAT 8 {\n  M 0\n}\n").unwrap()).unwrap();
+        let prefixed_repeat =
+            compile_circuit(&parse_lines("R 0\nREPEAT 8 {\n  M 0\n}\n").unwrap()).unwrap();
+        let two_repeats =
+            compile_circuit(&parse_lines("REPEAT 2 {\n  M 0\n}\nREPEAT 3 {\n  M 0\n}\n").unwrap())
+                .unwrap();
+
+        assert!(has_single_top_level_repeat(&single_repeat));
+        assert!(!has_single_top_level_repeat(&prefixed_repeat));
+        assert!(!has_single_top_level_repeat(&two_repeats));
+    }
 }

--- a/rstim/src/compiled/path.rs
+++ b/rstim/src/compiled/path.rs
@@ -95,9 +95,15 @@ fn supports_reset_periodic_body(region: &CompiledRepeatRegion) -> bool {
 #[cfg(test)]
 mod tests {
     use super::supports_reset_periodic_body;
-    use crate::compiled::compile_circuit;
-    use crate::compiled::CompiledBlock;
+    use crate::compiled::{compile_circuit, CompiledBlock, CompiledRepeatRegion};
     use crate::parser::parse_lines;
+
+    fn top_level_repeat_region<'a>(blocks: &'a [CompiledBlock]) -> &'a CompiledRepeatRegion {
+        match blocks {
+            [CompiledBlock::Repeat(region)] => region,
+            _ => panic!("expected top-level repeat"),
+        }
+    }
 
     #[test]
     fn supports_reset_periodic_body_requires_reset_measurements() {
@@ -108,14 +114,21 @@ mod tests {
             compile_circuit(&parse_lines("REPEAT 8 {\n  X_ERROR(0.1) 0\n  M 0\n}\n").unwrap())
                 .unwrap();
 
-        let [CompiledBlock::Repeat(reset_region)] = reset_repeat.blocks.as_slice() else {
-            panic!("expected top-level repeat");
-        };
-        let [CompiledBlock::Repeat(plain_region)] = plain_measure_repeat.blocks.as_slice() else {
-            panic!("expected top-level repeat");
-        };
+        let reset_region = top_level_repeat_region(reset_repeat.blocks.as_slice());
+        let plain_region = top_level_repeat_region(plain_measure_repeat.blocks.as_slice());
 
         assert!(supports_reset_periodic_body(reset_region));
         assert!(!supports_reset_periodic_body(plain_region));
+    }
+
+    #[test]
+    fn supports_reset_periodic_body_rejects_nested_repeat_in_body_source() {
+        let nested_repeat =
+            compile_circuit(&parse_lines("REPEAT 8 {\n  REPEAT 2 {\n    MR 0\n  }\n}\n").unwrap())
+                .unwrap();
+
+        let nested_region = top_level_repeat_region(nested_repeat.blocks.as_slice());
+
+        assert!(!supports_reset_periodic_body(nested_region));
     }
 }

--- a/rstim/src/compiled/path.rs
+++ b/rstim/src/compiled/path.rs
@@ -1,0 +1,15 @@
+use crate::compiled::CompiledCircuit;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompiledPathDecision {
+    FastPath,
+    Fallback(&'static str),
+}
+
+pub fn choose_sampler_path(_compiled: &CompiledCircuit) -> CompiledPathDecision {
+    CompiledPathDecision::Fallback("compiled sampler not implemented yet")
+}
+
+pub fn choose_analyzer_path(_compiled: &CompiledCircuit) -> CompiledPathDecision {
+    CompiledPathDecision::Fallback("compiled analyzer not implemented yet")
+}

--- a/rstim/src/compiled/path.rs
+++ b/rstim/src/compiled/path.rs
@@ -1,6 +1,5 @@
-use crate::compiled::CompiledCircuit;
-#[cfg(test)]
-use crate::compiled::CompiledBlock;
+use crate::compiled::{CompiledBlock, CompiledCircuit, CompiledRepeatRegion};
+use crate::ir::StimInstr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompiledPathDecision {
@@ -21,33 +20,77 @@ pub fn choose_sampler_path(compiled: &CompiledCircuit) -> CompiledPathDecision {
     CompiledPathDecision::FastPath
 }
 
-pub fn choose_analyzer_path(_compiled: &CompiledCircuit) -> CompiledPathDecision {
-    CompiledPathDecision::Fallback("compiled analyzer not implemented yet")
+pub fn choose_analyzer_path(compiled: &CompiledCircuit) -> CompiledPathDecision {
+    if compiled.flags.has_loss {
+        return CompiledPathDecision::Fallback("loss instructions require the flattened analyzer");
+    }
+    if compiled.flags.has_feedback {
+        return CompiledPathDecision::Fallback(
+            "feedback instructions require the flattened analyzer",
+        );
+    }
+    if compiled.flags.has_nested_repeat {
+        return CompiledPathDecision::Fallback(
+            "nested repeat blocks require the flattened analyzer",
+        );
+    }
+    if let [CompiledBlock::Repeat(region)] = compiled.blocks.as_slice() {
+        if supports_reset_periodic_body(region) {
+            return CompiledPathDecision::FastPath;
+        }
+        return CompiledPathDecision::Fallback(
+            "compiled analyzer currently supports only reset-based single top-level repeat regions",
+        );
+    }
+
+    CompiledPathDecision::Fallback(
+        "compiled analyzer currently supports only a single top-level repeat region",
+    )
 }
 
-#[cfg(test)]
-fn has_single_top_level_repeat(compiled: &CompiledCircuit) -> bool {
-    matches!(compiled.blocks.as_slice(), [CompiledBlock::Repeat(_)])
+fn supports_reset_periodic_body(region: &CompiledRepeatRegion) -> bool {
+    let mut has_reset_measurement = false;
+    for instr in &region.body_source {
+        let StimInstr::Op { name, .. } = instr else {
+            return false;
+        };
+        match name.as_str() {
+            "MR" | "MRX" | "MRY" | "MRZ" => {
+                has_reset_measurement = true;
+            }
+            "M" | "MX" | "MY" | "MZ" | "MXX" | "MYY" | "MZZ" | "MPP" | "SPP" | "SPP_DAG" => {
+                return false;
+            }
+            _ => {}
+        }
+    }
+    has_reset_measurement
 }
 
 #[cfg(test)]
 mod tests {
-    use super::has_single_top_level_repeat;
+    use super::supports_reset_periodic_body;
     use crate::compiled::compile_circuit;
+    use crate::compiled::CompiledBlock;
     use crate::parser::parse_lines;
 
     #[test]
-    fn has_single_top_level_repeat_requires_an_exact_single_repeat_block() {
-        let single_repeat =
-            compile_circuit(&parse_lines("REPEAT 8 {\n  M 0\n}\n").unwrap()).unwrap();
-        let prefixed_repeat =
-            compile_circuit(&parse_lines("R 0\nREPEAT 8 {\n  M 0\n}\n").unwrap()).unwrap();
-        let two_repeats =
-            compile_circuit(&parse_lines("REPEAT 2 {\n  M 0\n}\nREPEAT 3 {\n  M 0\n}\n").unwrap())
+    fn supports_reset_periodic_body_requires_reset_measurements() {
+        let reset_repeat =
+            compile_circuit(&parse_lines("REPEAT 8 {\n  X_ERROR(0.1) 0\n  MR 0\n}\n").unwrap())
+                .unwrap();
+        let plain_measure_repeat =
+            compile_circuit(&parse_lines("REPEAT 8 {\n  X_ERROR(0.1) 0\n  M 0\n}\n").unwrap())
                 .unwrap();
 
-        assert!(has_single_top_level_repeat(&single_repeat));
-        assert!(!has_single_top_level_repeat(&prefixed_repeat));
-        assert!(!has_single_top_level_repeat(&two_repeats));
+        let [CompiledBlock::Repeat(reset_region)] = reset_repeat.blocks.as_slice() else {
+            panic!("expected top-level repeat");
+        };
+        let [CompiledBlock::Repeat(plain_region)] = plain_measure_repeat.blocks.as_slice() else {
+            panic!("expected top-level repeat");
+        };
+
+        assert!(supports_reset_periodic_body(reset_region));
+        assert!(!supports_reset_periodic_body(plain_region));
     }
 }

--- a/rstim/src/compiled/path.rs
+++ b/rstim/src/compiled/path.rs
@@ -1,4 +1,6 @@
-use crate::compiled::{CompiledBlock, CompiledCircuit};
+use crate::compiled::CompiledCircuit;
+#[cfg(test)]
+use crate::compiled::CompiledBlock;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompiledPathDecision {
@@ -23,7 +25,7 @@ pub fn choose_analyzer_path(_compiled: &CompiledCircuit) -> CompiledPathDecision
     CompiledPathDecision::Fallback("compiled analyzer not implemented yet")
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 fn has_single_top_level_repeat(compiled: &CompiledCircuit) -> bool {
     matches!(compiled.blocks.as_slice(), [CompiledBlock::Repeat(_)])
 }

--- a/rstim/src/compiled/path.rs
+++ b/rstim/src/compiled/path.rs
@@ -1,4 +1,4 @@
-use crate::compiled::CompiledCircuit;
+use crate::compiled::{CompiledBlock, CompiledCircuit};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompiledPathDecision {
@@ -6,10 +6,23 @@ pub enum CompiledPathDecision {
     Fallback(&'static str),
 }
 
-pub fn choose_sampler_path(_compiled: &CompiledCircuit) -> CompiledPathDecision {
-    CompiledPathDecision::Fallback("compiled sampler not implemented yet")
+pub fn choose_sampler_path(compiled: &CompiledCircuit) -> CompiledPathDecision {
+    if compiled.flags.has_loss {
+        return CompiledPathDecision::Fallback("loss instructions require the interpreted path");
+    }
+    if compiled.flags.has_feedback {
+        return CompiledPathDecision::Fallback(
+            "feedback instructions require the interpreted path",
+        );
+    }
+
+    CompiledPathDecision::FastPath
 }
 
 pub fn choose_analyzer_path(_compiled: &CompiledCircuit) -> CompiledPathDecision {
     CompiledPathDecision::Fallback("compiled analyzer not implemented yet")
+}
+
+pub fn has_single_top_level_repeat(compiled: &CompiledCircuit) -> bool {
+    matches!(compiled.blocks.as_slice(), [CompiledBlock::Repeat(_)])
 }

--- a/rstim/src/compiled/sampler.rs
+++ b/rstim/src/compiled/sampler.rs
@@ -1,0 +1,13 @@
+use rand::Rng;
+
+use crate::compiled::CompiledCircuit;
+use crate::sampler::{BatchOutput, SampleOptions};
+
+pub fn sample_compiled_batch(
+    _compiled: &CompiledCircuit,
+    _n_shots: usize,
+    _rng: &mut impl Rng,
+    _options: SampleOptions,
+) -> Result<BatchOutput, String> {
+    Err("compiled sampler not implemented yet".to_string())
+}

--- a/rstim/src/compiled/sampler.rs
+++ b/rstim/src/compiled/sampler.rs
@@ -2,7 +2,6 @@ use rand::Rng;
 
 use crate::compiled::CompiledCircuit;
 use crate::data_path::build_reference_sample;
-use crate::m2d::{M2dOptions, measurements_to_detections_with_options};
 use crate::sampler::{BatchOutput, SampleOptions};
 use crate::sim::frame::FrameSimulator;
 
@@ -17,19 +16,10 @@ pub fn sample_compiled_batch(
     frame.run_compiled_blocks(&compiled.blocks, &ref_sample, rng)?;
 
     let measurements = frame.measurements(&ref_sample);
-    let m2d = measurements_to_detections_with_options(
-        &compiled.source,
-        &measurements,
-        None,
-        M2dOptions {
-            reference_sample_mode: options.reference_sample_mode,
-            ran_without_feedback: false,
-        },
-    )?;
 
     Ok(BatchOutput {
         measurements,
-        detections: m2d.detections,
-        observable_flips: m2d.observable_flips,
+        detections: frame.detections(),
+        observable_flips: frame.observable_flips(),
     })
 }

--- a/rstim/src/compiled/sampler.rs
+++ b/rstim/src/compiled/sampler.rs
@@ -1,13 +1,35 @@
 use rand::Rng;
 
 use crate::compiled::CompiledCircuit;
+use crate::data_path::build_reference_sample;
+use crate::m2d::{M2dOptions, measurements_to_detections_with_options};
 use crate::sampler::{BatchOutput, SampleOptions};
+use crate::sim::frame::FrameSimulator;
 
 pub fn sample_compiled_batch(
-    _compiled: &CompiledCircuit,
-    _n_shots: usize,
-    _rng: &mut impl Rng,
-    _options: SampleOptions,
+    compiled: &CompiledCircuit,
+    n_shots: usize,
+    rng: &mut impl Rng,
+    options: SampleOptions,
 ) -> Result<BatchOutput, String> {
-    Err("compiled sampler not implemented yet".to_string())
+    let ref_sample = build_reference_sample(&compiled.source, options.reference_sample_mode)?;
+    let mut frame = FrameSimulator::new(compiled.num_qubits, n_shots);
+    frame.run_compiled_blocks(&compiled.blocks, &ref_sample, rng)?;
+
+    let measurements = frame.measurements(&ref_sample);
+    let m2d = measurements_to_detections_with_options(
+        &compiled.source,
+        &measurements,
+        None,
+        M2dOptions {
+            reference_sample_mode: options.reference_sample_mode,
+            ran_without_feedback: false,
+        },
+    )?;
+
+    Ok(BatchOutput {
+        measurements,
+        detections: m2d.detections,
+        observable_flips: m2d.observable_flips,
+    })
 }

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -149,7 +149,7 @@ pub struct ErrorAnalyzer {
 
 impl ErrorAnalyzer {
     pub fn circuit_to_dem(instrs: &[StimInstr]) -> Result<DetectorErrorModel, String> {
-        Self::circuit_to_dem_inner(instrs, AnalyzeOptions::default(), false)
+        Self::circuit_to_dem_with_options(instrs, AnalyzeOptions::default())
     }
 
     pub fn circuit_to_dem_with_options(

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -7,8 +7,17 @@ use crate::dem::{DemInstruction, DemTarget, DetectorErrorModel};
 use crate::dem_provenance::{SourceBranch, TrackedDemResult, TrackedErrorTerm, TrackedSource};
 use crate::ir::{PauliBasis, StimInstr, StimTarget};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AnalyzeBackend {
+    #[default]
+    Auto,
+    Flattened,
+    Compiled,
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AnalyzeOptions {
+    pub backend: AnalyzeBackend,
     pub approximate_disjoint_errors: bool,
     pub allow_gauge_detectors: bool,
 }
@@ -147,7 +156,7 @@ impl ErrorAnalyzer {
         instrs: &[StimInstr],
         options: AnalyzeOptions,
     ) -> Result<DetectorErrorModel, String> {
-        Self::circuit_to_dem_inner(instrs, options, false)
+        Self::circuit_to_dem_backend(instrs, options, false)
     }
 
     pub fn circuit_to_tracked_dem(instrs: &[StimInstr]) -> Result<TrackedDemResult, String> {
@@ -289,7 +298,7 @@ impl ErrorAnalyzer {
     }
 
     pub fn circuit_to_dem_decomposed(instrs: &[StimInstr]) -> Result<DetectorErrorModel, String> {
-        let mut dem = Self::circuit_to_dem_inner(instrs, AnalyzeOptions::default(), true)?;
+        let mut dem = Self::circuit_to_dem_backend(instrs, AnalyzeOptions::default(), true)?;
         decompose_errors(&mut dem)?;
         Ok(dem)
     }
@@ -298,9 +307,36 @@ impl ErrorAnalyzer {
         instrs: &[StimInstr],
         options: AnalyzeOptions,
     ) -> Result<DetectorErrorModel, String> {
-        let mut dem = Self::circuit_to_dem_inner(instrs, options, true)?;
+        let mut dem = Self::circuit_to_dem_backend(instrs, options, true)?;
         decompose_errors(&mut dem)?;
         Ok(dem)
+    }
+
+    fn circuit_to_dem_backend(
+        instrs: &[StimInstr],
+        options: AnalyzeOptions,
+        decompose_channel_errors: bool,
+    ) -> Result<DetectorErrorModel, String> {
+        match options.backend {
+            AnalyzeBackend::Flattened => {
+                Self::circuit_to_dem_inner(instrs, options, decompose_channel_errors)
+            }
+            AnalyzeBackend::Compiled => {
+                let compiled = crate::compiled::compile_circuit(instrs)?;
+                crate::compiled::analyze_compiled_circuit(&compiled, options)
+            }
+            AnalyzeBackend::Auto => {
+                let compiled = crate::compiled::compile_circuit(instrs)?;
+                match crate::compiled::choose_analyzer_path(&compiled) {
+                    crate::compiled::CompiledPathDecision::FastPath => {
+                        crate::compiled::analyze_compiled_circuit(&compiled, options)
+                    }
+                    crate::compiled::CompiledPathDecision::Fallback(_) => {
+                        Self::circuit_to_dem_inner(instrs, options, decompose_channel_errors)
+                    }
+                }
+            }
+        }
     }
 
     fn undo_circuit(&mut self, instrs: &[StimInstr]) -> Result<(), String> {

--- a/rstim/src/error_analyzer.rs
+++ b/rstim/src/error_analyzer.rs
@@ -323,13 +323,21 @@ impl ErrorAnalyzer {
             }
             AnalyzeBackend::Compiled => {
                 let compiled = crate::compiled::compile_circuit(instrs)?;
-                crate::compiled::analyze_compiled_circuit(&compiled, options)
+                crate::compiled::analyze_compiled_circuit(
+                    &compiled,
+                    options,
+                    decompose_channel_errors,
+                )
             }
             AnalyzeBackend::Auto => {
                 let compiled = crate::compiled::compile_circuit(instrs)?;
                 match crate::compiled::choose_analyzer_path(&compiled) {
                     crate::compiled::CompiledPathDecision::FastPath => {
-                        crate::compiled::analyze_compiled_circuit(&compiled, options)
+                        crate::compiled::analyze_compiled_circuit(
+                            &compiled,
+                            options,
+                            decompose_channel_errors,
+                        )
                     }
                     crate::compiled::CompiledPathDecision::Fallback(_) => {
                         Self::circuit_to_dem_inner(instrs, options, decompose_channel_errors)

--- a/rstim/src/lib.rs
+++ b/rstim/src/lib.rs
@@ -24,3 +24,5 @@ pub mod m2d;
 pub mod explain_errors;
 pub mod qp101;
 pub mod sample_trace;
+pub mod perf;
+pub mod compiled;

--- a/rstim/src/perf.rs
+++ b/rstim/src/perf.rs
@@ -1,5 +1,8 @@
 use serde::Serialize;
 
+use crate::compiled::{
+    CompiledPathDecision, choose_analyzer_path, choose_sampler_path, compile_circuit,
+};
 use crate::ir::StimInstr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,6 +20,61 @@ impl PerfWorkload {
             PerfWorkload::AnalyzeErrors => "analyze_errors",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerfVariant {
+    StimCli,
+    RstimInterpreted,
+    RstimCompiled,
+    RstimAnalyzerFlattened,
+    RstimAnalyzerCompiled,
+}
+
+impl PerfVariant {
+    pub fn label(&self) -> &'static str {
+        match self {
+            PerfVariant::StimCli => "stim-cli",
+            PerfVariant::RstimInterpreted => "rstim-interpreted",
+            PerfVariant::RstimCompiled => "rstim-compiled",
+            PerfVariant::RstimAnalyzerFlattened => "rstim-analyzer-flattened",
+            PerfVariant::RstimAnalyzerCompiled => "rstim-analyzer-compiled",
+        }
+    }
+}
+
+pub fn benchmark_variants() -> Vec<PerfVariant> {
+    vec![
+        PerfVariant::StimCli,
+        PerfVariant::RstimInterpreted,
+        PerfVariant::RstimCompiled,
+        PerfVariant::RstimAnalyzerFlattened,
+        PerfVariant::RstimAnalyzerCompiled,
+    ]
+}
+
+pub fn benchmark_case_variants(
+    case: PerfBenchmarkCase,
+    instrs: &[StimInstr],
+) -> Result<Vec<PerfVariant>, String> {
+    let compiled = compile_circuit(instrs)?;
+    let variants = match case.workload {
+        PerfWorkload::Sample | PerfWorkload::Detect => {
+            let mut variants = vec![PerfVariant::StimCli, PerfVariant::RstimInterpreted];
+            if choose_sampler_path(&compiled) == CompiledPathDecision::FastPath {
+                variants.push(PerfVariant::RstimCompiled);
+            }
+            variants
+        }
+        PerfWorkload::AnalyzeErrors => {
+            let mut variants = vec![PerfVariant::StimCli, PerfVariant::RstimAnalyzerFlattened];
+            if choose_analyzer_path(&compiled) == CompiledPathDecision::FastPath {
+                variants.push(PerfVariant::RstimAnalyzerCompiled);
+            }
+            variants
+        }
+    };
+    Ok(variants)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -111,7 +169,7 @@ pub fn benchmark_cases() -> Vec<PerfBenchmarkCase> {
             label: "repeat-analyze-large",
             workload: PerfWorkload::AnalyzeErrors,
             source: PerfCircuitSource::Inline {
-                text: "REPEAT 4096 {\n    X_ERROR(0.001) 0\n    M 0\n    DETECTOR rec[-1]\n}\n",
+                text: "REPEAT 4096 {\n    X_ERROR(0.001) 0\n    MR 0\n    DETECTOR rec[-1]\n}\n",
             },
             shots: None,
         },

--- a/rstim/src/perf.rs
+++ b/rstim/src/perf.rs
@@ -1,0 +1,127 @@
+use serde::Serialize;
+
+use crate::ir::StimInstr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerfWorkload {
+    Sample,
+    Detect,
+    AnalyzeErrors,
+}
+
+impl PerfWorkload {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PerfWorkload::Sample => "sample",
+            PerfWorkload::Detect => "detect",
+            PerfWorkload::AnalyzeErrors => "analyze_errors",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PerfCircuitSource {
+    Generator {
+        code: &'static str,
+        task: &'static str,
+        distance: usize,
+        rounds: usize,
+        noise: f64,
+    },
+    Inline {
+        text: &'static str,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PerfBenchmarkCase {
+    pub label: &'static str,
+    pub workload: PerfWorkload,
+    pub source: PerfCircuitSource,
+    pub shots: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PerfRecord {
+    pub case_label: String,
+    pub tool_variant: String,
+    pub workload: String,
+    pub qubits: usize,
+    pub measurements: usize,
+    pub detectors: usize,
+    pub observables: usize,
+    pub repeat_depth: usize,
+    pub repeat_count: usize,
+    pub shots: Option<usize>,
+    pub wall_time_ns: u128,
+    pub peak_memory_bytes: Option<u64>,
+}
+
+impl PerfRecord {
+    pub fn to_json_line(&self) -> String {
+        let mut line = serde_json::to_string(self).expect("serialize perf record");
+        line.push('\n');
+        line
+    }
+}
+
+pub fn effective_repeat_count(instrs: &[StimInstr]) -> usize {
+    effective_repeat_count_with_multiplier(instrs, 1)
+}
+
+fn effective_repeat_count_with_multiplier(instrs: &[StimInstr], multiplier: usize) -> usize {
+    let mut total = 0usize;
+    for instr in instrs {
+        if let StimInstr::Repeat { count, body } = instr {
+            let scaled = multiplier.saturating_mul(*count as usize);
+            total = total.saturating_add(scaled);
+            total = total.saturating_add(effective_repeat_count_with_multiplier(body, scaled));
+        }
+    }
+    total
+}
+
+pub fn benchmark_cases() -> Vec<PerfBenchmarkCase> {
+    vec![
+        PerfBenchmarkCase {
+            label: "rep-sample-d13-r13",
+            workload: PerfWorkload::Sample,
+            source: PerfCircuitSource::Generator {
+                code: "repetition_code",
+                task: "memory",
+                distance: 13,
+                rounds: 13,
+                noise: 0.001,
+            },
+            shots: Some(20_000),
+        },
+        PerfBenchmarkCase {
+            label: "surface-detect-d13-r13",
+            workload: PerfWorkload::Detect,
+            source: PerfCircuitSource::Generator {
+                code: "surface_code",
+                task: "rotated_memory_x",
+                distance: 13,
+                rounds: 13,
+                noise: 0.001,
+            },
+            shots: Some(10_000),
+        },
+        PerfBenchmarkCase {
+            label: "repeat-analyze-large",
+            workload: PerfWorkload::AnalyzeErrors,
+            source: PerfCircuitSource::Inline {
+                text: "REPEAT 4096 {\n    X_ERROR(0.001) 0\n    M 0\n    DETECTOR rec[-1]\n}\n",
+            },
+            shots: None,
+        },
+        PerfBenchmarkCase {
+            label: "loss-protection-sample",
+            workload: PerfWorkload::Sample,
+            source: PerfCircuitSource::Inline {
+                text: "LOSS(1) 0\nMRL 0\nDETECTOR rec[-1]\n",
+            },
+            shots: Some(128),
+        },
+    ]
+}

--- a/rstim/src/sampler.rs
+++ b/rstim/src/sampler.rs
@@ -41,7 +41,12 @@ pub fn sample_batch_with_options(
         SamplingBackend::Interpreted => sample_batch_interpreted(instrs, n_shots, rng, options),
         SamplingBackend::Compiled => {
             let compiled = compile_circuit(instrs)?;
-            sample_compiled_batch(&compiled, n_shots, rng, options)
+            match choose_sampler_path(&compiled) {
+                CompiledPathDecision::FastPath => {
+                    sample_compiled_batch(&compiled, n_shots, rng, options)
+                }
+                CompiledPathDecision::Fallback(reason) => Err(reason.to_string()),
+            }
         }
         SamplingBackend::Auto => {
             let compiled = compile_circuit(instrs)?;

--- a/rstim/src/sampler.rs
+++ b/rstim/src/sampler.rs
@@ -1,5 +1,8 @@
 use rand::Rng;
 
+use crate::compiled::{
+    choose_sampler_path, compile_circuit, sample_compiled_batch, CompiledPathDecision,
+};
 use crate::data_path::build_reference_sample;
 use crate::executor::Executor;
 use crate::executor::max_qubit;
@@ -14,12 +17,55 @@ pub struct BatchOutput {
     pub observable_flips: BitTable,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SamplingBackend {
+    #[default]
+    Auto,
+    Interpreted,
+    Compiled,
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SampleOptions {
     pub reference_sample_mode: crate::data_path::ReferenceSampleMode,
+    pub backend: SamplingBackend,
 }
 
 pub fn sample_batch_with_options(
+    instrs: &[StimInstr],
+    n_shots: usize,
+    rng: &mut impl Rng,
+    options: SampleOptions,
+) -> Result<BatchOutput, String> {
+    match options.backend {
+        SamplingBackend::Interpreted => sample_batch_interpreted(instrs, n_shots, rng, options),
+        SamplingBackend::Compiled => {
+            let compiled = compile_circuit(instrs)?;
+            sample_compiled_batch(&compiled, n_shots, rng, options)
+        }
+        SamplingBackend::Auto => {
+            let compiled = compile_circuit(instrs)?;
+            match choose_sampler_path(&compiled) {
+                CompiledPathDecision::FastPath => {
+                    sample_compiled_batch(&compiled, n_shots, rng, options)
+                }
+                CompiledPathDecision::Fallback(_) => {
+                    sample_batch_interpreted(instrs, n_shots, rng, options)
+                }
+            }
+        }
+    }
+}
+
+pub fn sample_batch(
+    instrs: &[StimInstr],
+    n_shots: usize,
+    rng: &mut impl Rng,
+) -> Result<BatchOutput, String> {
+    sample_batch_with_options(instrs, n_shots, rng, SampleOptions::default())
+}
+
+fn sample_batch_interpreted(
     instrs: &[StimInstr],
     n_shots: usize,
     rng: &mut impl Rng,
@@ -43,14 +89,6 @@ pub fn sample_batch_with_options(
         detections,
         observable_flips,
     })
-}
-
-pub fn sample_batch(
-    instrs: &[StimInstr],
-    n_shots: usize,
-    rng: &mut impl Rng,
-) -> Result<BatchOutput, String> {
-    sample_batch_with_options(instrs, n_shots, rng, SampleOptions::default())
 }
 
 fn sample_batch_with_executor(
@@ -136,6 +174,7 @@ mod tests {
             &mut rng,
             SampleOptions {
                 reference_sample_mode: ReferenceSampleMode::AssumeAllZero,
+                ..SampleOptions::default()
             },
         );
 

--- a/rstim/src/sim/frame.rs
+++ b/rstim/src/sim/frame.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 
+use crate::compiled::CompiledBlock;
 use crate::ir::{PauliBasis, StimInstr, StimTarget};
 use crate::sim::bit_table::BitTable;
 use crate::sim::measure_record_batch::MeasureRecordBatch;
@@ -44,6 +45,29 @@ impl FrameSimulator {
                 StimInstr::Repeat { count, body } => {
                     for _ in 0..*count {
                         self.run(body, ref_sample, rng)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn run_compiled_blocks(
+        &mut self,
+        blocks: &[CompiledBlock],
+        ref_sample: &[bool],
+        rng: &mut impl Rng,
+    ) -> Result<(), String> {
+        for block in blocks {
+            match block {
+                CompiledBlock::Ops(ops) => {
+                    for op in ops {
+                        self.exec_op(op.name.as_str(), &op.args, &op.targets, ref_sample, rng)?;
+                    }
+                }
+                CompiledBlock::Repeat(region) => {
+                    for _ in 0..region.count {
+                        self.run_compiled_blocks(&region.body, ref_sample, rng)?;
                     }
                 }
             }

--- a/rstim/tests/compiled_analyzer.rs
+++ b/rstim/tests/compiled_analyzer.rs
@@ -62,3 +62,16 @@ fn compiled_backend_preserves_decomposed_entry_point_for_supported_repeat() {
         analyze_error_probabilities_decomposed(circuit, AnalyzeBackend::Compiled)
     );
 }
+
+#[test]
+fn circuit_to_dem_default_entry_point_uses_default_backend_routing() {
+    let instrs =
+        parse_lines("REPEAT 8 {\n    X_ERROR(0.125) 0\n    MR 0\n    DETECTOR rec[-1]\n}\n")
+            .unwrap();
+
+    let default_dem = ErrorAnalyzer::circuit_to_dem(&instrs).unwrap();
+    let auto_dem = ErrorAnalyzer::circuit_to_dem_with_options(&instrs, AnalyzeOptions::default())
+        .unwrap();
+
+    assert_eq!(default_dem.to_string(), auto_dem.to_string());
+}

--- a/rstim/tests/compiled_analyzer.rs
+++ b/rstim/tests/compiled_analyzer.rs
@@ -1,0 +1,38 @@
+use rstim::error_analyzer::{AnalyzeBackend, AnalyzeOptions, ErrorAnalyzer};
+use rstim::parser::parse_lines;
+use rstim::showcase::dem_semantic_summary;
+
+fn analyze_error_probabilities(
+    circuit: &str,
+    backend: AnalyzeBackend,
+) -> Result<std::collections::BTreeMap<String, f64>, String> {
+    let instrs = parse_lines(circuit).unwrap();
+    let dem = ErrorAnalyzer::circuit_to_dem_with_options(
+        &instrs,
+        AnalyzeOptions {
+            backend,
+            ..AnalyzeOptions::default()
+        },
+    )?;
+    Ok(dem_semantic_summary(&dem).error_probabilities)
+}
+
+#[test]
+fn compiled_backend_matches_flattened_for_single_top_level_repeat() {
+    let circuit = "REPEAT 32 {\n    X_ERROR(0.125) 0\n    MR 0\n    DETECTOR rec[-1]\n}\n";
+
+    assert_eq!(
+        analyze_error_probabilities(circuit, AnalyzeBackend::Flattened),
+        analyze_error_probabilities(circuit, AnalyzeBackend::Compiled)
+    );
+}
+
+#[test]
+fn auto_backend_falls_back_to_flattened_for_mixed_top_level_structure() {
+    let circuit = "R 0\nREPEAT 4 {\n    X_ERROR(0.125) 0\n    MR 0\n    DETECTOR rec[-1]\n}\nMR 0\nDETECTOR rec[-1]\n";
+
+    assert_eq!(
+        analyze_error_probabilities(circuit, AnalyzeBackend::Flattened),
+        analyze_error_probabilities(circuit, AnalyzeBackend::Auto)
+    );
+}

--- a/rstim/tests/compiled_analyzer.rs
+++ b/rstim/tests/compiled_analyzer.rs
@@ -1,4 +1,5 @@
 use rstim::error_analyzer::{AnalyzeBackend, AnalyzeOptions, ErrorAnalyzer};
+use rstim::compiled::{analyze_compiled_circuit, compile_circuit};
 use rstim::parser::parse_lines;
 use rstim::showcase::dem_semantic_summary;
 
@@ -74,4 +75,41 @@ fn circuit_to_dem_default_entry_point_uses_default_backend_routing() {
         .unwrap();
 
     assert_eq!(default_dem.to_string(), auto_dem.to_string());
+}
+
+#[test]
+fn analyze_compiled_circuit_returns_feedback_fallback_error() {
+    let compiled = compile_circuit(&parse_lines("M 0\nCX rec[-1] 0\n").unwrap()).unwrap();
+
+    let err = analyze_compiled_circuit(
+        &compiled,
+        AnalyzeOptions {
+            backend: AnalyzeBackend::Compiled,
+            ..AnalyzeOptions::default()
+        },
+        false,
+    )
+    .unwrap_err();
+
+    assert_eq!(err, "feedback instructions require the flattened analyzer");
+}
+
+#[test]
+fn analyze_compiled_circuit_rejects_non_repeat_top_level_structure() {
+    let compiled = compile_circuit(&parse_lines("MR 0\nDETECTOR rec[-1]\n").unwrap()).unwrap();
+
+    let err = analyze_compiled_circuit(
+        &compiled,
+        AnalyzeOptions {
+            backend: AnalyzeBackend::Compiled,
+            ..AnalyzeOptions::default()
+        },
+        false,
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        err,
+        "compiled analyzer currently supports only a single top-level repeat region"
+    );
 }

--- a/rstim/tests/compiled_analyzer.rs
+++ b/rstim/tests/compiled_analyzer.rs
@@ -17,6 +17,21 @@ fn analyze_error_probabilities(
     Ok(dem_semantic_summary(&dem).error_probabilities)
 }
 
+fn analyze_error_probabilities_decomposed(
+    circuit: &str,
+    backend: AnalyzeBackend,
+) -> Result<std::collections::BTreeMap<String, f64>, String> {
+    let instrs = parse_lines(circuit).unwrap();
+    let dem = ErrorAnalyzer::circuit_to_dem_with_options_decomposed(
+        &instrs,
+        AnalyzeOptions {
+            backend,
+            ..AnalyzeOptions::default()
+        },
+    )?;
+    Ok(dem_semantic_summary(&dem).error_probabilities)
+}
+
 #[test]
 fn compiled_backend_matches_flattened_for_single_top_level_repeat() {
     let circuit = "REPEAT 32 {\n    X_ERROR(0.125) 0\n    MR 0\n    DETECTOR rec[-1]\n}\n";
@@ -34,5 +49,16 @@ fn auto_backend_falls_back_to_flattened_for_mixed_top_level_structure() {
     assert_eq!(
         analyze_error_probabilities(circuit, AnalyzeBackend::Flattened),
         analyze_error_probabilities(circuit, AnalyzeBackend::Auto)
+    );
+}
+
+#[test]
+fn compiled_backend_preserves_decomposed_entry_point_for_supported_repeat() {
+    let circuit =
+        "REPEAT 8 {\n    DEPOLARIZE2(0.01) 0 1\n    MR 0 1\n    DETECTOR rec[-1]\n    DETECTOR rec[-2]\n}\n";
+
+    assert_eq!(
+        analyze_error_probabilities_decomposed(circuit, AnalyzeBackend::Flattened),
+        analyze_error_probabilities_decomposed(circuit, AnalyzeBackend::Compiled)
     );
 }

--- a/rstim/tests/compiled_circuit.rs
+++ b/rstim/tests/compiled_circuit.rs
@@ -1,4 +1,4 @@
-use rstim::compiled::{CompiledBlock, compile_circuit};
+use rstim::compiled::{compile_circuit, CompiledBlock};
 use rstim::parser::parse_lines;
 
 #[test]
@@ -48,4 +48,23 @@ fn compile_circuit_sets_feature_flags_from_source() {
     assert_eq!(compiled.num_measurements, 2);
     assert_eq!(compiled.num_detectors, 0);
     assert_eq!(compiled.num_observables, 0);
+}
+
+#[test]
+fn compile_circuit_distinguishes_non_nested_repeat_circuits() {
+    let compiled = compile_circuit(&parse_lines("REPEAT 4 {\n  M 0\n}\n").unwrap()).unwrap();
+
+    assert!(!compiled.flags.has_loss);
+    assert!(!compiled.flags.has_feedback);
+    assert!(!compiled.flags.has_nested_repeat);
+    assert_eq!(compiled.blocks.len(), 1);
+
+    match &compiled.blocks[0] {
+        CompiledBlock::Repeat(region) => {
+            assert_eq!(region.count, 4);
+            assert_eq!(region.measurement_span, 1);
+            assert_eq!(region.detector_span, 0);
+        }
+        other => panic!("expected repeat block, got {other:?}"),
+    }
 }

--- a/rstim/tests/compiled_circuit.rs
+++ b/rstim/tests/compiled_circuit.rs
@@ -1,0 +1,51 @@
+use rstim::compiled::{CompiledBlock, compile_circuit};
+use rstim::parser::parse_lines;
+
+#[test]
+fn compile_circuit_preserves_counts_and_repeat_regions() {
+    let instrs = parse_lines(
+        "R 0\nREPEAT 3 {\n  M 0\n  DETECTOR rec[-1]\n}\nOBSERVABLE_INCLUDE(0) rec[-1]\n",
+    )
+    .unwrap();
+
+    let compiled = compile_circuit(&instrs).unwrap();
+    let expected_repeat_body = match &instrs[1] {
+        rstim::ir::StimInstr::Repeat { body, .. } => body.clone(),
+        other => panic!("expected repeat instruction, got {other:?}"),
+    };
+
+    assert_eq!(compiled.source, instrs);
+    assert_eq!(compiled.num_qubits, 1);
+    assert_eq!(compiled.num_measurements, 3);
+    assert_eq!(compiled.num_detectors, 3);
+    assert_eq!(compiled.num_observables, 1);
+    assert_eq!(compiled.blocks.len(), 3);
+
+    match &compiled.blocks[1] {
+        CompiledBlock::Repeat(region) => {
+            assert_eq!(region.count, 3);
+            assert_eq!(region.body_source, expected_repeat_body);
+            assert_eq!(region.measurement_span, 1);
+            assert_eq!(region.detector_span, 1);
+            assert_eq!(region.body.len(), 1);
+        }
+        other => panic!("expected repeat block, got {other:?}"),
+    }
+}
+
+#[test]
+fn compile_circuit_sets_feature_flags_from_source() {
+    let instrs =
+        parse_lines("REPEAT 2 {\n  M 0\n  REPEAT 3 {\n    LOSS(1) 0\n    CX rec[-1] 1\n  }\n}\n")
+            .unwrap();
+
+    let compiled = compile_circuit(&instrs).unwrap();
+
+    assert!(compiled.flags.has_loss);
+    assert!(compiled.flags.has_feedback);
+    assert!(compiled.flags.has_nested_repeat);
+    assert_eq!(compiled.num_qubits, 2);
+    assert_eq!(compiled.num_measurements, 2);
+    assert_eq!(compiled.num_detectors, 0);
+    assert_eq!(compiled.num_observables, 0);
+}

--- a/rstim/tests/compiled_routing.rs
+++ b/rstim/tests/compiled_routing.rs
@@ -1,0 +1,64 @@
+use rstim::compiled::{
+    choose_analyzer_path, choose_sampler_path, compile_circuit, path::has_single_top_level_repeat,
+    CompiledPathDecision,
+};
+use rstim::parser::parse_lines;
+
+#[test]
+fn sampler_path_uses_fast_path_for_simple_repeat_circuit() {
+    let compiled =
+        compile_circuit(&parse_lines("REPEAT 8 {\n  X_ERROR(0.001) 0\n  M 0\n}\n").unwrap())
+            .unwrap();
+
+    assert_eq!(
+        choose_sampler_path(&compiled),
+        CompiledPathDecision::FastPath
+    );
+}
+
+#[test]
+fn sampler_path_falls_back_for_loss_circuit() {
+    let compiled = compile_circuit(&parse_lines("LOSS(1) 0\nMRL 0\n").unwrap()).unwrap();
+
+    assert_eq!(
+        choose_sampler_path(&compiled),
+        CompiledPathDecision::Fallback("loss instructions require the interpreted path")
+    );
+}
+
+#[test]
+fn sampler_path_falls_back_for_feedback_circuit() {
+    let compiled = compile_circuit(&parse_lines("M 0\nCX rec[-1] 0\n").unwrap()).unwrap();
+
+    assert_eq!(
+        choose_sampler_path(&compiled),
+        CompiledPathDecision::Fallback("feedback instructions require the interpreted path")
+    );
+}
+
+#[test]
+fn analyzer_path_falls_back_until_the_loop_aware_backend_exists() {
+    let compiled = compile_circuit(
+        &parse_lines("REPEAT 8 {\n  X_ERROR(0.001) 0\n  M 0\n  DETECTOR rec[-1]\n}\n").unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        choose_analyzer_path(&compiled),
+        CompiledPathDecision::Fallback("compiled analyzer not implemented yet")
+    );
+}
+
+#[test]
+fn has_single_top_level_repeat_requires_an_exact_single_repeat_block() {
+    let single_repeat = compile_circuit(&parse_lines("REPEAT 8 {\n  M 0\n}\n").unwrap()).unwrap();
+    let prefixed_repeat =
+        compile_circuit(&parse_lines("R 0\nREPEAT 8 {\n  M 0\n}\n").unwrap()).unwrap();
+    let two_repeats =
+        compile_circuit(&parse_lines("REPEAT 2 {\n  M 0\n}\nREPEAT 3 {\n  M 0\n}\n").unwrap())
+            .unwrap();
+
+    assert!(has_single_top_level_repeat(&single_repeat));
+    assert!(!has_single_top_level_repeat(&prefixed_repeat));
+    assert!(!has_single_top_level_repeat(&two_repeats));
+}

--- a/rstim/tests/compiled_routing.rs
+++ b/rstim/tests/compiled_routing.rs
@@ -1,6 +1,5 @@
 use rstim::compiled::{
-    choose_analyzer_path, choose_sampler_path, compile_circuit, path::has_single_top_level_repeat,
-    CompiledPathDecision,
+    choose_analyzer_path, choose_sampler_path, compile_circuit, CompiledPathDecision,
 };
 use rstim::parser::parse_lines;
 
@@ -47,18 +46,4 @@ fn analyzer_path_falls_back_until_the_loop_aware_backend_exists() {
         choose_analyzer_path(&compiled),
         CompiledPathDecision::Fallback("compiled analyzer not implemented yet")
     );
-}
-
-#[test]
-fn has_single_top_level_repeat_requires_an_exact_single_repeat_block() {
-    let single_repeat = compile_circuit(&parse_lines("REPEAT 8 {\n  M 0\n}\n").unwrap()).unwrap();
-    let prefixed_repeat =
-        compile_circuit(&parse_lines("R 0\nREPEAT 8 {\n  M 0\n}\n").unwrap()).unwrap();
-    let two_repeats =
-        compile_circuit(&parse_lines("REPEAT 2 {\n  M 0\n}\nREPEAT 3 {\n  M 0\n}\n").unwrap())
-            .unwrap();
-
-    assert!(has_single_top_level_repeat(&single_repeat));
-    assert!(!has_single_top_level_repeat(&prefixed_repeat));
-    assert!(!has_single_top_level_repeat(&two_repeats));
 }

--- a/rstim/tests/compiled_routing.rs
+++ b/rstim/tests/compiled_routing.rs
@@ -62,3 +62,33 @@ fn analyzer_path_falls_back_for_non_reset_repeat_circuit() {
         )
     );
 }
+
+#[test]
+fn analyzer_path_falls_back_when_qubit_is_touched_after_reset_measurement() {
+    let compiled = compile_circuit(
+        &parse_lines("REPEAT 8 {\n  MR 0\n  H 0\n  DETECTOR rec[-1]\n}\n").unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        choose_analyzer_path(&compiled),
+        CompiledPathDecision::Fallback(
+            "compiled analyzer currently supports only reset-based single top-level repeat regions",
+        )
+    );
+}
+
+#[test]
+fn analyzer_path_falls_back_for_cross_iteration_record_lookback() {
+    let compiled = compile_circuit(
+        &parse_lines("REPEAT 8 {\n  MR 0\n  DETECTOR rec[-2]\n  MR 0\n}\n").unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        choose_analyzer_path(&compiled),
+        CompiledPathDecision::Fallback(
+            "compiled analyzer currently supports only reset-based single top-level repeat regions",
+        )
+    );
+}

--- a/rstim/tests/compiled_routing.rs
+++ b/rstim/tests/compiled_routing.rs
@@ -49,6 +49,16 @@ fn analyzer_path_uses_fast_path_for_reset_based_single_repeat_circuit() {
 }
 
 #[test]
+fn analyzer_path_falls_back_for_loss_circuit() {
+    let compiled = compile_circuit(&parse_lines("LOSS(1) 0\nMRL 0\n").unwrap()).unwrap();
+
+    assert_eq!(
+        choose_analyzer_path(&compiled),
+        CompiledPathDecision::Fallback("loss instructions require the flattened analyzer")
+    );
+}
+
+#[test]
 fn analyzer_path_falls_back_for_non_reset_repeat_circuit() {
     let compiled = compile_circuit(
         &parse_lines("REPEAT 8 {\n  X_ERROR(0.001) 0\n  M 0\n  DETECTOR rec[-1]\n}\n").unwrap(),
@@ -60,6 +70,30 @@ fn analyzer_path_falls_back_for_non_reset_repeat_circuit() {
         CompiledPathDecision::Fallback(
             "compiled analyzer currently supports only reset-based single top-level repeat regions",
         )
+    );
+}
+
+#[test]
+fn analyzer_path_falls_back_for_feedback_circuit() {
+    let compiled = compile_circuit(&parse_lines("M 0\nCX rec[-1] 0\n").unwrap()).unwrap();
+
+    assert_eq!(
+        choose_analyzer_path(&compiled),
+        CompiledPathDecision::Fallback("feedback instructions require the flattened analyzer")
+    );
+}
+
+#[test]
+fn analyzer_path_falls_back_for_nested_repeat_circuit() {
+    let compiled = compile_circuit(
+        &parse_lines("REPEAT 8 {\n  REPEAT 2 {\n    MR 0\n    DETECTOR rec[-1]\n  }\n}\n")
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        choose_analyzer_path(&compiled),
+        CompiledPathDecision::Fallback("nested repeat blocks require the flattened analyzer")
     );
 }
 

--- a/rstim/tests/compiled_routing.rs
+++ b/rstim/tests/compiled_routing.rs
@@ -36,7 +36,20 @@ fn sampler_path_falls_back_for_feedback_circuit() {
 }
 
 #[test]
-fn analyzer_path_falls_back_until_the_loop_aware_backend_exists() {
+fn analyzer_path_uses_fast_path_for_reset_based_single_repeat_circuit() {
+    let compiled = compile_circuit(
+        &parse_lines("REPEAT 8 {\n  X_ERROR(0.001) 0\n  MR 0\n  DETECTOR rec[-1]\n}\n").unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        choose_analyzer_path(&compiled),
+        CompiledPathDecision::FastPath
+    );
+}
+
+#[test]
+fn analyzer_path_falls_back_for_non_reset_repeat_circuit() {
     let compiled = compile_circuit(
         &parse_lines("REPEAT 8 {\n  X_ERROR(0.001) 0\n  M 0\n  DETECTOR rec[-1]\n}\n").unwrap(),
     )
@@ -44,6 +57,8 @@ fn analyzer_path_falls_back_until_the_loop_aware_backend_exists() {
 
     assert_eq!(
         choose_analyzer_path(&compiled),
-        CompiledPathDecision::Fallback("compiled analyzer not implemented yet")
+        CompiledPathDecision::Fallback(
+            "compiled analyzer currently supports only reset-based single top-level repeat regions",
+        )
     );
 }

--- a/rstim/tests/compiled_sampler.rs
+++ b/rstim/tests/compiled_sampler.rs
@@ -140,3 +140,41 @@ fn auto_backend_keeps_loss_circuit_on_interpreted_path() {
         bit_table_rows(&interpreted.observable_flips)
     );
 }
+
+#[test]
+fn compiled_backend_matches_interpreted_for_observable_with_nonzero_reference_sample() {
+    let instrs = parse_lines("X 0\nM 0\nOBSERVABLE_INCLUDE(0) rec[-1]\n").unwrap();
+
+    let mut interpreted_rng = StdRng::seed_from_u64(19);
+    let mut compiled_rng = StdRng::seed_from_u64(19);
+
+    let interpreted = sample_batch_with_options(
+        &instrs,
+        16,
+        &mut interpreted_rng,
+        SampleOptions {
+            backend: SamplingBackend::Interpreted,
+            ..SampleOptions::default()
+        },
+    )
+    .unwrap();
+    let compiled = sample_batch_with_options(
+        &instrs,
+        16,
+        &mut compiled_rng,
+        SampleOptions {
+            backend: SamplingBackend::Compiled,
+            ..SampleOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        bit_table_rows(&compiled.measurements),
+        bit_table_rows(&interpreted.measurements)
+    );
+    assert_eq!(
+        bit_table_rows(&compiled.observable_flips),
+        bit_table_rows(&interpreted.observable_flips)
+    );
+}

--- a/rstim/tests/compiled_sampler.rs
+++ b/rstim/tests/compiled_sampler.rs
@@ -17,7 +17,7 @@ fn bit_table_rows(table: &BitTable) -> Vec<Vec<bool>> {
 #[test]
 fn compiled_backend_matches_interpreted_for_repeat_circuit() {
     let instrs = parse_lines(
-        "REPEAT 32 {\n  X_ERROR(0.001) 0\n  M 0\n  DETECTOR rec[-1]\n}\n",
+        "REPEAT 32 {\n  X_ERROR(0.001) 0\n  M 0\n  DETECTOR rec[-1]\n  OBSERVABLE_INCLUDE(0) rec[-1]\n}\n",
     )
     .unwrap();
 
@@ -57,6 +57,46 @@ fn compiled_backend_matches_interpreted_for_repeat_circuit() {
         bit_table_rows(&compiled.observable_flips),
         bit_table_rows(&interpreted.observable_flips)
     );
+}
+
+#[test]
+fn compiled_backend_rejects_loss_circuits_with_routing_reason() {
+    let instrs = parse_lines("LOSS(1) 0\nMRL 0\nDETECTOR rec[-1]\n").unwrap();
+    let mut rng = StdRng::seed_from_u64(13);
+
+    let err = sample_batch_with_options(
+        &instrs,
+        16,
+        &mut rng,
+        SampleOptions {
+            backend: SamplingBackend::Compiled,
+            ..SampleOptions::default()
+        },
+    )
+    .err()
+    .expect("compiled backend should reject loss circuits");
+
+    assert_eq!(err, "loss instructions require the interpreted path");
+}
+
+#[test]
+fn compiled_backend_rejects_feedback_circuits_with_routing_reason() {
+    let instrs = parse_lines("M 0\nCX rec[-1] 0\n").unwrap();
+    let mut rng = StdRng::seed_from_u64(17);
+
+    let err = sample_batch_with_options(
+        &instrs,
+        16,
+        &mut rng,
+        SampleOptions {
+            backend: SamplingBackend::Compiled,
+            ..SampleOptions::default()
+        },
+    )
+    .err()
+    .expect("compiled backend should reject feedback circuits");
+
+    assert_eq!(err, "feedback instructions require the interpreted path");
 }
 
 #[test]

--- a/rstim/tests/compiled_sampler.rs
+++ b/rstim/tests/compiled_sampler.rs
@@ -1,0 +1,102 @@
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use rstim::parser::parse_lines;
+use rstim::sampler::{sample_batch_with_options, SampleOptions, SamplingBackend};
+use rstim::sim::bit_table::BitTable;
+
+fn bit_table_rows(table: &BitTable) -> Vec<Vec<bool>> {
+    (0..table.num_major())
+        .map(|major| {
+            (0..table.num_minor())
+                .map(|minor| table.get(major, minor))
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn compiled_backend_matches_interpreted_for_repeat_circuit() {
+    let instrs = parse_lines(
+        "REPEAT 32 {\n  X_ERROR(0.001) 0\n  M 0\n  DETECTOR rec[-1]\n}\n",
+    )
+    .unwrap();
+
+    let mut interpreted_rng = StdRng::seed_from_u64(7);
+    let mut compiled_rng = StdRng::seed_from_u64(7);
+
+    let interpreted = sample_batch_with_options(
+        &instrs,
+        16,
+        &mut interpreted_rng,
+        SampleOptions {
+            backend: SamplingBackend::Interpreted,
+            ..SampleOptions::default()
+        },
+    )
+    .unwrap();
+    let compiled = sample_batch_with_options(
+        &instrs,
+        16,
+        &mut compiled_rng,
+        SampleOptions {
+            backend: SamplingBackend::Compiled,
+            ..SampleOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        bit_table_rows(&compiled.measurements),
+        bit_table_rows(&interpreted.measurements)
+    );
+    assert_eq!(
+        bit_table_rows(&compiled.detections),
+        bit_table_rows(&interpreted.detections)
+    );
+    assert_eq!(
+        bit_table_rows(&compiled.observable_flips),
+        bit_table_rows(&interpreted.observable_flips)
+    );
+}
+
+#[test]
+fn auto_backend_keeps_loss_circuit_on_interpreted_path() {
+    let instrs = parse_lines("LOSS(1) 0\nMRL 0\nDETECTOR rec[-1]\n").unwrap();
+
+    let mut auto_rng = StdRng::seed_from_u64(11);
+    let mut interpreted_rng = StdRng::seed_from_u64(11);
+
+    let auto = sample_batch_with_options(
+        &instrs,
+        16,
+        &mut auto_rng,
+        SampleOptions {
+            backend: SamplingBackend::Auto,
+            ..SampleOptions::default()
+        },
+    )
+    .unwrap();
+    let interpreted = sample_batch_with_options(
+        &instrs,
+        16,
+        &mut interpreted_rng,
+        SampleOptions {
+            backend: SamplingBackend::Interpreted,
+            ..SampleOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        bit_table_rows(&auto.measurements),
+        bit_table_rows(&interpreted.measurements)
+    );
+    assert_eq!(
+        bit_table_rows(&auto.detections),
+        bit_table_rows(&interpreted.detections)
+    );
+    assert_eq!(
+        bit_table_rows(&auto.observable_flips),
+        bit_table_rows(&interpreted.observable_flips)
+    );
+}

--- a/rstim/tests/perf_harness.rs
+++ b/rstim/tests/perf_harness.rs
@@ -1,4 +1,9 @@
-use rstim::perf::{PerfRecord, PerfWorkload, benchmark_cases};
+use rstim::compiled::{CompiledPathDecision, choose_analyzer_path, compile_circuit};
+use rstim::parser::parse_lines;
+use rstim::perf::{
+    PerfRecord, PerfVariant, PerfWorkload, benchmark_case_variants, benchmark_cases,
+    benchmark_variants,
+};
 use serde_json::Value;
 
 #[test]
@@ -56,4 +61,55 @@ fn perf_record_json_line_contains_required_keys() {
     assert_eq!(json["repeat_count"], 13);
     assert_eq!(json["shots"], 10_000);
     assert_eq!(json["peak_memory_bytes"], Value::Null);
+}
+
+#[test]
+fn benchmark_variants_cover_stim_and_both_rstim_backends() {
+    let variants = benchmark_variants();
+
+    assert!(variants.contains(&PerfVariant::StimCli));
+    assert!(variants.contains(&PerfVariant::RstimInterpreted));
+    assert!(variants.contains(&PerfVariant::RstimCompiled));
+    assert!(variants.contains(&PerfVariant::RstimAnalyzerFlattened));
+    assert!(variants.contains(&PerfVariant::RstimAnalyzerCompiled));
+}
+
+#[test]
+fn benchmark_cases_include_a_compiled_analyzer_compatible_repeat_case() {
+    let cases = benchmark_cases();
+
+    let compatible = cases.iter().filter(|case| case.workload == PerfWorkload::AnalyzeErrors).any(
+        |case| match case.source {
+            rstim::perf::PerfCircuitSource::Inline { text } => {
+                let instrs = parse_lines(text).unwrap();
+                let compiled = compile_circuit(&instrs).unwrap();
+                choose_analyzer_path(&compiled) == CompiledPathDecision::FastPath
+            }
+            rstim::perf::PerfCircuitSource::Generator { .. } => false,
+        },
+    );
+
+    assert!(
+        compatible,
+        "expected at least one analyze_errors benchmark case to support the compiled analyzer path"
+    );
+}
+
+#[test]
+fn loss_protection_case_skips_compiled_sampler_variant() {
+    let case = benchmark_cases()
+        .into_iter()
+        .find(|case| case.label == "loss-protection-sample")
+        .expect("loss protection case");
+    let text = match case.source {
+        rstim::perf::PerfCircuitSource::Inline { text } => text,
+        _ => panic!("loss protection case should be inline"),
+    };
+    let instrs = parse_lines(text).unwrap();
+
+    let variants = benchmark_case_variants(case, &instrs).unwrap();
+
+    assert!(variants.contains(&PerfVariant::StimCli));
+    assert!(variants.contains(&PerfVariant::RstimInterpreted));
+    assert!(!variants.contains(&PerfVariant::RstimCompiled));
 }

--- a/rstim/tests/perf_harness.rs
+++ b/rstim/tests/perf_harness.rs
@@ -1,8 +1,8 @@
 use rstim::compiled::{CompiledPathDecision, choose_analyzer_path, compile_circuit};
 use rstim::parser::parse_lines;
 use rstim::perf::{
-    PerfRecord, PerfVariant, PerfWorkload, benchmark_case_variants, benchmark_cases,
-    benchmark_variants,
+    PerfBenchmarkCase, PerfCircuitSource, PerfRecord, PerfVariant, PerfWorkload,
+    benchmark_case_variants, benchmark_cases, benchmark_variants, effective_repeat_count,
 };
 use serde_json::Value;
 
@@ -75,6 +75,25 @@ fn benchmark_variants_cover_stim_and_both_rstim_backends() {
 }
 
 #[test]
+fn perf_workload_and_variant_labels_are_stable() {
+    assert_eq!(PerfWorkload::Sample.as_str(), "sample");
+    assert_eq!(PerfWorkload::Detect.as_str(), "detect");
+    assert_eq!(PerfWorkload::AnalyzeErrors.as_str(), "analyze_errors");
+
+    assert_eq!(PerfVariant::StimCli.label(), "stim-cli");
+    assert_eq!(PerfVariant::RstimInterpreted.label(), "rstim-interpreted");
+    assert_eq!(PerfVariant::RstimCompiled.label(), "rstim-compiled");
+    assert_eq!(
+        PerfVariant::RstimAnalyzerFlattened.label(),
+        "rstim-analyzer-flattened"
+    );
+    assert_eq!(
+        PerfVariant::RstimAnalyzerCompiled.label(),
+        "rstim-analyzer-compiled"
+    );
+}
+
+#[test]
 fn benchmark_cases_include_a_compiled_analyzer_compatible_repeat_case() {
     let cases = benchmark_cases();
 
@@ -96,6 +115,46 @@ fn benchmark_cases_include_a_compiled_analyzer_compatible_repeat_case() {
 }
 
 #[test]
+fn benchmark_case_variants_add_compiled_backends_for_supported_paths() {
+    let sample_instrs = parse_lines("X_ERROR(0.001) 0\nM 0\n").unwrap();
+    let sample_case = PerfBenchmarkCase {
+        label: "inline-sample",
+        workload: PerfWorkload::Sample,
+        source: PerfCircuitSource::Inline {
+            text: "X_ERROR(0.001) 0\nM 0\n",
+        },
+        shots: Some(32),
+    };
+    let analyze_instrs =
+        parse_lines("REPEAT 8 {\n  X_ERROR(0.001) 0\n  MR 0\n  DETECTOR rec[-1]\n}\n").unwrap();
+    let analyze_case = PerfBenchmarkCase {
+        label: "inline-analyze",
+        workload: PerfWorkload::AnalyzeErrors,
+        source: PerfCircuitSource::Inline {
+            text: "REPEAT 8 {\n  X_ERROR(0.001) 0\n  MR 0\n  DETECTOR rec[-1]\n}\n",
+        },
+        shots: None,
+    };
+
+    assert_eq!(
+        benchmark_case_variants(sample_case, &sample_instrs).unwrap(),
+        vec![
+            PerfVariant::StimCli,
+            PerfVariant::RstimInterpreted,
+            PerfVariant::RstimCompiled,
+        ]
+    );
+    assert_eq!(
+        benchmark_case_variants(analyze_case, &analyze_instrs).unwrap(),
+        vec![
+            PerfVariant::StimCli,
+            PerfVariant::RstimAnalyzerFlattened,
+            PerfVariant::RstimAnalyzerCompiled,
+        ]
+    );
+}
+
+#[test]
 fn loss_protection_case_skips_compiled_sampler_variant() {
     let case = benchmark_cases()
         .into_iter()
@@ -112,4 +171,14 @@ fn loss_protection_case_skips_compiled_sampler_variant() {
     assert!(variants.contains(&PerfVariant::StimCli));
     assert!(variants.contains(&PerfVariant::RstimInterpreted));
     assert!(!variants.contains(&PerfVariant::RstimCompiled));
+}
+
+#[test]
+fn effective_repeat_count_scales_nested_repeat_regions() {
+    let instrs = parse_lines(
+        "H 0\nREPEAT 2 {\n  REPEAT 3 {\n    M 0\n  }\n  REPEAT 5 {\n    M 1\n  }\n}\nREPEAT 7 {\n  M 2\n}\n",
+    )
+    .unwrap();
+
+    assert_eq!(effective_repeat_count(&instrs), 25);
 }

--- a/rstim/tests/perf_harness.rs
+++ b/rstim/tests/perf_harness.rs
@@ -1,4 +1,5 @@
-use rstim::perf::{benchmark_cases, PerfRecord, PerfWorkload};
+use rstim::perf::{PerfRecord, PerfWorkload, benchmark_cases};
+use serde_json::Value;
 
 #[test]
 fn benchmark_cases_cover_sampling_detect_and_repeat_analysis() {
@@ -46,10 +47,13 @@ fn perf_record_json_line_contains_required_keys() {
     };
 
     let line = record.to_json_line();
+    let json: Value = serde_json::from_str(line.trim_end()).unwrap();
 
-    assert!(line.contains("\"case_label\":\"surface-detect-d13\""));
-    assert!(line.contains("\"tool_variant\":\"rstim-auto\""));
-    assert!(line.contains("\"workload\":\"detect\""));
-    assert!(line.contains("\"repeat_count\":13"));
     assert!(line.ends_with('\n'));
+    assert_eq!(json["case_label"], "surface-detect-d13");
+    assert_eq!(json["tool_variant"], "rstim-auto");
+    assert_eq!(json["workload"], "detect");
+    assert_eq!(json["repeat_count"], 13);
+    assert_eq!(json["shots"], 10_000);
+    assert_eq!(json["peak_memory_bytes"], Value::Null);
 }

--- a/rstim/tests/perf_harness.rs
+++ b/rstim/tests/perf_harness.rs
@@ -1,0 +1,55 @@
+use rstim::perf::{benchmark_cases, PerfRecord, PerfWorkload};
+
+#[test]
+fn benchmark_cases_cover_sampling_detect_and_repeat_analysis() {
+    let cases = benchmark_cases();
+
+    assert!(
+        cases
+            .iter()
+            .any(|case| case.workload == PerfWorkload::Sample),
+        "expected at least one sample benchmark case"
+    );
+    assert!(
+        cases
+            .iter()
+            .any(|case| case.workload == PerfWorkload::Detect),
+        "expected at least one detect benchmark case"
+    );
+    assert!(
+        cases
+            .iter()
+            .any(|case| case.workload == PerfWorkload::AnalyzeErrors),
+        "expected at least one analyze_errors benchmark case"
+    );
+    assert!(
+        cases.iter().any(|case| case.label.contains("repeat")),
+        "expected at least one repeat-focused benchmark case"
+    );
+}
+
+#[test]
+fn perf_record_json_line_contains_required_keys() {
+    let record = PerfRecord {
+        case_label: "surface-detect-d13".to_string(),
+        tool_variant: "rstim-auto".to_string(),
+        workload: PerfWorkload::Detect.as_str().to_string(),
+        qubits: 25,
+        measurements: 48,
+        detectors: 24,
+        observables: 1,
+        repeat_depth: 1,
+        repeat_count: 13,
+        shots: Some(10_000),
+        wall_time_ns: 123_456,
+        peak_memory_bytes: None,
+    };
+
+    let line = record.to_json_line();
+
+    assert!(line.contains("\"case_label\":\"surface-detect-d13\""));
+    assert!(line.contains("\"tool_variant\":\"rstim-auto\""));
+    assert!(line.contains("\"workload\":\"detect\""));
+    assert!(line.contains("\"repeat_count\":13"));
+    assert!(line.ends_with('\n'));
+}

--- a/rstim/tests/stim_error_analyzer.rs
+++ b/rstim/tests/stim_error_analyzer.rs
@@ -30,6 +30,7 @@ fn circuit_to_dem_with_options(
     ErrorAnalyzer::circuit_to_dem_with_options(
         &instrs,
         AnalyzeOptions {
+            backend: Default::default(),
             approximate_disjoint_errors,
             allow_gauge_detectors,
         },
@@ -849,6 +850,7 @@ fn circuit_to_dem_with_options_decomposed_respects_phase2_flags() {
     let dem = ErrorAnalyzer::circuit_to_dem_with_options_decomposed(
         &instrs,
         AnalyzeOptions {
+            backend: Default::default(),
             approximate_disjoint_errors: true,
             allow_gauge_detectors: false,
         },
@@ -863,6 +865,7 @@ fn circuit_to_dem_with_options_decomposed_allows_gauge_detectors() {
     let dem = ErrorAnalyzer::circuit_to_dem_with_options_decomposed(
         &instrs,
         AnalyzeOptions {
+            backend: Default::default(),
             approximate_disjoint_errors: false,
             allow_gauge_detectors: true,
         },


### PR DESCRIPTION
## Summary
- align default analyzer routing with `AnalyzeOptions` and fix the compiled sampler to preserve interpreted detector/observable semantics
- finalize the performance parity harness with Stim, interpreted, compiled, and analyzer backend variants chosen per benchmark case
- document the benchmark workflow and add perf harness coverage for supported analyzer cases and loss-path sampler fallback

## Test Plan
- cargo test -p rstim
- cargo test -p rstim --test perf_harness --test compiled_circuit --test compiled_routing --test compiled_sampler --test compiled_analyzer
- cargo run -p rstim --example performance_parity_foundation