### PR TITLE
feat: add ILP DEM decoder backends and rsinter integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["rstim", "rsinter", "rbposd", "rmatching"]
+members = ["rstim", "rsinter", "rbposd", "rmatching", "rilpqec"]
 resolver = "3"

--- a/docs/superpowers/specs/2026-06-01-rsinter-ilp-dem-decoder-design.md
+++ b/docs/superpowers/specs/2026-06-01-rsinter-ilp-dem-decoder-design.md
@@ -1,0 +1,470 @@
+# Rsinter ILP DEM Decoder Design
+
+Date: 2026-06-01
+Status: Proposed
+Scope: `rstim` workspace, new ILP decoder crate plus `rsinter` integration
+
+## Summary
+
+This design adds an integer-programming decoder for detector error models to
+the current workspace.
+
+The first production integration target is not `rstim` CLI code. It is
+[`rsinter/src/decode.rs`](/Users/nzy/rcode/rstim/rsinter/src/decode.rs:1),
+which already defines the repository's reusable decoder boundary for
+DEM-driven shot decoding.
+
+The recommended implementation is:
+
+- add a new workspace crate that owns DEM-to-ILP lowering and solver backends
+- add a thin `rsinter` adapter that implements `Decoder`
+- make `Gurobi` the preferred backend when available
+- fall back automatically to `HiGHS` when `Gurobi` is unavailable
+- support general multi-detector and multi-observable `error(...)` terms
+- treat `Separator` / `^` as a plain separator and ignore its alternative-path
+  semantics in the first version
+
+The goal is to ship a real end-to-end decoder path for existing `rsinter`
+workflows without welding solver-specific logic directly into `rsinter`.
+
+## Goals
+
+- Add a real ILP-based DEM decoder to the workspace.
+- Integrate the first usable version through the existing
+  `rsinter::decode::Decoder` trait.
+- Keep solver selection explicit:
+  prefer `Gurobi`, otherwise use `HiGHS`.
+- Separate three concerns cleanly:
+  DEM lowering, solver backend, and `rsinter` adapter.
+- Reuse a compiled model across many shots instead of rebuilding the full ILP
+  for every syndrome.
+- Preserve the current `rstim::dem::DetectorErrorModel` traversal semantics for
+  `Repeat` and `ShiftDetectors`.
+- Cover the current repository's existing DEM edge cases such as observable-only
+  terms and exact-probability terms.
+
+## Non-Goals
+
+- Do not support the full meaning of Stim `^` separator segments in the first
+  version. The first version intentionally discards that distinction.
+- Do not promise competitive performance against MWPM-based decoders in the
+  first phase.
+- Do not change `rstim`'s DEM representation or parser.
+- Do not make the first delivery a general-purpose public optimization crate.
+- Do not block the open-source development path on commercial solver
+  availability.
+- Do not route `rstim` CLI commands directly through the new decoder in the
+  first phase.
+
+## Current State
+
+The workspace already contains the boundaries needed for a clean decoder
+integration, but not an ILP decoder implementation.
+
+- [`rsinter/src/decode.rs`](/Users/nzy/rcode/rstim/rsinter/src/decode.rs:1)
+  defines the decoding boundary:
+  compile a decoder for a DEM, then decode bit-packed detector shots into
+  bit-packed observable predictions.
+- [`rsinter/src/rbposd_adapter.rs`](/Users/nzy/rcode/rstim/rsinter/src/rbposd_adapter.rs:1)
+  already lowers `DetectorErrorModel` into a matrix-like decoding problem for a
+  different decoder family. This file demonstrates the right integration layer
+  and already contains repository-specific handling for:
+  `Repeat`, `ShiftDetectors`, `Separator`, observable-only terms, and exact
+  probabilities.
+- [`rstim/src/dem.rs`](/Users/nzy/rcode/rstim/rstim/src/dem.rs:1)
+  already provides the repository-owned DEM tree and traversal semantics.
+- [`rmatching/src/decoder.rs`](/Users/nzy/rcode/rstim/rmatching/src/decoder.rs:1)
+  shows the other existing `rsinter` decoder integration pattern.
+
+This gives the project a stable target:
+
+- the new decoder should plug into `rsinter`
+- the solver and modeling logic should live outside `rsinter`
+- the lowering semantics should stay aligned with the current DEM model instead
+  of re-parsing DEM text in a second place
+
+## Decision Summary
+
+The chosen direction is:
+
+- add a new workspace crate dedicated to ILP DEM decoding
+- make that crate own the compiled problem representation and solver backends
+- keep `rsinter` integration as a thin adapter layer
+- use `Gurobi` first when the environment supports it
+- fall back automatically to `HiGHS` on machines without `Gurobi`
+- treat every DEM `error(...)` instruction as one ILP column after ignoring
+  `Separator` markers
+
+This is intentionally not the smallest possible patch. The extra structure is
+worth it because the first version already needs two solver backends and a
+compiled-model lifecycle.
+
+## Alternatives Considered
+
+### 1. Implement directly inside `rsinter`
+
+This would be the shortest path to a passing demo:
+
+- add `IlpDemDecoder` next to the existing decoder code
+- put DEM lowering, solver setup, and shot decoding in the same crate
+
+Benefits:
+
+- smallest initial diff
+- fastest route to end-to-end tests
+
+Costs:
+
+- mixes repository integration code with solver-specific modeling code
+- makes `Gurobi` / `HiGHS` fallback logic harder to isolate and test
+- makes later standalone benchmarks or backend reuse awkward
+
+### 2. Add a new ILP decoder crate and keep `rsinter` thin
+
+This option creates a new workspace crate, for example `rilpqec`, and keeps
+`rsinter` focused on its existing adapter boundary.
+
+Benefits:
+
+- clean separation between lowering, solving, and integration
+- natural home for backend-specific code and feature flags
+- easier to benchmark and test independently
+
+Costs:
+
+- larger up-front patch
+- requires one more crate in the workspace
+
+This is the recommended option.
+
+### 3. Use a generic modeling layer such as `good_lp` as the primary API
+
+This option would standardize model construction through a generic solver
+abstraction and dispatch to `Gurobi` or `HiGHS` beneath it.
+
+Benefits:
+
+- potentially shorter model-building code
+- simpler backend abstraction on paper
+
+Costs:
+
+- weaker fit for a workflow that should compile once and then solve many
+  syndromes by mutating the RHS
+- less direct access to backend-specific capabilities and tuning
+- likely to become a leaky abstraction if the project needs better reuse or
+  performance later
+
+This is not the recommended first implementation path.
+
+## Success Criteria
+
+The first delivery is successful only if all of the following are true:
+
+- a new `rsinter` decoder implementation can compile from an existing
+  `DetectorErrorModel`
+- the decoder can consume bit-packed detector shots and return bit-packed
+  observable predictions
+- the compiled decoder chooses `Gurobi` when available and otherwise decodes
+  using `HiGHS`
+- existing repository edge cases are covered:
+  multi-detector terms, multi-observable terms, observable-only terms,
+  `probability = 0`, `probability = 1`, `Repeat`, `ShiftDetectors`, and
+  `Separator` ignored as a plain separator
+- repository tests prove the decoder works through `rsinter`, not only through
+  unit tests of internal helpers
+
+Performance is not the first-phase success gate. Model reuse across shots is
+required, but no benchmark threshold is part of the first milestone.
+
+## Recommended Architecture
+
+The design is split into three layers.
+
+### Layer 1: DEM Lowering
+
+The new crate should expose a problem builder that converts
+`rstim::dem::DetectorErrorModel` into a compiled ILP problem description.
+
+Suggested internal output:
+
+- `num_detectors`
+- `num_observables`
+- sparse detector columns, one column per error mechanism
+- sparse observable columns, one column per error mechanism
+- adjusted per-column probabilities or weights
+- forced-syndrome bits induced by exact-probability columns
+- baseline observable bits induced by exact-probability or observable-only
+  columns
+
+The lowering pass should follow the same repository-local interpretation
+already established in the `rbposd` adapter:
+
+- `DemTarget::Detector` toggles detector membership in the current column
+- `DemTarget::Observable` toggles observable membership in the current column
+- `DemTarget::Separator` is ignored
+- `Repeat` recursively replays the body while carrying detector offsets
+- `ShiftDetectors` mutates the current offset
+- `Detector` and `LogicalObservable` annotation instructions do not generate
+  columns
+
+Each `error(probability)` instruction becomes one binary decision variable in
+the ILP after target cancellation is applied.
+
+### Layer 2: Solver Backend
+
+The new crate should define a backend boundary around a compiled model.
+
+Suggested shape:
+
+- `BackendKind`:
+  `Auto`, `Gurobi`, `Highs`
+- `BackendConfig`:
+  solver preference plus optional tuning such as time limit, MIP gap, threads,
+  and verbosity
+- `CompiledBackend` trait or enum-backed object:
+  own a reusable compiled model and solve for a provided syndrome
+
+The `Auto` path must implement:
+
+- choose `Gurobi` if the feature is enabled and the environment is usable
+- otherwise choose `HiGHS`
+
+The backend boundary must hide solver-specific details from the `rsinter`
+adapter. The adapter should not know whether the correction came from `Gurobi`
+or `HiGHS`.
+
+### Layer 3: `rsinter` Adapter
+
+`rsinter` should add a new decoder adapter, for example `IlpDemDecoder`, that
+implements `rsinter::decode::Decoder`.
+
+Responsibilities:
+
+- accept high-level decoder configuration
+- compile the DEM once into the new crate's compiled decoder
+- decode bit-packed detector shots by:
+  unpacking to syndrome bits,
+  applying forced syndrome toggles,
+  solving for the correction,
+  mapping the correction into observables,
+  XORing baseline observable toggles,
+  and packing the observable prediction bits back into bytes
+
+This is the same outer workflow that the current `rbposd` adapter already
+follows. The difference is that the correction is produced by an ILP solver
+instead of BP+OSD.
+
+## ILP Formulation
+
+For a lowered DEM problem with `m` detectors and `n` error mechanisms:
+
+- binary variables:
+  `e_j in {0,1}` for each mechanism `j`
+- integer auxiliary variables:
+  `a_i >= 0` for each detector parity constraint `i`
+
+Objective:
+
+- minimize `sum_j w_j * e_j`
+
+Constraints:
+
+- `sum_j H[i,j] * e_j = s_i + 2 * a_i` for each detector `i`
+
+Where:
+
+- `H` is the binary detector-incidence matrix produced from the DEM
+- `s` is the shot syndrome after applying any forced-syndrome toggles
+- `w_j` is the column weight derived from the mechanism probability
+
+Observable prediction is not part of the optimization variables. It is derived
+after solving:
+
+- `obs = baseline_obs XOR (O * e mod 2)`
+
+where `O` is the observable-incidence matrix.
+
+## Probability And Weight Handling
+
+The first version should not minimize raw probabilities. It should minimize
+log-likelihood-style weights derived from per-column probabilities.
+
+Recommended mapping:
+
+- for `0 < p < 0.5`:
+  `w = ln((1 - p) / p)`
+- for `p = 0`:
+  drop the column entirely
+- for `p = 1`:
+  fold its detector and observable effect into forced baseline state
+- for `p > 0.5`:
+  complement the column by toggling the same detector and observable support
+  into the forced baseline state and then use `1 - p` as the effective column
+  probability
+
+This preserves the maximum-likelihood meaning of the objective while keeping
+all optimized columns in the range `0 < p <= 0.5`.
+
+The implementation should clamp only for numerical safety near the endpoints,
+not as a semantic shortcut.
+
+## Data Flow
+
+The intended end-to-end flow is:
+
+1. `rsinter` receives a `DetectorErrorModel`
+2. the new adapter lowers it into a compiled ILP problem through the new crate
+3. the new crate compiles a solver-specific reusable model
+4. `rsinter` receives bit-packed detector outcomes for one or many shots
+5. each shot is unpacked into syndrome bits
+6. forced-syndrome bits are XORed in
+7. the backend solves for the binary correction vector
+8. observables are computed from the correction plus baseline toggles
+9. observable bits are packed back into the output buffer
+
+The reusable boundary is the compiled decoder, not a one-shot solve call.
+
+## Error Handling
+
+The first version should be strict about configuration and DEM shape, but it
+should not reject the repository-defined first-phase DEM subset.
+
+Expected error classes:
+
+- backend selection failure:
+  neither `Gurobi` nor `HiGHS` is available
+- backend compile failure:
+  solver model construction fails
+- solve failure:
+  solver reports infeasible, unbounded, or internal failure
+- dimension mismatch:
+  provided shot dimensions do not match the compiled DEM dimensions
+- invalid probability:
+  DEM contains a probability outside `[0, 1]`
+
+The decoder should not fail merely because a DEM contains `Separator` targets.
+Those targets are explicitly ignored in this design.
+
+The new crate should preserve rich internal error types. However, the current
+`rsinter::decode::Decoder` trait does not return `Result` from
+`compile_for_dem` or `decode_shots_bit_packed`.
+
+The first version should therefore keep the current `rsinter` trait shape and
+narrow backend compile or solve failures at the adapter boundary with precise
+error context, even if that currently means a fail-fast path instead of typed
+error propagation through `rsinter`.
+
+Changing the `rsinter` decoder trait to return `Result` is a valid future
+cleanup, but it is out of scope for this first design.
+
+## Crate And Feature Layout
+
+Recommended workspace change:
+
+- add a new member crate, tentatively named `rilpqec`
+
+Recommended dependency structure:
+
+- `rilpqec` depends on `rstim`
+- `rsinter` depends on `rilpqec`
+- `rilpqec` must not depend on `rsinter`
+
+Recommended feature layout:
+
+- default feature enables `HiGHS`
+- optional `gurobi` feature enables the `Gurobi` backend
+
+This keeps the open-source path buildable by default while still supporting
+the preferred commercial backend on equipped machines.
+
+## Testing Strategy
+
+Testing should be layered so that failures localize cleanly.
+
+### Lowering Tests
+
+Add unit tests in the new crate for:
+
+- multi-detector columns
+- multi-observable columns
+- `Separator` ignored while preserving one combined column
+- `Repeat` and `ShiftDetectors`
+- duplicate detector or observable targets cancelling mod 2
+- observable-only terms
+- exact-probability terms:
+  `0`, `1`, and `> 0.5`
+
+### Backend Tests
+
+Add backend-focused tests for:
+
+- `Auto` chooses `HiGHS` when `Gurobi` is unavailable
+- explicit `Highs` selection works
+- explicit `Gurobi` selection reports a clear error when unsupported in the
+  current build or environment
+- a small compiled model can solve repeated syndromes without recompiling
+
+These tests should stay small and deterministic.
+
+### `rsinter` Integration Tests
+
+Mirror the current style of
+[`rsinter/tests/decode_rbposd.rs`](/Users/nzy/rcode/rstim/rsinter/tests/decode_rbposd.rs:1).
+
+Required cases:
+
+- simple single-observable prediction
+- multi-observable prediction
+- observable-only baseline term
+- zero-syndrome case with baseline toggle
+- exact-probability forced syndrome case
+- `collect` pipeline smoke test using the new decoder name
+
+## Rollout Plan
+
+The implementation should land in three short phases.
+
+### Phase 1: New Crate And Lowering Core
+
+- add the new workspace crate
+- implement DEM lowering and compiled problem representation
+- add lowering tests
+
+### Phase 2: Solver Backends
+
+- add `HiGHS` backend first because it is the guaranteed open path
+- add `Gurobi` backend behind a feature flag
+- implement `Auto` backend selection
+- add backend tests
+
+### Phase 3: `rsinter` Adapter
+
+- add `IlpDemDecoder`
+- wire it into integration tests and `collect`
+- add repository-level smoke coverage
+
+This ordering keeps repository integration late enough that the core solver and
+lowering logic can stabilize first, while still preserving the agreed primary
+goal of `rsinter` integration.
+
+## Open Questions Resolved By This Design
+
+- Should the first version integrate through `rsinter` or start as an isolated
+  crate?
+  Answer:
+  integrate through `rsinter`, but keep the ILP machinery in a separate crate.
+
+- Should the first version require a commercial solver?
+  Answer:
+  no. Prefer `Gurobi`, but support automatic `HiGHS` fallback.
+
+- Should the first version preserve `Separator` / `^` alternative semantics?
+  Answer:
+  no. Ignore `Separator` targets and treat the whole `error(...)` line as one
+  mechanism after mod-2 target cancellation.
+
+- Should the first version support only fully decomposed DEMs?
+  Answer:
+  no. Support general multi-detector and multi-observable terms within the
+  repository-defined simplified interpretation above.

--- a/rilpqec/Cargo.toml
+++ b/rilpqec/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rilpqec"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+default = []
+gurobi = ["dep:gurobi"]
+
+[dependencies]
+rstim = { path = "../rstim" }
+thiserror = "2"
+highs = "2.1.0"
+highs-sys = "1.14.2"
+gurobi = { version = "0.3.4", optional = true }

--- a/rilpqec/src/backend/gurobi.rs
+++ b/rilpqec/src/backend/gurobi.rs
@@ -1,0 +1,165 @@
+use gurobi::{attr, param, Constr, ConstrSense, Env, Model, Status, Var, VarType};
+
+use crate::backend::BatchBackend;
+use crate::config::IlpDecoderConfig;
+use crate::error::IlpDecodeError;
+use crate::problem::LoweredDemProblem;
+
+pub struct GurobiBatchBackend {
+    _env: Env,
+    model: Model,
+    row_constraints: Vec<Constr>,
+    error_vars: Vec<Var>,
+    num_detectors: usize,
+    forced_syndrome: Vec<bool>,
+}
+
+impl GurobiBatchBackend {
+    pub fn new(
+        problem: &LoweredDemProblem,
+        config: &IlpDecoderConfig,
+    ) -> Result<Self, IlpDecodeError> {
+        let mut env = Env::new("").map_err(gurobi_error)?;
+        if !config.backend.verbose {
+            env.set(param::OutputFlag, 0).map_err(gurobi_error)?;
+        }
+        if let Some(threads) = config.backend.threads {
+            env.set(param::Threads, threads as i32)
+                .map_err(gurobi_error)?;
+        }
+        if let Some(limit) = config.backend.time_limit_seconds {
+            env.set(param::TimeLimit, limit).map_err(gurobi_error)?;
+        }
+        if let Some(gap) = config.backend.mip_gap {
+            env.set(param::MIPGap, gap).map_err(gurobi_error)?;
+        }
+
+        let mut model = Model::new("rilpqec", &env).map_err(gurobi_error)?;
+
+        let row_constraints = (0..problem.num_detectors)
+            .map(|row| {
+                model
+                    .add_constr(&format!("det_{row}"), 0.0.into(), ConstrSense::Equal, 0.0)
+                    .map_err(gurobi_error)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let error_vars = problem
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(column_index, column)| {
+                let constrs = column
+                    .detectors
+                    .iter()
+                    .map(|&det| row_constraints[det].clone())
+                    .collect::<Vec<_>>();
+                let coeffs = vec![1.0; constrs.len()];
+                model
+                    .add_var(
+                        &format!("e_{column_index}"),
+                        VarType::Binary,
+                        column.weight,
+                        0.0,
+                        1.0,
+                        &constrs,
+                        &coeffs,
+                    )
+                    .map_err(gurobi_error)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for (row, constr) in row_constraints.iter().enumerate() {
+            model
+                .add_var(
+                    &format!("a_{row}"),
+                    VarType::Integer,
+                    0.0,
+                    0.0,
+                    gurobi::INFINITY,
+                    std::slice::from_ref(constr),
+                    &[-2.0],
+                )
+                .map_err(gurobi_error)?;
+        }
+
+        model.update().map_err(gurobi_error)?;
+
+        Ok(Self {
+            _env: env,
+            model,
+            row_constraints,
+            error_vars,
+            num_detectors: problem.num_detectors,
+            forced_syndrome: problem.forced_syndrome.clone(),
+        })
+    }
+}
+
+impl BatchBackend for GurobiBatchBackend {
+    fn solve(&mut self, syndrome: &[bool]) -> Result<Vec<bool>, IlpDecodeError> {
+        if syndrome.len() != self.num_detectors {
+            return Err(IlpDecodeError::DetectorWidthMismatch {
+                expected: self.num_detectors,
+                actual: syndrome.len(),
+            });
+        }
+
+        for (row, (&bit, &forced)) in syndrome.iter().zip(&self.forced_syndrome).enumerate() {
+            let rhs = if bit ^ forced { 1.0 } else { 0.0 };
+            self.row_constraints[row]
+                .set(&mut self.model, attr::RHS, rhs)
+                .map_err(gurobi_error)?;
+        }
+
+        self.model.optimize().map_err(gurobi_error)?;
+        let status = self.model.status().map_err(gurobi_error)?;
+        let sol_count = self.model.get(attr::SolCount).map_err(gurobi_error)?;
+        if !accept_gurobi_status(status, sol_count) {
+            return Err(IlpDecodeError::Gurobi(format!(
+                "unexpected Gurobi solve status: status={status:?}, sol_count={sol_count}"
+            )));
+        }
+
+        let values = self
+            .model
+            .get_values(attr::X, &self.error_vars)
+            .map_err(gurobi_error)?;
+
+        Ok(values.into_iter().map(|value| value > 0.5).collect())
+    }
+}
+
+fn accept_gurobi_status(status: Status, sol_count: i32) -> bool {
+    match status {
+        Status::Optimal => true,
+        Status::TimeLimit | Status::SolutionLimit | Status::SubOptimal => sol_count > 0,
+        _ => false,
+    }
+}
+
+fn gurobi_error(err: gurobi::Error) -> IlpDecodeError {
+    IlpDecodeError::Gurobi(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use gurobi::Status;
+
+    use super::accept_gurobi_status;
+
+    #[test]
+    fn accepts_optimal_status_without_solution_count_check() {
+        assert!(accept_gurobi_status(Status::Optimal, 0));
+    }
+
+    #[test]
+    fn accepts_time_limited_run_with_incumbent() {
+        assert!(accept_gurobi_status(Status::TimeLimit, 1));
+    }
+
+    #[test]
+    fn rejects_time_limited_run_without_incumbent() {
+        assert!(!accept_gurobi_status(Status::TimeLimit, 0));
+    }
+}

--- a/rilpqec/src/backend/highs.rs
+++ b/rilpqec/src/backend/highs.rs
@@ -1,0 +1,114 @@
+use std::num::NonZeroU32;
+use std::os::raw::c_int;
+
+use highs::{ColProblem, HighsModelStatus, Model};
+
+use crate::backend::BatchBackend;
+use crate::config::IlpDecoderConfig;
+use crate::error::IlpDecodeError;
+use crate::problem::LoweredDemProblem;
+
+#[derive(Debug)]
+pub struct HighsBatchBackend {
+    model: Option<Model>,
+    num_detectors: usize,
+    num_columns: usize,
+    forced_syndrome: Vec<bool>,
+}
+
+impl HighsBatchBackend {
+    pub fn new(
+        problem: &LoweredDemProblem,
+        config: &IlpDecoderConfig,
+    ) -> Result<Self, IlpDecodeError> {
+        let mut col_problem = ColProblem::new();
+        let mut rows = Vec::with_capacity(problem.num_detectors);
+        for _ in 0..problem.num_detectors {
+            rows.push(col_problem.add_row(0.0..=0.0));
+        }
+
+        for column in &problem.columns {
+            let entries = column.detectors.iter().map(|&det| (rows[det], 1.0));
+            col_problem.add_integer_column(column.weight, 0.0..=1.0, entries);
+        }
+
+        let mut model = Model::try_new(col_problem)
+            .map_err(|err| IlpDecodeError::Highs(format!("failed to create model: {err:?}")))?;
+        if !config.backend.verbose {
+            model.make_quiet();
+        }
+        if let Some(threads) = config.backend.threads.and_then(NonZeroU32::new) {
+            model.set_threads(threads);
+        }
+        if let Some(limit) = config.backend.time_limit_seconds {
+            model.try_set_option("time_limit", limit).map_err(|err| {
+                IlpDecodeError::Highs(format!("failed to set time_limit option: {err:?}"))
+            })?;
+        }
+        if let Some(gap) = config.backend.mip_gap {
+            model.try_set_option("mip_rel_gap", gap).map_err(|err| {
+                IlpDecodeError::Highs(format!("failed to set mip_rel_gap option: {err:?}"))
+            })?;
+        }
+
+        Ok(Self {
+            model: Some(model),
+            num_detectors: problem.num_detectors,
+            num_columns: problem.columns.len(),
+            forced_syndrome: problem.forced_syndrome.clone(),
+        })
+    }
+}
+
+impl BatchBackend for HighsBatchBackend {
+    fn solve(&mut self, syndrome: &[bool]) -> Result<Vec<bool>, IlpDecodeError> {
+        if syndrome.len() != self.num_detectors {
+            return Err(IlpDecodeError::DetectorWidthMismatch {
+                expected: self.num_detectors,
+                actual: syndrome.len(),
+            });
+        }
+
+        let mut model = self
+            .model
+            .take()
+            .ok_or_else(|| IlpDecodeError::Highs("model already in use".to_string()))?;
+
+        for (row, (&bit, &forced)) in syndrome.iter().zip(&self.forced_syndrome).enumerate() {
+            let rhs = if bit ^ forced { 1.0 } else { 0.0 };
+            let status = unsafe {
+                highs_sys::Highs_changeRowBounds(model.as_mut_ptr(), row as c_int, rhs, rhs)
+            };
+            if status != highs_sys::STATUS_OK {
+                self.model = Some(model);
+                return Err(IlpDecodeError::Highs(format!(
+                    "failed to set row bounds for detector {row}: status {status}"
+                )));
+            }
+        }
+
+        let solved = model
+            .try_solve()
+            .map_err(|err| IlpDecodeError::Highs(format!("solve failed: {err:?}")))?;
+        if solved.status() != HighsModelStatus::Optimal {
+            let status = solved.status();
+            self.model = Some(solved.into());
+            return Err(IlpDecodeError::Highs(format!(
+                "expected optimal solution, got {status:?}"
+            )));
+        }
+
+        let columns = solved.get_solution().columns().to_vec();
+        self.model = Some(solved.into());
+
+        if columns.len() != self.num_columns {
+            return Err(IlpDecodeError::Highs(format!(
+                "solution width mismatch: expected {}, got {}",
+                self.num_columns,
+                columns.len()
+            )));
+        }
+
+        Ok(columns.into_iter().map(|value| value > 0.5).collect())
+    }
+}

--- a/rilpqec/src/backend/highs.rs
+++ b/rilpqec/src/backend/highs.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU32;
 use std::os::raw::c_int;
 
-use highs::{ColProblem, HighsModelStatus, Model};
+use highs::{ColProblem, HighsModelStatus, HighsSolutionStatus, Model};
 
 use crate::backend::BatchBackend;
 use crate::config::IlpDecoderConfig;
@@ -12,7 +12,7 @@ use crate::problem::LoweredDemProblem;
 pub struct HighsBatchBackend {
     model: Option<Model>,
     num_detectors: usize,
-    num_columns: usize,
+    num_error_columns: usize,
     forced_syndrome: Vec<bool>,
 }
 
@@ -30,6 +30,9 @@ impl HighsBatchBackend {
         for column in &problem.columns {
             let entries = column.detectors.iter().map(|&det| (rows[det], 1.0));
             col_problem.add_integer_column(column.weight, 0.0..=1.0, entries);
+        }
+        for &row in &rows {
+            col_problem.add_integer_column(0.0, 0.0.., [(row, -2.0)]);
         }
 
         let mut model = Model::try_new(col_problem)
@@ -54,9 +57,20 @@ impl HighsBatchBackend {
         Ok(Self {
             model: Some(model),
             num_detectors: problem.num_detectors,
-            num_columns: problem.columns.len(),
+            num_error_columns: problem.columns.len(),
             forced_syndrome: problem.forced_syndrome.clone(),
         })
+    }
+}
+
+fn accept_solved_model_status(
+    model_status: HighsModelStatus,
+    primal_status: HighsSolutionStatus,
+) -> bool {
+    match model_status {
+        HighsModelStatus::Optimal => true,
+        HighsModelStatus::ReachedTimeLimit => primal_status == HighsSolutionStatus::Feasible,
+        _ => false,
     }
 }
 
@@ -90,25 +104,69 @@ impl BatchBackend for HighsBatchBackend {
         let solved = model
             .try_solve()
             .map_err(|err| IlpDecodeError::Highs(format!("solve failed: {err:?}")))?;
-        if solved.status() != HighsModelStatus::Optimal {
-            let status = solved.status();
+        let model_status = solved.status();
+        let primal_status = solved.primal_solution_status();
+        if !accept_solved_model_status(model_status, primal_status) {
             self.model = Some(solved.into());
             return Err(IlpDecodeError::Highs(format!(
-                "expected optimal solution, got {status:?}"
+                "unexpected HiGHS solve status: model={model_status:?}, primal={primal_status:?}"
             )));
         }
 
         let columns = solved.get_solution().columns().to_vec();
         self.model = Some(solved.into());
 
-        if columns.len() != self.num_columns {
+        let expected_solution_width = self.num_error_columns + self.num_detectors;
+        if columns.len() != expected_solution_width {
             return Err(IlpDecodeError::Highs(format!(
                 "solution width mismatch: expected {}, got {}",
-                self.num_columns,
+                expected_solution_width,
                 columns.len()
             )));
         }
 
-        Ok(columns.into_iter().map(|value| value > 0.5).collect())
+        Ok(columns[..self.num_error_columns]
+            .iter()
+            .map(|&value| value > 0.5)
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use highs::{HighsModelStatus, HighsSolutionStatus};
+
+    use super::accept_solved_model_status;
+
+    #[test]
+    fn accepts_optimal_solution() {
+        assert!(accept_solved_model_status(
+            HighsModelStatus::Optimal,
+            HighsSolutionStatus::Feasible,
+        ));
+    }
+
+    #[test]
+    fn accepts_time_limited_feasible_solution() {
+        assert!(accept_solved_model_status(
+            HighsModelStatus::ReachedTimeLimit,
+            HighsSolutionStatus::Feasible,
+        ));
+    }
+
+    #[test]
+    fn rejects_time_limited_run_without_feasible_solution() {
+        assert!(!accept_solved_model_status(
+            HighsModelStatus::ReachedTimeLimit,
+            HighsSolutionStatus::None,
+        ));
+    }
+
+    #[test]
+    fn rejects_other_non_optimal_statuses_even_with_feasible_solution() {
+        assert!(!accept_solved_model_status(
+            HighsModelStatus::ReachedInterrupt,
+            HighsSolutionStatus::Feasible,
+        ));
     }
 }

--- a/rilpqec/src/backend/mod.rs
+++ b/rilpqec/src/backend/mod.rs
@@ -14,7 +14,10 @@ pub fn build_batch_backend(
 ) -> Result<Box<dyn BatchBackend>, IlpDecodeError> {
     match config.backend.kind {
         BackendKind::Highs => Ok(Box::new(highs::HighsBatchBackend::new(problem, config)?)),
-        BackendKind::Auto | BackendKind::Gurobi => Err(IlpDecodeError::BackendUnavailable {
+        BackendKind::Auto => Err(IlpDecodeError::BackendUnavailable {
+            requested: BackendKind::Auto,
+        }),
+        BackendKind::Gurobi => Err(IlpDecodeError::BackendUnavailable {
             requested: BackendKind::Gurobi,
         }),
     }

--- a/rilpqec/src/backend/mod.rs
+++ b/rilpqec/src/backend/mod.rs
@@ -1,0 +1,21 @@
+mod highs;
+
+use crate::config::{BackendKind, IlpDecoderConfig};
+use crate::error::IlpDecodeError;
+use crate::problem::LoweredDemProblem;
+
+pub trait BatchBackend {
+    fn solve(&mut self, syndrome: &[bool]) -> Result<Vec<bool>, IlpDecodeError>;
+}
+
+pub fn build_batch_backend(
+    problem: &LoweredDemProblem,
+    config: &IlpDecoderConfig,
+) -> Result<Box<dyn BatchBackend>, IlpDecodeError> {
+    match config.backend.kind {
+        BackendKind::Highs => Ok(Box::new(highs::HighsBatchBackend::new(problem, config)?)),
+        BackendKind::Auto | BackendKind::Gurobi => Err(IlpDecodeError::BackendUnavailable {
+            requested: BackendKind::Gurobi,
+        }),
+    }
+}

--- a/rilpqec/src/backend/mod.rs
+++ b/rilpqec/src/backend/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "gurobi")]
+mod gurobi;
 mod highs;
 
 use crate::config::{BackendKind, IlpDecoderConfig};
@@ -14,11 +16,37 @@ pub fn build_batch_backend(
 ) -> Result<Box<dyn BatchBackend>, IlpDecodeError> {
     match config.backend.kind {
         BackendKind::Highs => Ok(Box::new(highs::HighsBatchBackend::new(problem, config)?)),
-        BackendKind::Auto => Err(IlpDecodeError::BackendUnavailable {
-            requested: BackendKind::Auto,
-        }),
-        BackendKind::Gurobi => Err(IlpDecodeError::BackendUnavailable {
+        BackendKind::Auto => build_auto_backend(problem, config),
+        BackendKind::Gurobi => build_gurobi_backend(problem, config),
+    }
+}
+
+fn build_auto_backend(
+    problem: &LoweredDemProblem,
+    config: &IlpDecoderConfig,
+) -> Result<Box<dyn BatchBackend>, IlpDecodeError> {
+    #[cfg(feature = "gurobi")]
+    if let Ok(backend) = gurobi::GurobiBatchBackend::new(problem, config) {
+        return Ok(Box::new(backend));
+    }
+
+    Ok(Box::new(highs::HighsBatchBackend::new(problem, config)?))
+}
+
+fn build_gurobi_backend(
+    problem: &LoweredDemProblem,
+    config: &IlpDecoderConfig,
+) -> Result<Box<dyn BatchBackend>, IlpDecodeError> {
+    #[cfg(feature = "gurobi")]
+    {
+        return Ok(Box::new(gurobi::GurobiBatchBackend::new(problem, config)?));
+    }
+
+    #[cfg(not(feature = "gurobi"))]
+    {
+        let _ = (problem, config);
+        Err(IlpDecodeError::BackendUnavailable {
             requested: BackendKind::Gurobi,
-        }),
+        })
     }
 }

--- a/rilpqec/src/config.rs
+++ b/rilpqec/src/config.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendKind {
+    Auto,
+    Highs,
+    Gurobi,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BackendConfig {
+    pub kind: BackendKind,
+    pub time_limit_seconds: Option<f64>,
+    pub mip_gap: Option<f64>,
+    pub threads: Option<u32>,
+    pub verbose: bool,
+}
+
+impl Default for BackendConfig {
+    fn default() -> Self {
+        Self {
+            kind: BackendKind::Auto,
+            time_limit_seconds: None,
+            mip_gap: None,
+            threads: None,
+            verbose: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct IlpDecoderConfig {
+    pub backend: BackendConfig,
+}

--- a/rilpqec/src/decoder.rs
+++ b/rilpqec/src/decoder.rs
@@ -1,0 +1,69 @@
+use rstim::dem::DetectorErrorModel;
+
+use crate::backend::build_batch_backend;
+use crate::config::IlpDecoderConfig;
+use crate::error::IlpDecodeError;
+use crate::lowering::lower_dem_to_problem;
+use crate::problem::LoweredDemProblem;
+
+#[derive(Debug, Clone)]
+pub struct IlpDemDecoder {
+    problem: LoweredDemProblem,
+    config: IlpDecoderConfig,
+}
+
+impl IlpDemDecoder {
+    pub fn from_dem(
+        dem: &DetectorErrorModel,
+        config: IlpDecoderConfig,
+    ) -> Result<Self, IlpDecodeError> {
+        Ok(Self {
+            problem: lower_dem_to_problem(dem)?,
+            config,
+        })
+    }
+
+    pub fn decode_batch_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Result<Vec<u8>, IlpDecodeError> {
+        if num_dets != self.problem.num_detectors {
+            return Err(IlpDecodeError::DetectorWidthMismatch {
+                expected: self.problem.num_detectors,
+                actual: num_dets,
+            });
+        }
+        if num_obs != self.problem.num_observables {
+            return Err(IlpDecodeError::ObservableWidthMismatch {
+                expected: self.problem.num_observables,
+                actual: num_obs,
+            });
+        }
+
+        let det_bytes = num_dets.div_ceil(8);
+        let obs_bytes = num_obs.div_ceil(8);
+        let mut out = vec![0u8; num_shots * obs_bytes];
+        let mut backend = build_batch_backend(&self.problem, &self.config)?;
+
+        for shot in 0..num_shots {
+            let mut syndrome = vec![false; num_dets];
+            for det in 0..num_dets {
+                let byte = dets[shot * det_bytes + (det / 8)];
+                syndrome[det] = ((byte >> (det % 8)) & 1) != 0;
+            }
+
+            let correction = backend.solve(&syndrome)?;
+            let observables = self.problem.observables_from_correction(&correction)?;
+            for obs in 0..num_obs {
+                if observables[obs] {
+                    out[shot * obs_bytes + (obs / 8)] |= 1 << (obs % 8);
+                }
+            }
+        }
+
+        Ok(out)
+    }
+}

--- a/rilpqec/src/decoder.rs
+++ b/rilpqec/src/decoder.rs
@@ -45,7 +45,24 @@ impl IlpDemDecoder {
 
         let det_bytes = num_dets.div_ceil(8);
         let obs_bytes = num_obs.div_ceil(8);
+        let expected_det_len = num_shots * det_bytes;
+        if dets.len() != expected_det_len {
+            return Err(IlpDecodeError::PackedDetectionsLengthMismatch {
+                expected: expected_det_len,
+                actual: dets.len(),
+            });
+        }
         let mut out = vec![0u8; num_shots * obs_bytes];
+        if self.problem.columns.is_empty() {
+            for shot in 0..num_shots {
+                for obs in 0..num_obs {
+                    if self.problem.baseline_observables[obs] {
+                        out[shot * obs_bytes + (obs / 8)] |= 1 << (obs % 8);
+                    }
+                }
+            }
+            return Ok(out);
+        }
         let mut backend = build_batch_backend(&self.problem, &self.config)?;
 
         for shot in 0..num_shots {

--- a/rilpqec/src/error.rs
+++ b/rilpqec/src/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum IlpDecodeError {
+    #[error("DEM probability must lie in [0, 1], got {0}")]
+    InvalidProbability(f64),
+    #[error("detector width mismatch: expected {expected}, got {actual}")]
+    DetectorWidthMismatch { expected: usize, actual: usize },
+    #[error("observable width mismatch: expected {expected}, got {actual}")]
+    ObservableWidthMismatch { expected: usize, actual: usize },
+    #[error("no ILP backend is available for kind {requested:?}")]
+    BackendUnavailable {
+        requested: crate::config::BackendKind,
+    },
+    #[error("HiGHS backend error: {0}")]
+    Highs(String),
+    #[cfg(feature = "gurobi")]
+    #[error("Gurobi backend error: {0}")]
+    Gurobi(String),
+}

--- a/rilpqec/src/error.rs
+++ b/rilpqec/src/error.rs
@@ -6,6 +6,8 @@ pub enum IlpDecodeError {
     InvalidProbability(f64),
     #[error("detector width mismatch: expected {expected}, got {actual}")]
     DetectorWidthMismatch { expected: usize, actual: usize },
+    #[error("correction width mismatch: expected {expected}, got {actual}")]
+    CorrectionWidthMismatch { expected: usize, actual: usize },
     #[error("observable width mismatch: expected {expected}, got {actual}")]
     ObservableWidthMismatch { expected: usize, actual: usize },
     #[error("no ILP backend is available for kind {requested:?}")]

--- a/rilpqec/src/error.rs
+++ b/rilpqec/src/error.rs
@@ -1,11 +1,13 @@
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum IlpDecodeError {
     #[error("DEM probability must lie in [0, 1], got {0}")]
     InvalidProbability(f64),
     #[error("detector width mismatch: expected {expected}, got {actual}")]
     DetectorWidthMismatch { expected: usize, actual: usize },
+    #[error("packed detection buffer length mismatch: expected {expected}, got {actual}")]
+    PackedDetectionsLengthMismatch { expected: usize, actual: usize },
     #[error("correction width mismatch: expected {expected}, got {actual}")]
     CorrectionWidthMismatch { expected: usize, actual: usize },
     #[error("observable width mismatch: expected {expected}, got {actual}")]

--- a/rilpqec/src/lib.rs
+++ b/rilpqec/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod config;
+pub mod error;
+
+pub use config::{BackendConfig, BackendKind, IlpDecoderConfig};
+pub use error::IlpDecodeError;

--- a/rilpqec/src/lib.rs
+++ b/rilpqec/src/lib.rs
@@ -1,5 +1,9 @@
 pub mod config;
 pub mod error;
+pub mod lowering;
+pub mod problem;
 
 pub use config::{BackendConfig, BackendKind, IlpDecoderConfig};
 pub use error::IlpDecodeError;
+pub use lowering::lower_dem_to_problem;
+pub use problem::{ColumnTerm, LoweredDemProblem};

--- a/rilpqec/src/lib.rs
+++ b/rilpqec/src/lib.rs
@@ -1,9 +1,12 @@
+pub mod backend;
 pub mod config;
+pub mod decoder;
 pub mod error;
 pub mod lowering;
 pub mod problem;
 
 pub use config::{BackendConfig, BackendKind, IlpDecoderConfig};
+pub use decoder::IlpDemDecoder;
 pub use error::IlpDecodeError;
 pub use lowering::lower_dem_to_problem;
 pub use problem::{ColumnTerm, LoweredDemProblem};

--- a/rilpqec/src/lowering.rs
+++ b/rilpqec/src/lowering.rs
@@ -1,0 +1,146 @@
+use std::collections::BTreeSet;
+
+use rstim::dem::{DemInstruction, DemTarget, DetectorErrorModel};
+
+use crate::error::IlpDecodeError;
+use crate::problem::{ColumnTerm, LoweredDemProblem};
+
+pub fn lower_dem_to_problem(dem: &DetectorErrorModel) -> Result<LoweredDemProblem, IlpDecodeError> {
+    let num_detectors = dem.effective_num_detectors();
+    let num_observables = dem.num_observables();
+    let mut columns = Vec::new();
+    let mut forced_syndrome = vec![false; num_detectors];
+    let mut baseline_observables = vec![false; num_observables];
+
+    visit_dem(
+        dem.instructions(),
+        0,
+        &mut columns,
+        &mut forced_syndrome,
+        &mut baseline_observables,
+    )?;
+
+    Ok(LoweredDemProblem {
+        num_detectors,
+        num_observables,
+        columns,
+        forced_syndrome,
+        baseline_observables,
+    })
+}
+
+fn visit_dem(
+    instrs: &[DemInstruction],
+    detector_offset: usize,
+    columns: &mut Vec<ColumnTerm>,
+    forced_syndrome: &mut [bool],
+    baseline_observables: &mut [bool],
+) -> Result<usize, IlpDecodeError> {
+    let mut offset = detector_offset;
+    for instr in instrs {
+        match instr {
+            DemInstruction::Error {
+                probability,
+                targets,
+            } => {
+                push_error_term(
+                    *probability,
+                    targets,
+                    offset,
+                    columns,
+                    forced_syndrome,
+                    baseline_observables,
+                )?;
+            }
+            DemInstruction::ShiftDetectors {
+                detector_offset, ..
+            } => {
+                offset += detector_offset;
+            }
+            DemInstruction::Repeat { count, body } => {
+                for _ in 0..*count {
+                    offset = visit_dem(
+                        body.instructions(),
+                        offset,
+                        columns,
+                        forced_syndrome,
+                        baseline_observables,
+                    )?;
+                }
+            }
+            DemInstruction::Detector { .. } | DemInstruction::LogicalObservable { .. } => {}
+        }
+    }
+    Ok(offset)
+}
+
+fn push_error_term(
+    probability: f64,
+    targets: &[DemTarget],
+    detector_offset: usize,
+    columns: &mut Vec<ColumnTerm>,
+    forced_syndrome: &mut [bool],
+    baseline_observables: &mut [bool],
+) -> Result<(), IlpDecodeError> {
+    if !(0.0..=1.0).contains(&probability) {
+        return Err(IlpDecodeError::InvalidProbability(probability));
+    }
+
+    let mut detectors = BTreeSet::new();
+    let mut observables = BTreeSet::new();
+    for target in targets {
+        match target {
+            DemTarget::Detector(det) => toggle(&mut detectors, detector_offset + det),
+            DemTarget::Observable(obs) => toggle(&mut observables, *obs),
+            DemTarget::Separator => {}
+        }
+    }
+
+    let detectors: Vec<usize> = detectors.into_iter().collect();
+    let observables: Vec<usize> = observables.into_iter().collect();
+
+    if probability == 0.0 {
+        return Ok(());
+    }
+
+    if probability == 1.0 {
+        xor_indices(forced_syndrome, &detectors);
+        xor_indices(baseline_observables, &observables);
+        return Ok(());
+    }
+
+    let mut effective_probability = probability;
+    if probability > 0.5 {
+        xor_indices(forced_syndrome, &detectors);
+        xor_indices(baseline_observables, &observables);
+        effective_probability = 1.0 - probability;
+    }
+
+    if detectors.is_empty() {
+        return Ok(());
+    }
+
+    columns.push(ColumnTerm {
+        detectors,
+        observables,
+        weight: log_likelihood_weight(effective_probability),
+    });
+    Ok(())
+}
+
+fn log_likelihood_weight(probability: f64) -> f64 {
+    let p = probability.clamp(1e-12, 1.0 - 1e-12);
+    ((1.0 - p) / p).ln()
+}
+
+fn toggle(set: &mut BTreeSet<usize>, value: usize) {
+    if !set.insert(value) {
+        set.remove(&value);
+    }
+}
+
+fn xor_indices(bits: &mut [bool], indices: &[usize]) {
+    for &index in indices {
+        bits[index] ^= true;
+    }
+}

--- a/rilpqec/src/problem.rs
+++ b/rilpqec/src/problem.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnTerm {
+    pub detectors: Vec<usize>,
+    pub observables: Vec<usize>,
+    pub weight: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoweredDemProblem {
+    pub num_detectors: usize,
+    pub num_observables: usize,
+    pub columns: Vec<ColumnTerm>,
+    pub forced_syndrome: Vec<bool>,
+    pub baseline_observables: Vec<bool>,
+}
+
+impl LoweredDemProblem {
+    pub fn observables_from_correction(&self, correction: &[bool]) -> Vec<bool> {
+        let mut out = self.baseline_observables.clone();
+        for (column, enabled) in self.columns.iter().zip(correction.iter().copied()) {
+            if !enabled {
+                continue;
+            }
+            for &obs in &column.observables {
+                out[obs] ^= true;
+            }
+        }
+        out
+    }
+}

--- a/rilpqec/src/problem.rs
+++ b/rilpqec/src/problem.rs
@@ -1,3 +1,5 @@
+use crate::error::IlpDecodeError;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ColumnTerm {
     pub detectors: Vec<usize>,
@@ -15,7 +17,17 @@ pub struct LoweredDemProblem {
 }
 
 impl LoweredDemProblem {
-    pub fn observables_from_correction(&self, correction: &[bool]) -> Vec<bool> {
+    pub fn observables_from_correction(
+        &self,
+        correction: &[bool],
+    ) -> Result<Vec<bool>, IlpDecodeError> {
+        if correction.len() != self.columns.len() {
+            return Err(IlpDecodeError::CorrectionWidthMismatch {
+                expected: self.columns.len(),
+                actual: correction.len(),
+            });
+        }
+
         let mut out = self.baseline_observables.clone();
         for (column, enabled) in self.columns.iter().zip(correction.iter().copied()) {
             if !enabled {
@@ -25,6 +37,6 @@ impl LoweredDemProblem {
                 out[obs] ^= true;
             }
         }
-        out
+        Ok(out)
     }
 }

--- a/rilpqec/tests/backend_auto.rs
+++ b/rilpqec/tests/backend_auto.rs
@@ -1,0 +1,71 @@
+use rilpqec::{BackendConfig, BackendKind, IlpDecoderConfig, IlpDemDecoder};
+#[cfg(not(feature = "gurobi"))]
+use rilpqec::IlpDecodeError;
+use rstim::dem::DetectorErrorModel;
+
+#[test]
+fn auto_backend_falls_back_to_highs() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\nerror(0.2) D1\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(&dem, IlpDecoderConfig::default()).unwrap();
+
+    let predictions = decoder
+        .decode_batch_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap();
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[cfg(not(feature = "gurobi"))]
+#[test]
+fn explicit_gurobi_selection_reports_unavailable_without_feature() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Gurobi,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: None,
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let err = decoder
+        .decode_batch_bit_packed(&[0b0000_0001], 1, 1, 1)
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        IlpDecodeError::BackendUnavailable {
+            requested: BackendKind::Gurobi,
+        }
+    );
+}
+
+#[cfg(feature = "gurobi")]
+#[test]
+fn explicit_gurobi_selection_decodes_with_the_gurobi_backend() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\nerror(0.2) D1\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Gurobi,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: Some(1),
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let predictions = decoder
+        .decode_batch_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap();
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}

--- a/rilpqec/tests/highs_backend.rs
+++ b/rilpqec/tests/highs_backend.rs
@@ -1,0 +1,49 @@
+use rilpqec::{BackendConfig, BackendKind, IlpDecoderConfig, IlpDemDecoder};
+use rstim::dem::DetectorErrorModel;
+
+#[test]
+fn highs_decodes_a_single_observable_flip() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\nerror(0.2) D1\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Highs,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: Some(1),
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let predictions = decoder
+        .decode_batch_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap();
+    assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[test]
+fn highs_reuses_one_batch_backend_for_multiple_shots() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\nerror(0.1) D1\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Highs,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: Some(1),
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let predictions = decoder
+        .decode_batch_bit_packed(&[0b0000_0001, 0b0000_0000], 2, 2, 1)
+        .unwrap();
+
+    assert_eq!(predictions, vec![0b0000_0001, 0b0000_0000]);
+}

--- a/rilpqec/tests/highs_backend.rs
+++ b/rilpqec/tests/highs_backend.rs
@@ -1,4 +1,4 @@
-use rilpqec::{BackendConfig, BackendKind, IlpDecoderConfig, IlpDemDecoder};
+use rilpqec::{BackendConfig, BackendKind, IlpDecodeError, IlpDecoderConfig, IlpDemDecoder};
 use rstim::dem::DetectorErrorModel;
 
 #[test]
@@ -46,4 +46,80 @@ fn highs_reuses_one_batch_backend_for_multiple_shots() {
         .unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001, 0b0000_0000]);
+}
+
+#[test]
+fn decode_batch_rejects_short_packed_detection_buffer() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\nerror(0.1) D1\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Highs,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: Some(1),
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let err = decoder
+        .decode_batch_bit_packed(&[0b0000_0001], 2, 2, 1)
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        IlpDecodeError::PackedDetectionsLengthMismatch {
+            expected: 2,
+            actual: 1,
+        }
+    );
+}
+
+#[test]
+fn highs_supports_parity_solutions_requiring_two_columns_on_one_detector() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 D1\nerror(0.1) D0 L0\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Highs,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: Some(1),
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let predictions = decoder
+        .decode_batch_bit_packed(&[0b0000_0010], 1, 2, 1)
+        .unwrap();
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[test]
+fn decode_batch_handles_baseline_only_problem_without_building_a_solver_model() {
+    let dem = DetectorErrorModel::parse("error(0.75) L0\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Highs,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: Some(1),
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let predictions = decoder.decode_batch_bit_packed(&[], 1, 0, 1).unwrap();
+
+    assert_eq!(predictions, vec![0b0000_0001]);
 }

--- a/rilpqec/tests/highs_backend.rs
+++ b/rilpqec/tests/highs_backend.rs
@@ -1,4 +1,8 @@
-use rilpqec::{BackendConfig, BackendKind, IlpDecodeError, IlpDecoderConfig, IlpDemDecoder};
+use rilpqec::backend::build_batch_backend;
+use rilpqec::{
+    lower_dem_to_problem, BackendConfig, BackendKind, IlpDecodeError, IlpDecoderConfig,
+    IlpDemDecoder,
+};
 use rstim::dem::DetectorErrorModel;
 
 #[test]
@@ -79,6 +83,66 @@ fn decode_batch_rejects_short_packed_detection_buffer() {
 }
 
 #[test]
+fn decode_batch_rejects_detector_width_mismatch_before_building_a_backend() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Highs,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: Some(1),
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let err = decoder
+        .decode_batch_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        IlpDecodeError::DetectorWidthMismatch {
+            expected: 1,
+            actual: 2,
+        }
+    );
+}
+
+#[test]
+fn decode_batch_rejects_observable_width_mismatch_before_building_a_backend() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\n").unwrap();
+    let decoder = IlpDemDecoder::from_dem(
+        &dem,
+        IlpDecoderConfig {
+            backend: BackendConfig {
+                kind: BackendKind::Highs,
+                time_limit_seconds: None,
+                mip_gap: None,
+                threads: Some(1),
+                verbose: false,
+            },
+        },
+    )
+    .unwrap();
+
+    let err = decoder
+        .decode_batch_bit_packed(&[0b0000_0001], 1, 1, 2)
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        IlpDecodeError::ObservableWidthMismatch {
+            expected: 1,
+            actual: 2,
+        }
+    );
+}
+
+#[test]
 fn highs_supports_parity_solutions_requiring_two_columns_on_one_detector() {
     let dem = DetectorErrorModel::parse("error(0.1) D0 D1\nerror(0.1) D0 L0\n").unwrap();
     let decoder = IlpDemDecoder::from_dem(
@@ -122,4 +186,50 @@ fn decode_batch_handles_baseline_only_problem_without_building_a_solver_model() 
     let predictions = decoder.decode_batch_bit_packed(&[], 1, 0, 1).unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[test]
+fn direct_highs_backend_supports_optional_solver_settings() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\nerror(0.2) D1\n").unwrap();
+    let problem = lower_dem_to_problem(&dem).unwrap();
+    let config = IlpDecoderConfig {
+        backend: BackendConfig {
+            kind: BackendKind::Highs,
+            time_limit_seconds: Some(1.0),
+            mip_gap: Some(0.05),
+            threads: Some(1),
+            verbose: false,
+        },
+    };
+
+    let mut backend = build_batch_backend(&problem, &config).unwrap();
+    let correction = backend.solve(&[true, false]).unwrap();
+
+    assert_eq!(correction, vec![true, false]);
+}
+
+#[test]
+fn direct_highs_backend_rejects_detector_width_mismatch() {
+    let dem = DetectorErrorModel::parse("error(0.1) D0 L0\n").unwrap();
+    let problem = lower_dem_to_problem(&dem).unwrap();
+    let config = IlpDecoderConfig {
+        backend: BackendConfig {
+            kind: BackendKind::Highs,
+            time_limit_seconds: None,
+            mip_gap: None,
+            threads: Some(1),
+            verbose: false,
+        },
+    };
+
+    let mut backend = build_batch_backend(&problem, &config).unwrap();
+    let err = backend.solve(&[true, false]).unwrap_err();
+
+    assert_eq!(
+        err,
+        IlpDecodeError::DetectorWidthMismatch {
+            expected: 1,
+            actual: 2,
+        }
+    );
 }

--- a/rilpqec/tests/lowering.rs
+++ b/rilpqec/tests/lowering.rs
@@ -1,4 +1,4 @@
-use rilpqec::lower_dem_to_problem;
+use rilpqec::{lower_dem_to_problem, IlpDecodeError};
 use rstim::dem::DetectorErrorModel;
 
 #[test]
@@ -34,4 +34,49 @@ fn repeat_shift_and_probability_extremes_become_forced_state_or_drop() {
     assert_eq!(problem.columns[0].detectors, vec![0, 1]);
     assert_eq!(problem.columns[1].detectors, vec![3, 4]);
     assert!(problem.columns.iter().all(|term| term.weight > 0.0));
+}
+
+#[test]
+fn observable_only_terms_are_dropped_after_baseline_normalization_rules() {
+    let high_dem = DetectorErrorModel::parse("error(0.75) L0\n").unwrap();
+    let high_problem = lower_dem_to_problem(&high_dem).unwrap();
+    assert!(high_problem.columns.is_empty());
+    assert_eq!(high_problem.baseline_observables, vec![true]);
+
+    let low_dem = DetectorErrorModel::parse("error(0.25) L0\n").unwrap();
+    let low_problem = lower_dem_to_problem(&low_dem).unwrap();
+    assert!(low_problem.columns.is_empty());
+    assert_eq!(low_problem.baseline_observables, vec![false]);
+}
+
+#[test]
+fn observables_from_correction_rejects_width_mismatch() {
+    let dem = DetectorErrorModel::parse("error(0.25) D0 L0\n").unwrap();
+    let problem = lower_dem_to_problem(&dem).unwrap();
+
+    assert!(matches!(
+        problem.observables_from_correction(&[]),
+        Err(IlpDecodeError::CorrectionWidthMismatch {
+            expected: 1,
+            actual: 0,
+        })
+    ));
+    assert!(matches!(
+        problem.observables_from_correction(&[true, false]),
+        Err(IlpDecodeError::CorrectionWidthMismatch {
+            expected: 1,
+            actual: 2,
+        })
+    ));
+}
+
+#[test]
+fn observables_from_correction_applies_columns_when_width_matches() {
+    let dem = DetectorErrorModel::parse("error(0.25) D0 L0\nerror(0.25) D1\n").unwrap();
+    let problem = lower_dem_to_problem(&dem).unwrap();
+
+    assert_eq!(
+        problem.observables_from_correction(&[true, false]).unwrap(),
+        vec![true]
+    );
 }

--- a/rilpqec/tests/lowering.rs
+++ b/rilpqec/tests/lowering.rs
@@ -80,3 +80,29 @@ fn observables_from_correction_applies_columns_when_width_matches() {
         vec![true]
     );
 }
+
+#[test]
+fn lowering_rejects_invalid_probability() {
+    let dem = DetectorErrorModel::parse("error(1.25) D0\n").unwrap();
+
+    assert_eq!(
+        lower_dem_to_problem(&dem).unwrap_err(),
+        IlpDecodeError::InvalidProbability(1.25)
+    );
+}
+
+#[test]
+fn detector_and_logical_observable_annotations_do_not_create_columns() {
+    let dem = DetectorErrorModel::parse(
+        "error(0.25) D0 L0\ndetector(1, 2) D0\nlogical_observable L3\n",
+    )
+    .unwrap();
+
+    let problem = lower_dem_to_problem(&dem).unwrap();
+
+    assert_eq!(problem.num_detectors, 1);
+    assert_eq!(problem.num_observables, 4);
+    assert_eq!(problem.columns.len(), 1);
+    assert_eq!(problem.columns[0].detectors, vec![0]);
+    assert_eq!(problem.columns[0].observables, vec![0]);
+}

--- a/rilpqec/tests/lowering.rs
+++ b/rilpqec/tests/lowering.rs
@@ -1,0 +1,37 @@
+use rilpqec::lower_dem_to_problem;
+use rstim::dem::DetectorErrorModel;
+
+#[test]
+fn separator_targets_are_merged_into_one_column() {
+    let dem = DetectorErrorModel::parse("error(0.25) D0 ^ D1 L0\n").unwrap();
+
+    let problem = lower_dem_to_problem(&dem).unwrap();
+
+    assert_eq!(problem.num_detectors, 2);
+    assert_eq!(problem.num_observables, 1);
+    assert_eq!(problem.columns.len(), 1);
+    assert_eq!(problem.columns[0].detectors, vec![0, 1]);
+    assert_eq!(problem.columns[0].observables, vec![0]);
+}
+
+#[test]
+fn repeat_shift_and_probability_extremes_become_forced_state_or_drop() {
+    let dem = DetectorErrorModel::parse(
+        "error(1) D0 L0\nerror(0) D0\nrepeat 2 {\n    error(0.75) D0 D1 L0\n    shift_detectors 3\n}\nerror(0.25) L0\n",
+    )
+    .unwrap();
+
+    let problem = lower_dem_to_problem(&dem).unwrap();
+
+    assert_eq!(problem.num_detectors, 5);
+    assert_eq!(problem.num_observables, 1);
+    assert_eq!(problem.columns.len(), 2);
+    assert_eq!(
+        problem.forced_syndrome,
+        vec![false, true, false, true, true]
+    );
+    assert_eq!(problem.baseline_observables, vec![true]);
+    assert_eq!(problem.columns[0].detectors, vec![0, 1]);
+    assert_eq!(problem.columns[1].detectors, vec![3, 4]);
+    assert!(problem.columns.iter().all(|term| term.weight > 0.0));
+}

--- a/rilpqec/tests/smoke.rs
+++ b/rilpqec/tests/smoke.rs
@@ -12,7 +12,7 @@ fn default_decoder_config_prefers_auto_backend() {
 }
 
 #[test]
-fn explicit_backend_config_is_copyable_and_comparable() {
+fn explicit_backend_config_supports_equality_comparison() {
     let cfg = BackendConfig {
         kind: BackendKind::Highs,
         time_limit_seconds: Some(12.5),

--- a/rilpqec/tests/smoke.rs
+++ b/rilpqec/tests/smoke.rs
@@ -21,9 +21,13 @@ fn explicit_backend_config_is_copyable_and_comparable() {
         verbose: true,
     };
 
-    assert_eq!(cfg.kind, BackendKind::Highs);
-    assert_eq!(cfg.time_limit_seconds, Some(12.5));
-    assert_eq!(cfg.mip_gap, Some(0.01));
-    assert_eq!(cfg.threads, Some(4));
-    assert!(cfg.verbose);
+    let expected = BackendConfig {
+        kind: BackendKind::Highs,
+        time_limit_seconds: Some(12.5),
+        mip_gap: Some(0.01),
+        threads: Some(4),
+        verbose: true,
+    };
+
+    assert_eq!(cfg, expected);
 }

--- a/rilpqec/tests/smoke.rs
+++ b/rilpqec/tests/smoke.rs
@@ -1,0 +1,29 @@
+use rilpqec::{BackendConfig, BackendKind, IlpDecoderConfig};
+
+#[test]
+fn default_decoder_config_prefers_auto_backend() {
+    let cfg = IlpDecoderConfig::default();
+
+    assert_eq!(cfg.backend.kind, BackendKind::Auto);
+    assert_eq!(cfg.backend.time_limit_seconds, None);
+    assert_eq!(cfg.backend.mip_gap, None);
+    assert_eq!(cfg.backend.threads, None);
+    assert!(!cfg.backend.verbose);
+}
+
+#[test]
+fn explicit_backend_config_is_copyable_and_comparable() {
+    let cfg = BackendConfig {
+        kind: BackendKind::Highs,
+        time_limit_seconds: Some(12.5),
+        mip_gap: Some(0.01),
+        threads: Some(4),
+        verbose: true,
+    };
+
+    assert_eq!(cfg.kind, BackendKind::Highs);
+    assert_eq!(cfg.time_limit_seconds, Some(12.5));
+    assert_eq!(cfg.mip_gap, Some(0.01));
+    assert_eq!(cfg.threads, Some(4));
+    assert!(cfg.verbose);
+}

--- a/rsinter/Cargo.toml
+++ b/rsinter/Cargo.toml
@@ -3,9 +3,14 @@ name = "rsinter"
 version = "0.1.1"
 edition = "2024"
 
+[features]
+default = []
+gurobi = ["rilpqec/gurobi"]
+
 [dependencies]
 rstim = { path = "../rstim" }
 rbposd = { path = "../rbposd" }
+rilpqec = { path = "../rilpqec" }
 rand = "0.8"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }

--- a/rsinter/src/decode.rs
+++ b/rsinter/src/decode.rs
@@ -1,5 +1,6 @@
 use rstim::dem::DetectorErrorModel;
 
+pub use crate::ilpqec_adapter::IlpDemDecoder;
 pub use crate::rbposd_adapter::RbposdDemDecoder;
 
 pub trait CompiledDecoder: Send {

--- a/rsinter/src/ilpqec_adapter.rs
+++ b/rsinter/src/ilpqec_adapter.rs
@@ -1,0 +1,48 @@
+use rilpqec::{BackendKind, IlpDecoderConfig};
+use rstim::dem::DetectorErrorModel;
+
+use crate::decode::{CompiledDecoder, Decoder};
+
+pub struct IlpDemDecoder {
+    config: IlpDecoderConfig,
+}
+
+impl IlpDemDecoder {
+    pub fn new(config: IlpDecoderConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for IlpDemDecoder {
+    fn default() -> Self {
+        let mut config = IlpDecoderConfig::default();
+        config.backend.kind = BackendKind::Auto;
+        Self::new(config)
+    }
+}
+
+struct CompiledIlpDemDecoder {
+    decoder: rilpqec::IlpDemDecoder,
+}
+
+impl Decoder for IlpDemDecoder {
+    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
+        let decoder = rilpqec::IlpDemDecoder::from_dem(dem, self.config.clone())
+            .expect("failed to compile ILP DEM decoder");
+        Box::new(CompiledIlpDemDecoder { decoder })
+    }
+}
+
+impl CompiledDecoder for CompiledIlpDemDecoder {
+    fn decode_shots_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Vec<u8> {
+        self.decoder
+            .decode_batch_bit_packed(dets, num_shots, num_dets, num_obs)
+            .expect("ILP DEM decode failed")
+    }
+}

--- a/rsinter/src/lib.rs
+++ b/rsinter/src/lib.rs
@@ -1,3 +1,4 @@
+mod ilpqec_adapter;
 mod rbposd_adapter;
 
 pub mod collect;

--- a/rsinter/tests/decode_ilp.rs
+++ b/rsinter/tests/decode_ilp.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+
+#[cfg(feature = "gurobi")]
+use rilpqec::{BackendConfig, BackendKind, IlpDecoderConfig};
+use rsinter::collect::{collect, CollectOptions};
+use rsinter::decode::{Decoder, IlpDemDecoder as RsinterIlpDemDecoder};
+use rsinter::task::{CollectionOptions, Task};
+use rstim::dem::DetectorErrorModel;
+use rstim::error_analyzer::ErrorAnalyzer;
+use rstim::parser::parse_lines;
+
+#[test]
+fn ilp_dem_decoder_predicts_a_single_observable_flip() {
+    let dem = DetectorErrorModel::parse("error(0.125) D0 L0\nerror(0.25) D1\n").unwrap();
+    let decoder = RsinterIlpDemDecoder::default();
+    let compiled = decoder.compile_for_dem(&dem);
+
+    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[test]
+fn ilp_dem_decoder_handles_observable_only_terms() {
+    let dem = DetectorErrorModel::parse("error(0.75) L0\n").unwrap();
+    let decoder = RsinterIlpDemDecoder::default();
+    let compiled = decoder.compile_for_dem(&dem);
+
+    let predictions = compiled.decode_shots_bit_packed(&[], 1, 0, 1);
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[test]
+fn collect_runs_with_the_ilp_adapter() {
+    let circuit =
+        parse_lines("R 0\nX_ERROR(0.05) 0\nM 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n")
+            .unwrap();
+    let dem = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
+
+    let task = Task {
+        circuit,
+        decoder: "ilp".into(),
+        dem,
+        metadata: serde_json::json!({"case": "single-qubit"}),
+        collection_options: CollectionOptions {
+            max_shots: Some(32),
+            max_errors: Some(32),
+        },
+    };
+
+    let mut decoders: HashMap<String, Box<dyn Decoder>> = HashMap::new();
+    decoders.insert("ilp".into(), Box::new(RsinterIlpDemDecoder::default()));
+
+    let results = collect(
+        vec![task],
+        decoders,
+        &CollectOptions {
+            num_workers: 1,
+            max_shots: None,
+            max_errors: None,
+            max_batch_size: Some(32),
+            start_batch_size: 8,
+            save_resume_filepath: None,
+            print_progress: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].shots > 0);
+}
+
+#[cfg(feature = "gurobi")]
+#[test]
+fn ilp_dem_decoder_can_explicitly_use_gurobi_through_rsinter() {
+    let dem = DetectorErrorModel::parse("error(0.125) D0 L0\nerror(0.25) D1\n").unwrap();
+    let decoder = RsinterIlpDemDecoder::new(IlpDecoderConfig {
+        backend: BackendConfig {
+            kind: BackendKind::Gurobi,
+            time_limit_seconds: None,
+            mip_gap: None,
+            threads: Some(1),
+            verbose: false,
+        },
+    });
+    let compiled = decoder.compile_for_dem(&dem);
+
+    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+
+    assert_eq!(predictions, vec![0b0000_0001]);
+}


### PR DESCRIPTION
## Summary
- add a feature-gated Gurobi batch backend in `rilpqec`, and make `BackendKind::Auto` prefer Gurobi when available while falling back to HiGHS by default
- fix the HiGHS parity formulation with integer auxiliary variables, add packed detection length validation and baseline-only fast paths, and broaden backend coverage tests
- integrate the ILP DEM decoder into `rsinter` with a thin adapter plus HiGHS and Gurobi integration tests

## Test Plan
- [x] `cargo test -p rilpqec`
- [x] `cargo test -p rilpqec --features gurobi`
- [x] `cargo test -p rsinter --test decode_ilp`
- [x] `cargo test -p rsinter --features gurobi --test decode_ilp`