### PR TITLE
Add qec-code Steane v1 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "qec-code",
     "rstim",
     "rsinter",
     "rbposd",

--- a/docs/superpowers/plans/2026-06-09-qec-code-steane-v1-implementation.md
+++ b/docs/superpowers/plans/2026-06-09-qec-code-steane-v1-implementation.md
@@ -1,0 +1,1048 @@
+# QEC Code Steane V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new in-workspace `qec-code` crate that models qubit stabilizer codes in binary symplectic form, ships Steane as the first built-in code, computes validated logical operators and exact small-code distance, and exposes a minimal CLI for inspecting Steane.
+
+**Architecture:** Build the crate in four layers. First scaffold the crate and the GF(2)/Pauli foundations. Then add the validated `StabilizerCode` core plus CSS and Steane constructors. Next implement logical-basis extraction and exact distance on top of the same core representation. Finish with a small `clap` CLI and smoke tests that exercise the Steane workflows end to end.
+
+**Tech Stack:** Rust 2024 workspace crate, `clap`, `thiserror`, `serde`, `serde_json`, `cargo test`, existing workspace conventions for `src/lib.rs`, `src/main.rs`, and `tests/*.rs`
+
+---
+
+## File Structure
+
+- Modify: `Cargo.toml`
+  - Add `qec-code` as a workspace member.
+- Create: `qec-code/Cargo.toml`
+  - Define the new package, library, and binary dependencies.
+- Create: `qec-code/src/lib.rs`
+  - Re-export the public API in dependency order.
+- Create: `qec-code/src/error.rs`
+  - Define domain-specific construction and analysis errors.
+- Create: `qec-code/src/binary.rs`
+  - Hold GF(2) matrix helpers used by code validation, logical extraction, and distance.
+- Create: `qec-code/src/pauli.rs`
+  - Hold binary symplectic `Pauli` representation, weight, and commutation helpers.
+- Create: `qec-code/src/code.rs`
+  - Define `StabilizerCode`, constructor validation, and basic invariants such as `n`, rank, and `k`.
+- Create: `qec-code/src/css.rs`
+  - Define CSS convenience construction from `Hx`/`Hz`.
+- Create: `qec-code/src/codes/mod.rs`
+  - Register built-in code modules.
+- Create: `qec-code/src/codes/steane.rs`
+  - Define `Steane::new()` and expose its stabilizer metadata.
+- Create: `qec-code/src/logical.rs`
+  - Define `LogicalBasis` and exact logical-operator extraction over the symplectic core.
+- Create: `qec-code/src/distance.rs`
+  - Define `DistanceResult` and exact small-code distance search.
+- Create: `qec-code/src/cli.rs`
+  - Define `clap` types and text/JSON output helpers for Steane inspection commands.
+- Create: `qec-code/src/main.rs`
+  - Parse CLI args and route to `qec_code::cli::run(...)`.
+- Create: `qec-code/tests/binary.rs`
+  - Cover GF(2) rank and span membership.
+- Create: `qec-code/tests/code.rs`
+  - Cover stabilizer-code validation, CSS construction, and Steane invariants.
+- Create: `qec-code/tests/logical_distance.rs`
+  - Cover logical-basis properties and exact Steane distance.
+- Create: `qec-code/tests/cli.rs`
+  - Cover Steane CLI subcommands and stable output surface.
+- Create: `docs/superpowers/plans/2026-06-09-qec-code-steane-v1-implementation.md`
+  - Implementation handoff for the approved design.
+
+## Task 1: Scaffold The `qec-code` Crate And Lock The Algebra Foundations
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `qec-code/Cargo.toml`
+- Create: `qec-code/src/lib.rs`
+- Create: `qec-code/src/error.rs`
+- Create: `qec-code/src/binary.rs`
+- Create: `qec-code/src/pauli.rs`
+- Create: `qec-code/tests/binary.rs`
+
+- [ ] **Step 1: Write the failing algebra tests**
+
+Create `qec-code/tests/binary.rs`:
+
+```rust
+use qec_code::binary::{binary_rank, in_row_span};
+use qec_code::pauli::Pauli;
+
+#[test]
+fn binary_rank_counts_independent_rows_over_gf2() {
+    let rows = vec![
+        vec![1, 0, 1, 0],
+        vec![0, 1, 1, 0],
+        vec![1, 1, 0, 0],
+    ];
+
+    assert_eq!(binary_rank(&rows), 2);
+}
+
+#[test]
+fn in_row_span_detects_membership_after_reduction() {
+    let basis = vec![
+        vec![1, 0, 1, 0],
+        vec![0, 1, 1, 0],
+    ];
+
+    assert!(in_row_span(&basis, &[1, 1, 0, 0]));
+    assert!(!in_row_span(&basis, &[1, 0, 0, 1]));
+}
+
+#[test]
+fn pauli_commutation_and_weight_follow_symplectic_rules() {
+    let x0 = Pauli::from_xz_bits(2, vec![1, 0], vec![0, 0]).unwrap();
+    let z0 = Pauli::from_xz_bits(2, vec![0, 0], vec![1, 0]).unwrap();
+    let x1 = Pauli::from_xz_bits(2, vec![0, 1], vec![0, 0]).unwrap();
+
+    assert_eq!(x0.weight(), 1);
+    assert!(x0.anticommutes_with(&z0));
+    assert!(x0.commutes_with(&x1));
+}
+```
+
+- [ ] **Step 2: Run the focused test target and verify it fails**
+
+Run:
+
+```bash
+cargo test -p qec-code --test binary -v
+```
+
+Expected: FAIL with `package ID specification 'qec-code' did not match any packages`.
+
+- [ ] **Step 3: Create the crate scaffold and minimal algebra implementation**
+
+Update the workspace root `Cargo.toml`:
+
+```toml
+[workspace]
+members = [
+    "rstim",
+    "rsinter",
+    "rbposd",
+    "rmatching",
+    "rilpqec",
+    "qec-code",
+    "benchmarks/surface_decoder_compare/rust_bridge",
+]
+resolver = "3"
+```
+
+Create `qec-code/Cargo.toml`:
+
+```toml
+[package]
+name = "qec-code"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"
+```
+
+Create `qec-code/src/error.rs`:
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum QecError {
+    #[error("row width mismatch: expected {expected}, got {actual}")]
+    RowWidthMismatch { expected: usize, actual: usize },
+    #[error("invalid pauli width: expected {expected}, got {actual}")]
+    InvalidPauliWidth { expected: usize, actual: usize },
+    #[error("stabilizers do not commute")]
+    NonCommutingStabilizers,
+    #[error("stabilizer generators are linearly dependent")]
+    DependentStabilizers,
+    #[error("css parity checks do not commute")]
+    InvalidCssOrthogonality,
+    #[error("logical basis could not be extracted")]
+    LogicalBasisNotFound,
+    #[error("distance witness could not be found")]
+    DistanceWitnessNotFound,
+}
+```
+
+Create `qec-code/src/binary.rs`:
+
+```rust
+pub fn binary_rank(rows: &[Vec<u8>]) -> usize {
+    let mut matrix = rows.to_vec();
+    eliminate_to_row_echelon(&mut matrix)
+}
+
+pub fn in_row_span(rows: &[Vec<u8>], target: &[u8]) -> bool {
+    let mut matrix = rows.to_vec();
+    matrix.push(target.to_vec());
+    binary_rank(&matrix) == binary_rank(rows)
+}
+
+pub fn eliminate_to_row_echelon(matrix: &mut [Vec<u8>]) -> usize {
+    if matrix.is_empty() {
+        return 0;
+    }
+    let width = matrix[0].len();
+    let mut rank = 0;
+
+    for col in 0..width {
+        let pivot = (rank..matrix.len()).find(|&row| matrix[row][col] == 1);
+        if let Some(pivot_row) = pivot {
+            matrix.swap(rank, pivot_row);
+            for row in 0..matrix.len() {
+                if row != rank && matrix[row][col] == 1 {
+                    for c in col..width {
+                        matrix[row][c] ^= matrix[rank][c];
+                    }
+                }
+            }
+            rank += 1;
+        }
+    }
+
+    rank
+}
+```
+
+Create `qec-code/src/pauli.rs`:
+
+```rust
+use crate::error::QecError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Pauli {
+    n: usize,
+    x: Vec<u8>,
+    z: Vec<u8>,
+}
+
+impl Pauli {
+    pub fn from_xz_bits(n: usize, x: Vec<u8>, z: Vec<u8>) -> Result<Self, QecError> {
+        if x.len() != n {
+            return Err(QecError::InvalidPauliWidth {
+                expected: n,
+                actual: x.len(),
+            });
+        }
+        if z.len() != n {
+            return Err(QecError::InvalidPauliWidth {
+                expected: n,
+                actual: z.len(),
+            });
+        }
+        Ok(Self { n, x, z })
+    }
+
+    pub fn n(&self) -> usize {
+        self.n
+    }
+
+    pub fn x_bits(&self) -> &[u8] {
+        &self.x
+    }
+
+    pub fn z_bits(&self) -> &[u8] {
+        &self.z
+    }
+
+    pub fn symplectic_product(&self, other: &Self) -> u8 {
+        let xz: u8 = self
+            .x
+            .iter()
+            .zip(other.z.iter())
+            .map(|(a, b)| a & b)
+            .fold(0, |acc, bit| acc ^ bit);
+        let zx: u8 = self
+            .z
+            .iter()
+            .zip(other.x.iter())
+            .map(|(a, b)| a & b)
+            .fold(0, |acc, bit| acc ^ bit);
+        xz ^ zx
+    }
+
+    pub fn commutes_with(&self, other: &Self) -> bool {
+        self.symplectic_product(other) == 0
+    }
+
+    pub fn anticommutes_with(&self, other: &Self) -> bool {
+        self.symplectic_product(other) == 1
+    }
+
+    pub fn weight(&self) -> usize {
+        self.x
+            .iter()
+            .zip(self.z.iter())
+            .filter(|(x, z)| **x == 1 || **z == 1)
+            .count()
+    }
+
+    pub fn to_symplectic_row(&self) -> Vec<u8> {
+        let mut row = self.x.clone();
+        row.extend_from_slice(&self.z);
+        row
+    }
+}
+```
+
+Create `qec-code/src/lib.rs`:
+
+```rust
+pub mod binary;
+pub mod error;
+pub mod pauli;
+
+pub use error::QecError;
+pub use pauli::Pauli;
+```
+
+- [ ] **Step 4: Run the focused algebra tests and verify they pass**
+
+Run:
+
+```bash
+cargo test -p qec-code --test binary -v
+```
+
+Expected: PASS with 3 passing tests in `tests/binary.rs`.
+
+- [ ] **Step 5: Commit the scaffold checkpoint**
+
+```bash
+git add Cargo.toml qec-code/Cargo.toml qec-code/src/lib.rs qec-code/src/error.rs qec-code/src/binary.rs qec-code/src/pauli.rs qec-code/tests/binary.rs
+git commit -m "feat: scaffold qec-code algebra foundations"
+```
+
+## Task 2: Add `StabilizerCode`, CSS Construction, And Built-In Steane
+
+**Files:**
+- Create: `qec-code/src/code.rs`
+- Create: `qec-code/src/css.rs`
+- Create: `qec-code/src/codes/mod.rs`
+- Create: `qec-code/src/codes/steane.rs`
+- Modify: `qec-code/src/lib.rs`
+- Create: `qec-code/tests/code.rs`
+
+- [ ] **Step 1: Write the failing code-construction tests**
+
+Create `qec-code/tests/code.rs`:
+
+```rust
+use qec_code::codes::steane::Steane;
+use qec_code::css::CssCode;
+use qec_code::{Pauli, QecError, StabilizerCode};
+
+#[test]
+fn stabilizer_code_rejects_non_commuting_generators() {
+    let x0 = Pauli::from_xz_bits(1, vec![1], vec![0]).unwrap();
+    let z0 = Pauli::from_xz_bits(1, vec![0], vec![1]).unwrap();
+
+    let err = StabilizerCode::from_stabilizers(1, vec![x0, z0]).unwrap_err();
+    assert_eq!(err, QecError::NonCommutingStabilizers);
+}
+
+#[test]
+fn css_code_requires_hx_hz_orthogonality() {
+    let err = CssCode::from_hx_hz(vec![vec![1]], vec![vec![1]]).unwrap_err();
+    assert_eq!(err, QecError::InvalidCssOrthogonality);
+}
+
+#[test]
+fn steane_constructor_exposes_expected_basic_invariants() {
+    let steane = Steane::new().unwrap();
+
+    assert_eq!(steane.code().n(), 7);
+    assert_eq!(steane.code().stabilizer_rank(), 6);
+    assert_eq!(steane.code().num_logical_qubits(), 1);
+    assert_eq!(steane.code().stabilizers().len(), 6);
+}
+```
+
+- [ ] **Step 2: Run the focused construction tests and verify they fail**
+
+Run:
+
+```bash
+cargo test -p qec-code --test code -v
+```
+
+Expected: FAIL with unresolved imports for `StabilizerCode`, `CssCode`, and `codes::steane::Steane`.
+
+- [ ] **Step 3: Implement validated code construction and Steane**
+
+Create `qec-code/src/code.rs`:
+
+```rust
+use crate::binary::binary_rank;
+use crate::{Pauli, QecError};
+
+#[derive(Debug, Clone)]
+pub struct StabilizerCode {
+    n: usize,
+    stabilizers: Vec<Pauli>,
+    stabilizer_rank: usize,
+}
+
+impl StabilizerCode {
+    pub fn from_stabilizers(n: usize, stabilizers: Vec<Pauli>) -> Result<Self, QecError> {
+        for stabilizer in &stabilizers {
+            if stabilizer.n() != n {
+                return Err(QecError::InvalidPauliWidth {
+                    expected: n,
+                    actual: stabilizer.n(),
+                });
+            }
+        }
+
+        for i in 0..stabilizers.len() {
+            for j in (i + 1)..stabilizers.len() {
+                if !stabilizers[i].commutes_with(&stabilizers[j]) {
+                    return Err(QecError::NonCommutingStabilizers);
+                }
+            }
+        }
+
+        let rows: Vec<Vec<u8>> = stabilizers.iter().map(Pauli::to_symplectic_row).collect();
+        let rank = binary_rank(&rows);
+        if rank != stabilizers.len() {
+            return Err(QecError::DependentStabilizers);
+        }
+
+        Ok(Self {
+            n,
+            stabilizers,
+            stabilizer_rank: rank,
+        })
+    }
+
+    pub fn n(&self) -> usize {
+        self.n
+    }
+
+    pub fn stabilizers(&self) -> &[Pauli] {
+        &self.stabilizers
+    }
+
+    pub fn stabilizer_rank(&self) -> usize {
+        self.stabilizer_rank
+    }
+
+    pub fn num_logical_qubits(&self) -> usize {
+        self.n - self.stabilizer_rank
+    }
+}
+```
+
+Create `qec-code/src/css.rs`:
+
+```rust
+use crate::{Pauli, QecError, StabilizerCode};
+
+#[derive(Debug, Clone)]
+pub struct CssCode {
+    code: StabilizerCode,
+}
+
+impl CssCode {
+    pub fn from_hx_hz(hx: Vec<Vec<u8>>, hz: Vec<Vec<u8>>) -> Result<Self, QecError> {
+        let n = hx
+            .first()
+            .map(|row| row.len())
+            .or_else(|| hz.first().map(|row| row.len()))
+            .unwrap_or(0);
+
+        for row in &hx {
+            if row.len() != n {
+                return Err(QecError::RowWidthMismatch {
+                    expected: n,
+                    actual: row.len(),
+                });
+            }
+        }
+        for row in &hz {
+            if row.len() != n {
+                return Err(QecError::RowWidthMismatch {
+                    expected: n,
+                    actual: row.len(),
+                });
+            }
+        }
+
+        for x_row in &hx {
+            for z_row in &hz {
+                let overlap = x_row
+                    .iter()
+                    .zip(z_row.iter())
+                    .map(|(x, z)| x & z)
+                    .fold(0, |acc, bit| acc ^ bit);
+                if overlap == 1 {
+                    return Err(QecError::InvalidCssOrthogonality);
+                }
+            }
+        }
+
+        let mut stabilizers = Vec::new();
+        for row in hx {
+            stabilizers.push(Pauli::from_xz_bits(n, row, vec![0; n])?);
+        }
+        for row in hz {
+            stabilizers.push(Pauli::from_xz_bits(n, vec![0; n], row)?);
+        }
+
+        Ok(Self {
+            code: StabilizerCode::from_stabilizers(n, stabilizers)?,
+        })
+    }
+
+    pub fn code(&self) -> &StabilizerCode {
+        &self.code
+    }
+}
+```
+
+Create `qec-code/src/codes/mod.rs`:
+
+```rust
+pub mod steane;
+```
+
+Create `qec-code/src/codes/steane.rs`:
+
+```rust
+use crate::css::CssCode;
+use crate::{QecError, StabilizerCode};
+
+#[derive(Debug, Clone)]
+pub struct Steane {
+    code: StabilizerCode,
+}
+
+impl Steane {
+    pub fn new() -> Result<Self, QecError> {
+        let h = vec![
+            vec![1, 1, 1, 1, 0, 0, 0],
+            vec![1, 1, 0, 0, 1, 1, 0],
+            vec![1, 0, 1, 0, 1, 0, 1],
+        ];
+        let css = CssCode::from_hx_hz(h.clone(), h)?;
+        Ok(Self {
+            code: css.code().clone(),
+        })
+    }
+
+    pub fn code(&self) -> &StabilizerCode {
+        &self.code
+    }
+}
+```
+
+Update `qec-code/src/lib.rs`:
+
+```rust
+pub mod binary;
+pub mod code;
+pub mod codes;
+pub mod css;
+pub mod error;
+pub mod pauli;
+
+pub use code::StabilizerCode;
+pub use error::QecError;
+pub use pauli::Pauli;
+```
+
+- [ ] **Step 4: Run the construction tests and verify they pass**
+
+Run:
+
+```bash
+cargo test -p qec-code --test code -v
+```
+
+Expected: PASS with 3 passing tests in `tests/code.rs`.
+
+- [ ] **Step 5: Commit the code-construction checkpoint**
+
+```bash
+git add qec-code/src/lib.rs qec-code/src/code.rs qec-code/src/css.rs qec-code/src/codes/mod.rs qec-code/src/codes/steane.rs qec-code/tests/code.rs
+git commit -m "feat: add stabilizer code and steane constructors"
+```
+
+## Task 3: Implement Logical-Basis Extraction And Exact Steane Distance
+
+**Files:**
+- Create: `qec-code/src/logical.rs`
+- Create: `qec-code/src/distance.rs`
+- Modify: `qec-code/src/code.rs`
+- Modify: `qec-code/src/lib.rs`
+- Create: `qec-code/tests/logical_distance.rs`
+
+- [ ] **Step 1: Write the failing logical/distance tests**
+
+Create `qec-code/tests/logical_distance.rs`:
+
+```rust
+use qec_code::codes::steane::Steane;
+use qec_code::distance::compute_distance;
+use qec_code::logical::extract_logical_basis;
+
+#[test]
+fn steane_logical_basis_has_one_xz_pair_with_correct_commutation() {
+    let steane = Steane::new().unwrap();
+    let logicals = extract_logical_basis(steane.code()).unwrap();
+
+    assert_eq!(logicals.k, 1);
+    assert_eq!(logicals.logical_x.len(), 1);
+    assert_eq!(logicals.logical_z.len(), 1);
+    assert!(logicals.logical_x[0].anticommutes_with(&logicals.logical_z[0]));
+
+    for stabilizer in steane.code().stabilizers() {
+        assert!(logicals.logical_x[0].commutes_with(stabilizer));
+        assert!(logicals.logical_z[0].commutes_with(stabilizer));
+    }
+}
+
+#[test]
+fn steane_distance_is_exactly_three_with_nontrivial_witness() {
+    let steane = Steane::new().unwrap();
+    let result = compute_distance(steane.code()).unwrap();
+
+    assert_eq!(result.distance, 3);
+    assert_eq!(result.witness.weight(), 3);
+
+    for stabilizer in steane.code().stabilizers() {
+        assert!(result.witness.commutes_with(stabilizer));
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused logical/distance tests and verify they fail**
+
+Run:
+
+```bash
+cargo test -p qec-code --test logical_distance -v
+```
+
+Expected: FAIL with unresolved imports for `logical` and `distance`.
+
+- [ ] **Step 3: Implement exact logical-basis extraction and distance search**
+
+Append the following helper to `qec-code/src/code.rs`:
+
+```rust
+    pub fn stabilizer_rows(&self) -> Vec<Vec<u8>> {
+        self.stabilizers.iter().map(Pauli::to_symplectic_row).collect()
+    }
+```
+
+Create `qec-code/src/logical.rs`:
+
+```rust
+use crate::binary::in_row_span;
+use crate::{Pauli, QecError, StabilizerCode};
+
+#[derive(Debug, Clone)]
+pub struct LogicalBasis {
+    pub k: usize,
+    pub logical_x: Vec<Pauli>,
+    pub logical_z: Vec<Pauli>,
+}
+
+pub fn extract_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis, QecError> {
+    let candidates = all_paulis(code.n())?;
+    let stabilizer_rows = code.stabilizer_rows();
+    let mut normalizer = Vec::new();
+
+    for pauli in candidates {
+        if code.stabilizers().iter().all(|s| pauli.commutes_with(s))
+            && !in_row_span(&stabilizer_rows, &pauli.to_symplectic_row())
+        {
+            normalizer.push(pauli);
+        }
+    }
+
+    for x in &normalizer {
+        for z in &normalizer {
+            if x.anticommutes_with(z) {
+                return Ok(LogicalBasis {
+                    k: code.num_logical_qubits(),
+                    logical_x: vec![x.clone()],
+                    logical_z: vec![z.clone()],
+                });
+            }
+        }
+    }
+
+    Err(QecError::LogicalBasisNotFound)
+}
+
+fn all_paulis(n: usize) -> Result<Vec<Pauli>, QecError> {
+    let mut out = Vec::new();
+    let limit = 1usize << (2 * n);
+    for mask in 0..limit {
+        let mut x = vec![0; n];
+        let mut z = vec![0; n];
+        for i in 0..n {
+            x[i] = ((mask >> i) & 1) as u8;
+            z[i] = ((mask >> (n + i)) & 1) as u8;
+        }
+        if x.iter().all(|bit| *bit == 0) && z.iter().all(|bit| *bit == 0) {
+            continue;
+        }
+        out.push(Pauli::from_xz_bits(n, x, z)?);
+    }
+    Ok(out)
+}
+```
+
+Create `qec-code/src/distance.rs`:
+
+```rust
+use crate::binary::in_row_span;
+use crate::{Pauli, QecError, StabilizerCode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogicalClass {
+    XLike,
+    ZLike,
+    Mixed,
+}
+
+#[derive(Debug, Clone)]
+pub struct DistanceResult {
+    pub distance: usize,
+    pub witness: Pauli,
+    pub logical_class: LogicalClass,
+}
+
+pub fn compute_distance(code: &StabilizerCode) -> Result<DistanceResult, QecError> {
+    let stabilizer_rows = code.stabilizer_rows();
+    let mut best: Option<Pauli> = None;
+
+    for pauli in super::logical::extract_logical_basis(code)?
+        .logical_x
+        .into_iter()
+        .chain(super::logical::extract_logical_basis(code)?.logical_z.into_iter())
+        .chain(all_normalizer_candidates(code)?.into_iter())
+    {
+        if in_row_span(&stabilizer_rows, &pauli.to_symplectic_row()) {
+            continue;
+        }
+        if best
+            .as_ref()
+            .map(|current| pauli.weight() < current.weight())
+            .unwrap_or(true)
+        {
+            best = Some(pauli);
+        }
+    }
+
+    let witness = best.ok_or(QecError::DistanceWitnessNotFound)?;
+    let logical_class = match (
+        witness.x_bits().iter().any(|bit| *bit == 1),
+        witness.z_bits().iter().any(|bit| *bit == 1),
+    ) {
+        (true, false) => LogicalClass::XLike,
+        (false, true) => LogicalClass::ZLike,
+        _ => LogicalClass::Mixed,
+    };
+
+    Ok(DistanceResult {
+        distance: witness.weight(),
+        witness,
+        logical_class,
+    })
+}
+
+fn all_normalizer_candidates(code: &StabilizerCode) -> Result<Vec<Pauli>, QecError> {
+    let mut out = Vec::new();
+    let limit = 1usize << (2 * code.n());
+    for mask in 0..limit {
+        let mut x = vec![0; code.n()];
+        let mut z = vec![0; code.n()];
+        for i in 0..code.n() {
+            x[i] = ((mask >> i) & 1) as u8;
+            z[i] = ((mask >> (code.n() + i)) & 1) as u8;
+        }
+        if x.iter().all(|bit| *bit == 0) && z.iter().all(|bit| *bit == 0) {
+            continue;
+        }
+        let pauli = Pauli::from_xz_bits(code.n(), x, z)?;
+        if code.stabilizers().iter().all(|s| pauli.commutes_with(s)) {
+            out.push(pauli);
+        }
+    }
+    out.sort_by_key(Pauli::weight);
+    Ok(out)
+}
+```
+
+Update `qec-code/src/lib.rs`:
+
+```rust
+pub mod binary;
+pub mod code;
+pub mod codes;
+pub mod css;
+pub mod distance;
+pub mod error;
+pub mod logical;
+pub mod pauli;
+
+pub use code::StabilizerCode;
+pub use error::QecError;
+pub use pauli::Pauli;
+```
+
+- [ ] **Step 4: Run the logical/distance tests and then the full crate test suite**
+
+Run:
+
+```bash
+cargo test -p qec-code --test logical_distance -v
+cargo test -p qec-code -v
+```
+
+Expected:
+
+- first command: PASS with 2 passing tests
+- second command: PASS for `binary`, `code`, and `logical_distance`
+
+- [ ] **Step 5: Commit the logical/distance checkpoint**
+
+```bash
+git add qec-code/src/lib.rs qec-code/src/code.rs qec-code/src/logical.rs qec-code/src/distance.rs qec-code/tests/logical_distance.rs
+git commit -m "feat: add steane logicals and exact distance"
+```
+
+## Task 4: Add The Steane Inspection CLI And Smoke Tests
+
+**Files:**
+- Create: `qec-code/src/cli.rs`
+- Create: `qec-code/src/main.rs`
+- Modify: `qec-code/src/lib.rs`
+- Create: `qec-code/tests/cli.rs`
+
+- [ ] **Step 1: Write the failing CLI smoke tests**
+
+Create `qec-code/tests/cli.rs`:
+
+```rust
+use std::process::Command;
+
+fn qec_code_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_qec-code"))
+}
+
+#[test]
+fn steane_summary_reports_basic_invariants() {
+    let output = qec_code_cmd()
+        .args(["code", "steane", "summary"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let text = String::from_utf8(output.stdout).unwrap();
+    assert!(text.contains("n: 7"));
+    assert!(text.contains("stabilizer_rank: 6"));
+    assert!(text.contains("k: 1"));
+}
+
+#[test]
+fn steane_distance_reports_exact_distance_and_class() {
+    let output = qec_code_cmd()
+        .args(["code", "steane", "distance"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let text = String::from_utf8(output.stdout).unwrap();
+    assert!(text.contains("distance: 3"));
+    assert!(text.contains("logical_class:"));
+}
+```
+
+- [ ] **Step 2: Run the focused CLI tests and verify they fail**
+
+Run:
+
+```bash
+cargo test -p qec-code --test cli -v
+```
+
+Expected: FAIL because the crate does not yet provide a `qec-code` binary.
+
+- [ ] **Step 3: Implement the CLI surface**
+
+Create `qec-code/src/cli.rs`:
+
+```rust
+use clap::{Parser, Subcommand};
+
+use crate::codes::steane::Steane;
+use crate::distance::compute_distance;
+use crate::logical::extract_logical_basis;
+use crate::QecError;
+
+#[derive(Parser)]
+#[command(name = "qec-code", version, about = "Algebraic quantum code inspection")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    Code {
+        code: String,
+        #[command(subcommand)]
+        command: CodeCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CodeCommands {
+    Summary,
+    Stabilizers,
+    Logicals,
+    Distance,
+}
+
+pub fn run(cli: Cli) -> Result<String, QecError> {
+    match cli.command {
+        Commands::Code { code, command } if code == "steane" => run_steane(command),
+        Commands::Code { .. } => Err(QecError::LogicalBasisNotFound),
+    }
+}
+
+fn run_steane(command: CodeCommands) -> Result<String, QecError> {
+    let steane = Steane::new()?;
+    match command {
+        CodeCommands::Summary => Ok(format!(
+            "n: {}\nstabilizer_rank: {}\nk: {}\n",
+            steane.code().n(),
+            steane.code().stabilizer_rank(),
+            steane.code().num_logical_qubits()
+        )),
+        CodeCommands::Stabilizers => {
+            let mut out = String::new();
+            for (idx, stabilizer) in steane.code().stabilizers().iter().enumerate() {
+                out.push_str(&format!("s{idx}: {:?}\n", stabilizer.to_symplectic_row()));
+            }
+            Ok(out)
+        }
+        CodeCommands::Logicals => {
+            let logicals = extract_logical_basis(steane.code())?;
+            Ok(format!(
+                "k: {}\nlogical_x: {:?}\nlogical_z: {:?}\n",
+                logicals.k,
+                logicals.logical_x[0].to_symplectic_row(),
+                logicals.logical_z[0].to_symplectic_row()
+            ))
+        }
+        CodeCommands::Distance => {
+            let distance = compute_distance(steane.code())?;
+            Ok(format!(
+                "distance: {}\nlogical_class: {:?}\nweight: {}\n",
+                distance.distance,
+                distance.logical_class,
+                distance.witness.weight()
+            ))
+        }
+    }
+}
+```
+
+Create `qec-code/src/main.rs`:
+
+```rust
+use clap::Parser;
+
+fn main() {
+    let cli = qec_code::cli::Cli::parse();
+    match qec_code::cli::run(cli) {
+        Ok(output) => {
+            print!("{output}");
+        }
+        Err(err) => {
+            eprintln!("Error: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+```
+
+Update `qec-code/src/lib.rs`:
+
+```rust
+pub mod binary;
+pub mod cli;
+pub mod code;
+pub mod codes;
+pub mod css;
+pub mod distance;
+pub mod error;
+pub mod logical;
+pub mod pauli;
+
+pub use code::StabilizerCode;
+pub use error::QecError;
+pub use pauli::Pauli;
+```
+
+- [ ] **Step 4: Run the CLI smoke tests and the full crate suite**
+
+Run:
+
+```bash
+cargo test -p qec-code --test cli -v
+cargo test -p qec-code -v
+```
+
+Expected:
+
+- first command: PASS with 2 passing CLI smoke tests
+- second command: PASS for all `qec-code` tests and binary builds
+
+- [ ] **Step 5: Commit the CLI checkpoint**
+
+```bash
+git add qec-code/src/lib.rs qec-code/src/cli.rs qec-code/src/main.rs qec-code/tests/cli.rs
+git commit -m "feat: add qec-code steane inspection cli"
+```
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - workspace crate boundary: Task 1
+  - binary symplectic core + Pauli/GF(2): Task 1
+  - validated `StabilizerCode`: Task 2
+  - CSS convenience + `Steane::new()`: Task 2
+  - validated logical basis: Task 3
+  - exact small-code distance + witness: Task 3
+  - minimal CLI for Steane: Task 4
+  - focused tests at algebra / Steane / CLI layers: Tasks 1-4
+- Placeholder scan:
+  - no placeholder markers remain in executable steps
+  - each code-changing step includes concrete code or exact file edits
+  - each verification step includes exact commands and expected outcomes
+- Type consistency:
+  - public names are consistent across tasks: `StabilizerCode`, `CssCode`, `Steane`, `LogicalBasis`, `DistanceResult`
+  - package name is `qec-code`, library crate path is `qec_code`, CLI command is `qec-code`
+
+## Notes For The Implementer
+
+- Keep the first implementation correctness-first. The distance search is allowed to be exponential because the only promised built-in example is Steane.
+- Do not pull `rstim` or `rilpqec` into the new crate during this plan.
+- If the exact `env!("CARGO_BIN_EXE_qec-code")` name is awkward on the local toolchain, rename the binary target explicitly in `qec-code/Cargo.toml` and update the CLI test in the same task before proceeding.

--- a/docs/superpowers/specs/2026-06-09-qec-code-steane-v1-design.md
+++ b/docs/superpowers/specs/2026-06-09-qec-code-steane-v1-design.md
@@ -1,0 +1,427 @@
+# QEC Code Steane V1 Design
+
+Date: 2026-06-09
+Status: Proposed
+Scope: new in-workspace `qec-code` crate for algebraic stabilizer-code modeling,
+logical-operator extraction, and exact small-code distance analysis, with
+Steane code as the first shipped example
+
+## Summary
+
+This design adds a new workspace crate, tentatively named `qec-code`, to the
+existing repository.
+
+The crate's responsibility is code-level algebra, not circuit simulation or
+decoding:
+
+- represent qubit stabilizer codes in a general binary symplectic form
+- provide convenient constructors for common structured cases such as CSS codes
+- ship Steane code as the first built-in example
+- compute a validated logical-operator basis
+- compute exact code distance for small codes
+- expose a minimal CLI for inspection and experimentation
+
+The chosen direction is:
+
+- keep the new work inside the current git repository as a separate workspace
+  crate
+- use a general qubit stabilizer-code core instead of a CSS-only model
+- provide CSS and built-in code constructors as convenience layers on top of
+  the same core representation
+- treat Steane code as the first fully supported example, not as a special-case
+  architecture driver
+- make distance computation exact for small codes in v1 using a correctness-
+  first search algorithm
+- leave a clean integration path for future ILP-backed distance engines without
+  coupling v1 to `rilpqec`
+
+## Goals
+
+- Add a dedicated crate for algebraic quantum-code work without expanding
+  `rstim` beyond its circuit/simulator scope.
+- Support a general qubit stabilizer-code abstraction suitable for future
+  non-CSS stabilizer codes.
+- Make Steane code available as a built-in example with a direct constructor.
+- Return a validated logical operator basis, not just arbitrary commuting
+  representatives.
+- Compute exact distance for small codes such as Steane and return a witness
+  logical operator.
+- Provide a small CLI so the new crate is usable immediately during development
+  and debugging.
+- Keep the design compatible with later ILP-backed distance computation and
+  future collaboration with `rilpqec`.
+
+## Non-Goals
+
+- Do not generate syndrome-extraction circuits in this crate.
+- Do not integrate the crate into `rstim` circuit generation in v1.
+- Do not support external file import or export formats in v1.
+- Do not support qudit codes, subsystem codes, or non-Pauli generalized
+  operator systems in v1.
+- Do not depend on `rilpqec` in v1.
+- Do not optimize distance computation for large codes in v1.
+- Do not design a broad plugin-like backend framework before concrete need
+  appears.
+
+## Current State
+
+The repository already separates related concerns across workspace crates:
+
+- `rstim` handles circuit representation, simulation, analysis, and CLI flows
+- `rmatching` and `rbposd` handle decoder implementations
+- `rilpqec` handles ILP decoding from detector error models
+
+What is missing is a crate centered on the algebraic structure of a quantum
+code itself:
+
+- stabilizer generators as first-class objects
+- logical operator extraction
+- exact distance analysis
+- reusable code constructors independent of circuit generation
+
+That gap currently makes it awkward to experiment with code structure in a
+clean way, especially when the desired workflow is "construct a code, inspect
+its algebra, and verify basic invariants" instead of "simulate a circuit" or
+"decode a syndrome".
+
+## Alternatives Considered
+
+### 1. CSS-first crate
+
+This option would make `Hx` and `Hz` the true core representation and derive
+all other behavior from CSS assumptions.
+
+Benefits:
+
+- smallest v1 implementation
+- Steane fits naturally
+- direct path to parity-check style APIs
+
+Costs:
+
+- does not generalize cleanly to arbitrary stabilizer codes
+- risks forcing future non-CSS work through the wrong abstraction
+- makes canonical logical-operator work more awkward once the code family
+  broadens
+
+This is not the recommended option.
+
+### 2. General symplectic core with CSS conveniences
+
+This option uses a binary symplectic stabilizer-code model as the real core,
+then layers `CssCode`/`HxHz` conveniences and built-in examples on top.
+
+Benefits:
+
+- matches the chosen goal of a truly general stabilizer-code abstraction
+- still keeps Steane ergonomics simple
+- provides a stable internal representation for logical-basis and distance
+  work
+- gives a clean future path toward non-CSS stabilizer codes
+
+Costs:
+
+- more up-front implementation than a CSS-only crate
+- requires a small linear-algebra foundation before visible features land
+
+This is the recommended option.
+
+### 3. Fully extensible trait-heavy framework from day one
+
+This option would define a broad set of traits and backend interfaces before
+the first concrete implementation is complete.
+
+Benefits:
+
+- maximal future flexibility in theory
+- explicit seams for alternative backends
+
+Costs:
+
+- likely over-design for a first crate
+- pushes speculative abstractions ahead of working code
+- makes it easier to ship empty interfaces instead of validated behavior
+
+This is not the recommended first step.
+
+## Decision Summary
+
+The new crate should be added to the current workspace and built around a
+general binary symplectic stabilizer-code representation.
+
+The architecture should be layered:
+
+1. binary linear algebra
+2. Pauli/symplectic operators
+3. general stabilizer-code core
+4. CSS convenience construction
+5. built-in codes such as Steane
+6. logical-operator extraction
+7. exact small-code distance analysis
+8. minimal inspection CLI
+
+This keeps v1 focused while preserving a path to later growth.
+
+## Recommended Architecture
+
+### Workspace placement
+
+Add a new crate, tentatively named `qec-code`, as another member of the
+existing top-level Cargo workspace.
+
+This placement is deliberate:
+
+- it keeps development close to `rstim` and `rilpqec`
+- it avoids prematurely splitting versioning and CI into a second repository
+- it still preserves a clear ownership boundary at the crate level
+
+The crate should not depend on `rstim` for its core algebraic types. The code
+model needs to stand on its own.
+
+### Module structure
+
+The initial module layout should remain small and purpose-specific:
+
+- `binary`: GF(2) vectors, matrices, rank/elimination helpers
+- `pauli`: binary symplectic Pauli representation, weight, commutation checks
+- `code`: core `StabilizerCode` type and validation
+- `css`: CSS-specific constructors and checks
+- `codes::steane`: built-in Steane constructor and metadata
+- `logical`: logical-basis extraction
+- `distance`: exact small-code distance computation
+- `cli`: command-line front-end
+
+The important design rule is that `codes::steane` and `css` are consumers of
+the same core code model, not alternate cores.
+
+### Core data model
+
+The central type should be a general-purpose `StabilizerCode`.
+
+Representative fields:
+
+- `n: usize`: number of physical qubits
+- `stabilizers: Vec<Pauli>`: an independent generating set in binary
+  symplectic form
+- cached derived facts as needed, such as stabilizer rank or a normalizer
+  basis
+
+The constructor must validate the algebraic invariants that define a valid
+stabilizer code:
+
+- each row has width consistent with `n`
+- all stabilizer generators commute pairwise
+- the generator list is linearly independent after mod-2 reduction
+
+Primary construction paths should be:
+
+- `StabilizerCode::from_symplectic_rows(...)`
+- `CssCode::from_hx_hz(...)`
+- `Steane::new()`
+
+`Steane::new()` should be the ergonomic front door for the first built-in code,
+but it must lower into the same underlying `StabilizerCode` representation used
+everywhere else.
+
+### CSS convenience layer
+
+Although the core is general, v1 should make CSS entry straightforward.
+
+`CssCode` should accept `Hx` and `Hz` matrices, validate the CSS commutation
+condition, and then lower to the general symplectic code model. This lets v1
+remain pleasant for structured codes while keeping the actual foundations
+general enough for later non-CSS work.
+
+The CSS layer is a constructor and validation convenience, not the main
+semantic center of the crate.
+
+## Logical Operator Design
+
+The logical-operator API should return a verified basis, not ad hoc commuting
+examples.
+
+Representative result shape:
+
+- `k: usize`
+- `logical_x: Vec<Pauli>`
+- `logical_z: Vec<Pauli>`
+
+The returned operators must satisfy:
+
+- each logical operator commutes with every stabilizer
+- `logical_x[i]` anticommutes with `logical_z[i]`
+- `logical_x[i]` commutes with `logical_z[j]` for `i != j`
+- operators are nontrivial modulo the stabilizer span
+
+The implementation should proceed in algebraic stages:
+
+1. compute the stabilizer span and rank
+2. compute the normalizer of the stabilizer group
+3. work in the quotient space normalizer / stabilizer
+4. organize a basis into symplectically paired logical X/Z operators
+
+The exact internal algorithm may look like a symplectic Gram-Schmidt style
+cleanup over quotient representatives. What matters for the design is the
+observable contract: the crate returns a validated logical basis with stable
+pairing semantics.
+
+For Steane, this yields one logical X operator and one logical Z operator. The
+same API must continue to work when later examples have `k > 1`.
+
+## Distance Design
+
+### Distance contract
+
+Distance computation in v1 should be exact for small codes and should return a
+certificate of what was found.
+
+Representative result shape:
+
+- `distance: usize`
+- `witness: Pauli`
+- `logical_class: XLike | ZLike | Mixed`
+
+The witness must be verifiable as:
+
+- commuting with all stabilizers
+- not belonging to the stabilizer span
+- having weight equal to the reported distance
+
+### V1 algorithm
+
+The v1 implementation should prioritize correctness and clarity over
+performance.
+
+The recommended algorithm is an exact search over candidate logical Paulis,
+structured around the normalizer:
+
+1. derive the normalizer
+2. search for a lowest-weight Pauli in the normalizer that is not in the
+   stabilizer span
+3. stop at the first weight with a valid witness
+
+The implementation may use direct weight-ordered enumeration, quotient-space
+enumeration, or another exact small-code strategy, but it must remain easy to
+test and reason about for cases like Steane.
+
+This is sufficient for v1 because the target example is small and correctness
+is the main requirement.
+
+### Future ILP path
+
+The design must leave a clean path to later ILP-backed distance computation,
+but v1 should not depend on `rilpqec`.
+
+The key reason is scope mismatch:
+
+- `rilpqec` currently models ILP decoding from detector error models
+- code distance requires a different front-end problem statement
+- coupling the two crates now would distort the new crate's core abstraction
+
+Instead, `qec-code` should keep its public distance API focused on the code
+problem itself. A later phase can add an alternative engine, shared problem
+lowering, or a common optimization crate once a concrete integration target is
+clear.
+
+## CLI Design
+
+The CLI should stay intentionally small in v1 and focus on built-in codes.
+
+Representative commands:
+
+- `qec-code code steane summary`
+- `qec-code code steane stabilizers`
+- `qec-code code steane logicals`
+- `qec-code code steane distance`
+
+The CLI is for inspection, validation, and manual experimentation during
+development. It should not try to solve file-format or workflow-integration
+problems in the first version.
+
+Default output should be human-readable text. Optional `--json` output is
+useful if it falls out naturally from the implementation, but it is not a
+required v1 deliverable.
+
+## Testing Strategy
+
+Testing should scale with the fact that the correctness burden is in the
+algebraic foundation.
+
+### 1. Binary and symplectic unit tests
+
+These tests should cover:
+
+- GF(2) row operations
+- rank computation
+- linear-independence checks
+- symplectic inner product
+- Pauli commutation and anticommutation
+
+These are the base invariants for the entire crate.
+
+### 2. Steane gold tests
+
+Steane should have explicit behavior tests confirming:
+
+- physical length is 7
+- stabilizer rank is 6
+- logical qubit count is 1
+- returned logical X/Z operators satisfy the expected commutation relations
+- exact distance is 3
+- the reported witness is in the normalizer and not in the stabilizer span
+
+The tests should validate properties, not brittle textual formatting.
+
+### 3. CLI smoke tests
+
+Run representative subcommands and assert that the expected fields or sections
+appear in output.
+
+This keeps the user entrypoint covered without overinvesting in CLI-specific
+testing.
+
+## Error Handling
+
+The crate should fail explicitly on invalid algebraic inputs instead of
+silently normalizing malformed data.
+
+Representative errors include:
+
+- inconsistent row widths
+- noncommuting stabilizer generators
+- linearly dependent stabilizer generator sets
+- invalid CSS `Hx`/`Hz` commutation
+- impossible or unsupported distance requests
+
+These errors should be domain-specific enough that callers can understand
+whether the issue is malformed input, unsupported scope, or an internal bug.
+
+## V1 Scope Boundary
+
+To keep the first implementation focused, v1 should stop at algebraic code
+description and analysis.
+
+Out of scope for this design:
+
+- syndrome-extraction circuit generation
+- integration with `rstim gen` or other circuit workflows
+- decoder integration
+- external file schemas
+- large-code optimized distance algorithms
+- direct `rilpqec` solver plumbing
+
+Those items can be layered on later once the core algebraic model is stable and
+validated.
+
+## Implementation Notes
+
+The crate name `qec-code` is tentative. The implementation plan can revisit the
+final package name before code lands, but the design assumes a dedicated new
+workspace member with the boundaries described above.
+
+The most important architectural rule is this:
+
+the code model must be the center, and everything else should lower to it.
+
+That prevents Steane-specific ergonomics, CSS conveniences, and future solver
+experiments from fragmenting the crate into competing representations.

--- a/qec-code/Cargo.toml
+++ b/qec-code/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "qec-code"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/qec-code/src/binary.rs
+++ b/qec-code/src/binary.rs
@@ -1,0 +1,146 @@
+use crate::error::{QecError, Result};
+
+fn validate_binary_rows(matrix: &[Vec<u8>]) -> Result<usize> {
+    let width = matrix.first().map_or(0, Vec::len);
+    for (row_index, row) in matrix.iter().enumerate() {
+        if row.len() != width {
+            return Err(QecError::RowWidthMismatch {
+                expected: width,
+                actual: row.len(),
+            });
+        }
+        for (col_index, bit) in row.iter().enumerate() {
+            if *bit > 1 {
+                return Err(QecError::InvalidBinaryEntry {
+                    row: row_index,
+                    col: col_index,
+                    value: *bit,
+                });
+            }
+        }
+    }
+    Ok(width)
+}
+
+fn assert_binary_rows(matrix: &[Vec<u8>]) -> usize {
+    validate_binary_rows(matrix).expect("matrix rows must be rectangular binary vectors")
+}
+
+fn validate_binary_target(target: &[u8]) -> Result<()> {
+    for (index, bit) in target.iter().enumerate() {
+        if *bit > 1 {
+            return Err(QecError::InvalidBinaryEntry {
+                row: 0,
+                col: index,
+                value: *bit,
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn eliminate_to_row_echelon(matrix: &[Vec<u8>]) -> Vec<Vec<u8>> {
+    let width = assert_binary_rows(matrix);
+    let mut rows = matrix.to_vec();
+    let mut pivot_row = 0;
+
+    for col in 0..width {
+        let Some(pivot) = (pivot_row..rows.len()).find(|&row| rows[row][col] == 1) else {
+            continue;
+        };
+        rows.swap(pivot_row, pivot);
+
+        for row in (pivot_row + 1)..rows.len() {
+            if rows[row][col] == 1 {
+                for k in col..width {
+                    rows[row][k] ^= rows[pivot_row][k];
+                }
+            }
+        }
+
+        pivot_row += 1;
+        if pivot_row == rows.len() {
+            break;
+        }
+    }
+
+    rows
+}
+
+fn row_echelon_rank(rows: &mut [Vec<u8>], width: usize) -> usize {
+    let mut rank = 0;
+    let mut pivot_row = 0;
+
+    for col in 0..width {
+        let Some(pivot) = (pivot_row..rows.len()).find(|&row| rows[row][col] == 1) else {
+            continue;
+        };
+        rows.swap(pivot_row, pivot);
+
+        for row in 0..rows.len() {
+            if row != pivot_row && rows[row][col] == 1 {
+                for k in col..width {
+                    rows[row][k] ^= rows[pivot_row][k];
+                }
+            }
+        }
+
+        rank += 1;
+        pivot_row += 1;
+        if pivot_row == rows.len() {
+            break;
+        }
+    }
+
+    rank
+}
+
+pub fn binary_rank(matrix: &[Vec<u8>]) -> usize {
+    let width = assert_binary_rows(matrix);
+    let mut rows = matrix.to_vec();
+    row_echelon_rank(&mut rows, width)
+}
+
+pub fn try_eliminate_to_row_echelon(matrix: &[Vec<u8>]) -> Result<Vec<Vec<u8>>> {
+    validate_binary_rows(matrix)?;
+    Ok(eliminate_to_row_echelon(matrix))
+}
+
+pub fn try_binary_rank(matrix: &[Vec<u8>]) -> Result<usize> {
+    validate_binary_rows(matrix)?;
+    Ok(binary_rank(matrix))
+}
+
+pub fn try_in_row_span(matrix: &[Vec<u8>], target: &[u8]) -> Result<bool> {
+    let width = validate_binary_rows(matrix)?;
+    validate_binary_target(target)?;
+
+    if matrix.is_empty() {
+        return Ok(!target.iter().any(|bit| *bit != 0));
+    }
+
+    if target.len() != width {
+        return Err(QecError::RowWidthMismatch {
+            expected: width,
+            actual: target.len(),
+        });
+    }
+
+    Ok(in_row_span(matrix, target))
+}
+
+pub fn in_row_span(matrix: &[Vec<u8>], target: &[u8]) -> bool {
+    let width = assert_binary_rows(matrix);
+    validate_binary_target(target).expect("target entries must be binary");
+
+    if matrix.is_empty() {
+        return !target.iter().any(|bit| *bit != 0);
+    }
+
+    assert_eq!(target.len(), width, "target length must match matrix width");
+
+    let rank = binary_rank(matrix);
+    let mut augmented = matrix.to_vec();
+    augmented.push(target.to_vec());
+    binary_rank(&augmented) == rank
+}

--- a/qec-code/src/cli.rs
+++ b/qec-code/src/cli.rs
@@ -1,0 +1,108 @@
+use clap::{Parser, Subcommand};
+
+use crate::QecError;
+use crate::codes::steane::Steane;
+use crate::distance::compute_distance;
+use crate::logical::extract_logical_basis;
+
+#[derive(Debug, Parser)]
+#[command(name = "qec-code")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    Code {
+        #[command(subcommand)]
+        command: CodeCommands,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CodeCommands {
+    Steane {
+        #[command(subcommand)]
+        command: SteaneCommands,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SteaneCommands {
+    Summary,
+    Stabilizers,
+    Logicals,
+    Distance,
+}
+
+pub fn run(cli: Cli) -> Result<String, QecError> {
+    match cli.command {
+        Commands::Code { command } => run_code(command),
+    }
+}
+
+fn run_code(command: CodeCommands) -> Result<String, QecError> {
+    match command {
+        CodeCommands::Steane { command } => run_steane(command),
+    }
+}
+
+fn run_steane(command: SteaneCommands) -> Result<String, QecError> {
+    let steane = Steane::new()?;
+    let code = steane.code();
+
+    match command {
+        SteaneCommands::Summary => Ok(format!(
+            "name: steane\nn: {}\nstabilizer_rank: {}\nk: {}",
+            code.n(),
+            code.stabilizer_rank(),
+            code.num_logical_qubits()
+        )),
+        SteaneCommands::Stabilizers => {
+            let lines = code
+                .stabilizers()
+                .iter()
+                .enumerate()
+                .map(|(index, stabilizer)| format!("g{}: {}", index + 1, format_pauli(stabilizer)))
+                .collect::<Vec<_>>();
+            Ok(lines.join("\n"))
+        }
+        SteaneCommands::Logicals => {
+            let basis = extract_logical_basis(code)?;
+            Ok(format!(
+                "k: {}\nlogical_x:\n{}\nlogical_z:\n{}",
+                basis.k,
+                format_pauli_list(&basis.logical_x),
+                format_pauli_list(&basis.logical_z)
+            ))
+        }
+        SteaneCommands::Distance => {
+            let distance = compute_distance(code)?;
+            Ok(format!(
+                "distance: {}\nlogical_class: {:?}\nwitness: {}",
+                distance.distance,
+                distance.logical_class,
+                format_pauli(&distance.witness)
+            ))
+        }
+    }
+}
+
+fn format_pauli_list(paulis: &[crate::Pauli]) -> String {
+    paulis
+        .iter()
+        .enumerate()
+        .map(|(index, pauli)| format!("  {}: {}", index + 1, format_pauli(pauli)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_pauli(pauli: &crate::Pauli) -> String {
+    format!(
+        "x={:?} z={:?} weight={}",
+        pauli.x_bits(),
+        pauli.z_bits(),
+        pauli.weight()
+    )
+}

--- a/qec-code/src/code.rs
+++ b/qec-code/src/code.rs
@@ -51,6 +51,13 @@ impl StabilizerCode {
         &self.stabilizers
     }
 
+    pub fn stabilizer_rows(&self) -> Vec<Vec<u8>> {
+        self.stabilizers
+            .iter()
+            .map(Pauli::to_symplectic_row)
+            .collect()
+    }
+
     pub fn stabilizer_rank(&self) -> usize {
         self.stabilizer_rank
     }

--- a/qec-code/src/code.rs
+++ b/qec-code/src/code.rs
@@ -1,0 +1,61 @@
+use crate::Pauli;
+use crate::binary::try_binary_rank;
+use crate::error::{QecError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StabilizerCode {
+    n: usize,
+    stabilizers: Vec<Pauli>,
+    stabilizer_rank: usize,
+}
+
+impl StabilizerCode {
+    pub fn from_stabilizers(n: usize, stabilizers: Vec<Pauli>) -> Result<Self> {
+        for stabilizer in &stabilizers {
+            if stabilizer.n() != n {
+                return Err(QecError::InvalidPauliWidth {
+                    x_width: stabilizer.n(),
+                    z_width: n,
+                });
+            }
+        }
+
+        for i in 0..stabilizers.len() {
+            for j in (i + 1)..stabilizers.len() {
+                if !stabilizers[i].try_commutes_with(&stabilizers[j])? {
+                    return Err(QecError::NonCommutingStabilizers);
+                }
+            }
+        }
+
+        let symplectic_rows: Vec<Vec<u8>> =
+            stabilizers.iter().map(Pauli::to_symplectic_row).collect();
+        let stabilizer_rank = try_binary_rank(&symplectic_rows)?;
+
+        if stabilizer_rank != stabilizers.len() {
+            return Err(QecError::DependentStabilizers);
+        }
+
+        Ok(Self {
+            n,
+            stabilizers,
+            stabilizer_rank,
+        })
+    }
+
+    pub fn n(&self) -> usize {
+        self.n
+    }
+
+    pub fn stabilizers(&self) -> &[Pauli] {
+        &self.stabilizers
+    }
+
+    pub fn stabilizer_rank(&self) -> usize {
+        self.stabilizer_rank
+    }
+
+    pub fn num_logical_qubits(&self) -> usize {
+        self.n - self.stabilizer_rank
+    }
+}

--- a/qec-code/src/codes/mod.rs
+++ b/qec-code/src/codes/mod.rs
@@ -1,0 +1,1 @@
+pub mod steane;

--- a/qec-code/src/codes/steane.rs
+++ b/qec-code/src/codes/steane.rs
@@ -1,0 +1,27 @@
+use crate::code::StabilizerCode;
+use crate::css::CssCode;
+use crate::error::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Steane {
+    code: StabilizerCode,
+}
+
+impl Steane {
+    pub fn new() -> Result<Self> {
+        let h = vec![
+            vec![1, 0, 0, 1, 0, 1, 1],
+            vec![0, 1, 0, 1, 1, 0, 1],
+            vec![0, 0, 1, 0, 1, 1, 1],
+        ];
+        let css = CssCode::from_hx_hz(h.clone(), h)?;
+
+        Ok(Self {
+            code: css.code().clone(),
+        })
+    }
+
+    pub fn code(&self) -> &StabilizerCode {
+        &self.code
+    }
+}

--- a/qec-code/src/css.rs
+++ b/qec-code/src/css.rs
@@ -1,0 +1,81 @@
+use crate::Pauli;
+use crate::code::StabilizerCode;
+use crate::error::{QecError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CssCode {
+    code: StabilizerCode,
+}
+
+impl CssCode {
+    pub fn from_hx_hz(hx: Vec<Vec<u8>>, hz: Vec<Vec<u8>>) -> Result<Self> {
+        let n = shared_width(&hx, &hz)?;
+
+        if !checks_are_orthogonal(&hx, &hz) {
+            return Err(QecError::InvalidCssOrthogonality);
+        }
+
+        let mut stabilizers = Vec::with_capacity(hx.len() + hz.len());
+        for row in hx {
+            stabilizers.push(Pauli::from_xz_bits(row, vec![0; n])?);
+        }
+        for row in hz {
+            stabilizers.push(Pauli::from_xz_bits(vec![0; n], row)?);
+        }
+
+        Ok(Self {
+            code: StabilizerCode::from_stabilizers(n, stabilizers)?,
+        })
+    }
+
+    pub fn code(&self) -> &StabilizerCode {
+        &self.code
+    }
+}
+
+fn shared_width(hx: &[Vec<u8>], hz: &[Vec<u8>]) -> Result<usize> {
+    let n = hx
+        .first()
+        .map(Vec::len)
+        .or_else(|| hz.first().map(Vec::len))
+        .unwrap_or(0);
+
+    validate_rows(hx, n)?;
+    validate_rows(hz, n)?;
+
+    Ok(n)
+}
+
+fn validate_rows(matrix: &[Vec<u8>], expected_width: usize) -> Result<()> {
+    for (row_index, row) in matrix.iter().enumerate() {
+        if row.len() != expected_width {
+            return Err(QecError::RowWidthMismatch {
+                expected: expected_width,
+                actual: row.len(),
+            });
+        }
+
+        for (col_index, bit) in row.iter().enumerate() {
+            if *bit > 1 {
+                return Err(QecError::InvalidBinaryEntry {
+                    row: row_index,
+                    col: col_index,
+                    value: *bit,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn checks_are_orthogonal(hx: &[Vec<u8>], hz: &[Vec<u8>]) -> bool {
+    hx.iter()
+        .all(|x_row| hz.iter().all(|z_row| dot_product_mod_2(x_row, z_row) == 0))
+}
+
+fn dot_product_mod_2(lhs: &[u8], rhs: &[u8]) -> u8 {
+    lhs.iter()
+        .zip(rhs)
+        .fold(0, |parity, (left, right)| parity ^ (*left & *right))
+}

--- a/qec-code/src/distance.rs
+++ b/qec-code/src/distance.rs
@@ -1,0 +1,89 @@
+use crate::Pauli;
+use crate::binary::try_in_row_span;
+use crate::code::StabilizerCode;
+use crate::error::{QecError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogicalClass {
+    XLike,
+    ZLike,
+    Mixed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DistanceResult {
+    pub distance: usize,
+    pub witness: Pauli,
+    pub logical_class: LogicalClass,
+}
+
+pub fn compute_distance(code: &StabilizerCode) -> Result<DistanceResult> {
+    let mut best_witness: Option<Pauli> = None;
+
+    for candidate in all_normalizer_candidates(code)? {
+        let replace = match &best_witness {
+            Some(current) => candidate.weight() < current.weight(),
+            None => true,
+        };
+
+        if replace {
+            best_witness = Some(candidate);
+        }
+    }
+
+    let witness = best_witness.ok_or(QecError::DistanceWitnessNotFound)?;
+
+    Ok(DistanceResult {
+        distance: witness.weight(),
+        logical_class: classify_logical(&witness),
+        witness,
+    })
+}
+
+fn all_normalizer_candidates(code: &StabilizerCode) -> Result<Vec<Pauli>> {
+    let n = code.n();
+    let symplectic_bits = n
+        .checked_mul(2)
+        .expect("symplectic width must fit in usize");
+    let total = 1usize
+        .checked_shl(symplectic_bits as u32)
+        .expect("exhaustive Pauli enumeration requires 2n < usize::BITS");
+    let stabilizer_rows = code.stabilizer_rows();
+    let mut candidates = Vec::new();
+
+    for mask in 1..total {
+        let mut x = vec![0; n];
+        let mut z = vec![0; n];
+
+        for qubit in 0..n {
+            x[qubit] = ((mask >> qubit) & 1) as u8;
+            z[qubit] = ((mask >> (n + qubit)) & 1) as u8;
+        }
+
+        let candidate =
+            Pauli::from_xz_bits(x, z).expect("generated Pauli supports must be valid binary rows");
+
+        if code
+            .stabilizers()
+            .iter()
+            .all(|stabilizer| candidate.commutes_with(stabilizer))
+            && !try_in_row_span(&stabilizer_rows, &candidate.to_symplectic_row())?
+        {
+            candidates.push(candidate);
+        }
+    }
+
+    Ok(candidates)
+}
+
+fn classify_logical(pauli: &Pauli) -> LogicalClass {
+    let has_x = pauli.x_bits().contains(&1);
+    let has_z = pauli.z_bits().contains(&1);
+
+    match (has_x, has_z) {
+        (true, false) => LogicalClass::XLike,
+        (false, true) => LogicalClass::ZLike,
+        (true, true) => LogicalClass::Mixed,
+        (false, false) => unreachable!("logical witnesses are non-identity"),
+    }
+}

--- a/qec-code/src/distance.rs
+++ b/qec-code/src/distance.rs
@@ -44,10 +44,10 @@ fn all_normalizer_candidates(code: &StabilizerCode) -> Result<Vec<Pauli>> {
     let n = code.n();
     let symplectic_bits = n
         .checked_mul(2)
-        .expect("symplectic width must fit in usize");
+        .ok_or(QecError::UnsupportedExhaustiveEnumeration { n })?;
     let total = 1usize
         .checked_shl(symplectic_bits as u32)
-        .expect("exhaustive Pauli enumeration requires 2n < usize::BITS");
+        .ok_or(QecError::UnsupportedExhaustiveEnumeration { n })?;
     let stabilizer_rows = code.stabilizer_rows();
     let mut candidates = Vec::new();
 

--- a/qec-code/src/distance.rs
+++ b/qec-code/src/distance.rs
@@ -87,3 +87,20 @@ fn classify_logical(pauli: &Pauli) -> LogicalClass {
         (false, false) => unreachable!("logical witnesses are non-identity"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{LogicalClass, classify_logical};
+    use crate::Pauli;
+
+    #[test]
+    fn classify_logical_distinguishes_x_z_and_mixed_supports() {
+        let x_like = Pauli::from_xz_bits(vec![1, 0], vec![0, 0]).unwrap();
+        let z_like = Pauli::from_xz_bits(vec![0, 0], vec![0, 1]).unwrap();
+        let mixed = Pauli::from_xz_bits(vec![0, 1], vec![0, 1]).unwrap();
+
+        assert_eq!(classify_logical(&x_like), LogicalClass::XLike);
+        assert_eq!(classify_logical(&z_like), LogicalClass::ZLike);
+        assert_eq!(classify_logical(&mixed), LogicalClass::Mixed);
+    }
+}

--- a/qec-code/src/error.rs
+++ b/qec-code/src/error.rs
@@ -22,6 +22,8 @@ pub enum QecError {
     InvalidCssOrthogonality,
     #[error("logical basis extraction is unsupported for {k} logical qubits")]
     UnsupportedLogicalBasis { k: usize },
+    #[error("exhaustive Pauli enumeration is unsupported for {n} qubits on this target")]
+    UnsupportedExhaustiveEnumeration { n: usize },
     #[error("logical basis not found")]
     LogicalBasisNotFound,
     #[error("distance witness not found")]

--- a/qec-code/src/error.rs
+++ b/qec-code/src/error.rs
@@ -20,6 +20,8 @@ pub enum QecError {
     DependentStabilizers,
     #[error("CSS X/Z checks are not orthogonal")]
     InvalidCssOrthogonality,
+    #[error("logical basis extraction is unsupported for {k} logical qubits")]
+    UnsupportedLogicalBasis { k: usize },
     #[error("logical basis not found")]
     LogicalBasisNotFound,
     #[error("distance witness not found")]

--- a/qec-code/src/error.rs
+++ b/qec-code/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum QecError {
+    #[error("row width mismatch: expected {expected}, got {actual}")]
+    RowWidthMismatch { expected: usize, actual: usize },
+    #[error("non-binary matrix entry {value} at row {row}, column {col}")]
+    InvalidBinaryEntry { row: usize, col: usize, value: u8 },
+    #[error("invalid Pauli width: x has {x_width} bits, z has {z_width}")]
+    InvalidPauliWidth { x_width: usize, z_width: usize },
+    #[error("non-binary Pauli bit {value} in {which} support at index {index}")]
+    InvalidPauliBit {
+        which: &'static str,
+        index: usize,
+        value: u8,
+    },
+    #[error("stabilizers do not mutually commute")]
+    NonCommutingStabilizers,
+    #[error("stabilizers are linearly dependent")]
+    DependentStabilizers,
+    #[error("CSS X/Z checks are not orthogonal")]
+    InvalidCssOrthogonality,
+    #[error("logical basis not found")]
+    LogicalBasisNotFound,
+    #[error("distance witness not found")]
+    DistanceWitnessNotFound,
+}
+
+pub type Result<T> = core::result::Result<T, QecError>;

--- a/qec-code/src/lib.rs
+++ b/qec-code/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod binary;
+pub mod cli;
 pub mod code;
 pub mod codes;
 pub mod css;

--- a/qec-code/src/lib.rs
+++ b/qec-code/src/lib.rs
@@ -2,7 +2,9 @@ pub mod binary;
 pub mod code;
 pub mod codes;
 pub mod css;
+pub mod distance;
 pub mod error;
+pub mod logical;
 pub mod pauli;
 
 pub use code::StabilizerCode;

--- a/qec-code/src/lib.rs
+++ b/qec-code/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod binary;
+pub mod code;
+pub mod codes;
+pub mod css;
 pub mod error;
 pub mod pauli;
 
+pub use code::StabilizerCode;
 pub use error::QecError;
 pub use pauli::Pauli;

--- a/qec-code/src/lib.rs
+++ b/qec-code/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod binary;
+pub mod error;
+pub mod pauli;
+
+pub use error::QecError;
+pub use pauli::Pauli;

--- a/qec-code/src/logical.rs
+++ b/qec-code/src/logical.rs
@@ -1,0 +1,79 @@
+use crate::Pauli;
+use crate::binary::try_in_row_span;
+use crate::code::StabilizerCode;
+use crate::error::{QecError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogicalBasis {
+    pub k: usize,
+    pub logical_x: Vec<Pauli>,
+    pub logical_z: Vec<Pauli>,
+}
+
+pub fn extract_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
+    let k = code.num_logical_qubits();
+    if k == 0 {
+        return Ok(LogicalBasis {
+            k,
+            logical_x: Vec::new(),
+            logical_z: Vec::new(),
+        });
+    }
+    if k > 1 {
+        return Err(QecError::UnsupportedLogicalBasis { k });
+    }
+
+    let stabilizer_rows = code.stabilizer_rows();
+    let mut logicals = Vec::new();
+
+    for candidate in all_paulis(code.n()) {
+        if code
+            .stabilizers()
+            .iter()
+            .all(|stabilizer| candidate.commutes_with(stabilizer))
+            && !try_in_row_span(&stabilizer_rows, &candidate.to_symplectic_row())?
+        {
+            logicals.push(candidate);
+        }
+    }
+
+    for i in 0..logicals.len() {
+        for j in (i + 1)..logicals.len() {
+            if logicals[i].try_anticommutes_with(&logicals[j])? {
+                return Ok(LogicalBasis {
+                    k,
+                    logical_x: vec![logicals[i].clone()],
+                    logical_z: vec![logicals[j].clone()],
+                });
+            }
+        }
+    }
+
+    Err(QecError::LogicalBasisNotFound)
+}
+
+fn all_paulis(n: usize) -> Vec<Pauli> {
+    let symplectic_bits = n
+        .checked_mul(2)
+        .expect("symplectic width must fit in usize");
+    let total = 1usize
+        .checked_shl(symplectic_bits as u32)
+        .expect("exhaustive Pauli enumeration requires 2n < usize::BITS");
+    let mut paulis = Vec::with_capacity(total.saturating_sub(1));
+
+    for mask in 1..total {
+        let mut x = vec![0; n];
+        let mut z = vec![0; n];
+
+        for qubit in 0..n {
+            x[qubit] = ((mask >> qubit) & 1) as u8;
+            z[qubit] = ((mask >> (n + qubit)) & 1) as u8;
+        }
+
+        paulis.push(
+            Pauli::from_xz_bits(x, z).expect("generated Pauli supports must be valid binary rows"),
+        );
+    }
+
+    paulis
+}

--- a/qec-code/src/logical.rs
+++ b/qec-code/src/logical.rs
@@ -26,7 +26,7 @@ pub fn extract_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
     let stabilizer_rows = code.stabilizer_rows();
     let mut logicals = Vec::new();
 
-    for candidate in all_paulis(code.n()) {
+    for candidate in all_paulis(code.n())? {
         if code
             .stabilizers()
             .iter()
@@ -52,13 +52,13 @@ pub fn extract_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
     Err(QecError::LogicalBasisNotFound)
 }
 
-fn all_paulis(n: usize) -> Vec<Pauli> {
+fn all_paulis(n: usize) -> Result<Vec<Pauli>> {
     let symplectic_bits = n
         .checked_mul(2)
-        .expect("symplectic width must fit in usize");
+        .ok_or(QecError::UnsupportedExhaustiveEnumeration { n })?;
     let total = 1usize
         .checked_shl(symplectic_bits as u32)
-        .expect("exhaustive Pauli enumeration requires 2n < usize::BITS");
+        .ok_or(QecError::UnsupportedExhaustiveEnumeration { n })?;
     let mut paulis = Vec::with_capacity(total.saturating_sub(1));
 
     for mask in 1..total {
@@ -75,5 +75,5 @@ fn all_paulis(n: usize) -> Vec<Pauli> {
         );
     }
 
-    paulis
+    Ok(paulis)
 }

--- a/qec-code/src/logical.rs
+++ b/qec-code/src/logical.rs
@@ -37,19 +37,12 @@ pub fn extract_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
         }
     }
 
-    for i in 0..logicals.len() {
-        for j in (i + 1)..logicals.len() {
-            if logicals[i].try_anticommutes_with(&logicals[j])? {
-                return Ok(LogicalBasis {
-                    k,
-                    logical_x: vec![logicals[i].clone()],
-                    logical_z: vec![logicals[j].clone()],
-                });
-            }
-        }
-    }
-
-    Err(QecError::LogicalBasisNotFound)
+    let (logical_x, logical_z) = select_anticommuting_pair(&logicals)?;
+    Ok(LogicalBasis {
+        k,
+        logical_x: vec![logical_x],
+        logical_z: vec![logical_z],
+    })
 }
 
 fn all_paulis(n: usize) -> Result<Vec<Pauli>> {
@@ -76,4 +69,46 @@ fn all_paulis(n: usize) -> Result<Vec<Pauli>> {
     }
 
     Ok(paulis)
+}
+
+fn select_anticommuting_pair(logicals: &[Pauli]) -> Result<(Pauli, Pauli)> {
+    for i in 0..logicals.len() {
+        for j in (i + 1)..logicals.len() {
+            if logicals[i].try_anticommutes_with(&logicals[j])? {
+                return Ok((logicals[i].clone(), logicals[j].clone()));
+            }
+        }
+    }
+
+    Err(QecError::LogicalBasisNotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_anticommuting_pair;
+    use crate::{Pauli, QecError};
+
+    #[test]
+    fn select_anticommuting_pair_returns_the_first_found_pair() {
+        let logical_x = Pauli::from_xz_bits(vec![1, 1], vec![0, 0]).unwrap();
+        let logical_z = Pauli::from_xz_bits(vec![0, 0], vec![1, 0]).unwrap();
+        let commuting = Pauli::from_xz_bits(vec![0, 0], vec![0, 1]).unwrap();
+
+        let (x, z) = select_anticommuting_pair(&[logical_x.clone(), logical_z.clone(), commuting])
+            .unwrap();
+
+        assert_eq!(x, logical_x);
+        assert_eq!(z, logical_z);
+    }
+
+    #[test]
+    fn select_anticommuting_pair_reports_when_no_pair_exists() {
+        let x0 = Pauli::from_xz_bits(vec![1, 0], vec![0, 0]).unwrap();
+        let x1 = Pauli::from_xz_bits(vec![0, 1], vec![0, 0]).unwrap();
+
+        assert_eq!(
+            select_anticommuting_pair(&[x0, x1]),
+            Err(QecError::LogicalBasisNotFound)
+        );
+    }
 }

--- a/qec-code/src/main.rs
+++ b/qec-code/src/main.rs
@@ -1,0 +1,16 @@
+use clap::Parser;
+use qec_code::cli::{Cli, run};
+
+fn main() {
+    let cli = Cli::parse();
+
+    match run(cli) {
+        Ok(output) => {
+            println!("{output}");
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/qec-code/src/main.rs
+++ b/qec-code/src/main.rs
@@ -1,16 +1,102 @@
 use clap::Parser;
 use qec_code::cli::{Cli, run};
+use qec_code::QecError;
+use std::io::{self, Write};
 
 fn main() {
     let cli = Cli::parse();
+    let exit_code = run_and_write(cli, &mut io::stdout(), &mut io::stderr());
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+}
 
-    match run(cli) {
-        Ok(output) => {
-            println!("{output}");
-        }
-        Err(error) => {
-            eprintln!("{error}");
-            std::process::exit(1);
-        }
+fn run_and_write(cli: Cli, stdout: &mut impl Write, stderr: &mut impl Write) -> i32 {
+    write_result(run(cli), stdout, stderr)
+}
+
+fn write_result(
+    result: Result<String, QecError>,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> i32 {
+    match result {
+        Ok(output) => write_success(stdout, &output),
+        Err(error) => write_error(stderr, &error),
+    }
+}
+
+fn write_success(stdout: &mut impl Write, output: &str) -> i32 {
+    writeln!(stdout, "{output}").expect("stdout write should succeed");
+    0
+}
+
+fn write_error(stderr: &mut impl Write, error: &qec_code::QecError) -> i32 {
+    writeln!(stderr, "{error}").expect("stderr write should succeed");
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_and_write, write_result};
+    use qec_code::cli::{Cli, CodeCommands, Commands, SteaneCommands};
+    use qec_code::QecError;
+
+    #[test]
+    fn run_and_write_writes_stdout_on_success() {
+        let cli = Cli {
+            command: Commands::Code {
+                command: CodeCommands::Steane {
+                    command: SteaneCommands::Summary,
+                },
+            },
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let exit_code = run_and_write(cli, &mut stdout, &mut stderr);
+
+        assert_eq!(exit_code, 0);
+        assert!(String::from_utf8(stdout).unwrap().contains("name: steane"));
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn write_result_writes_stderr_on_error() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let exit_code = write_result(
+            Err(QecError::DistanceWitnessNotFound),
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(exit_code, 1);
+        assert!(stdout.is_empty());
+        assert_eq!(
+            String::from_utf8(stderr).unwrap(),
+            "distance witness not found\n"
+        );
+    }
+
+    #[test]
+    fn write_result_writes_stdout_on_success() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let exit_code = write_result(Ok("ok".to_string()), &mut stdout, &mut stderr);
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(String::from_utf8(stdout).unwrap(), "ok\n");
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn qec_errors_render_human_readable_messages() {
+        assert_eq!(
+            QecError::DistanceWitnessNotFound.to_string(),
+            "distance witness not found"
+        );
     }
 }

--- a/qec-code/src/pauli.rs
+++ b/qec-code/src/pauli.rs
@@ -1,0 +1,102 @@
+use crate::error::{QecError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Pauli {
+    x: Vec<u8>,
+    z: Vec<u8>,
+}
+
+impl Pauli {
+    pub fn from_xz_bits(x: Vec<u8>, z: Vec<u8>) -> Result<Self> {
+        if x.len() != z.len() {
+            return Err(QecError::InvalidPauliWidth {
+                x_width: x.len(),
+                z_width: z.len(),
+            });
+        }
+        validate_pauli_bits("X", &x)?;
+        validate_pauli_bits("Z", &z)?;
+        Ok(Self { x, z })
+    }
+
+    pub fn n(&self) -> usize {
+        self.x.len()
+    }
+
+    pub fn x_bits(&self) -> &[u8] {
+        &self.x
+    }
+
+    pub fn z_bits(&self) -> &[u8] {
+        &self.z
+    }
+
+    pub fn try_symplectic_product(&self, other: &Self) -> Result<u8> {
+        if self.n() != other.n() {
+            return Err(QecError::InvalidPauliWidth {
+                x_width: self.n(),
+                z_width: other.n(),
+            });
+        }
+
+        Ok(self
+            .x
+            .iter()
+            .zip(&self.z)
+            .zip(other.x.iter().zip(&other.z))
+            .fold(0, |parity, ((x1, z1), (x2, z2))| {
+                parity ^ ((*x1 & *z2) ^ (*z1 & *x2))
+            }))
+    }
+
+    pub fn symplectic_product(&self, other: &Self) -> u8 {
+        self.try_symplectic_product(other)
+            .expect("Pauli widths must match")
+    }
+
+    pub fn weight(&self) -> usize {
+        self.x
+            .iter()
+            .zip(&self.z)
+            .filter(|(x, z)| (**x | **z) == 1)
+            .count()
+    }
+
+    pub fn try_commutes_with(&self, other: &Self) -> Result<bool> {
+        Ok(self.try_symplectic_product(other)? == 0)
+    }
+
+    pub fn commutes_with(&self, other: &Self) -> bool {
+        self.try_commutes_with(other)
+            .expect("Pauli widths must match")
+    }
+
+    pub fn try_anticommutes_with(&self, other: &Self) -> Result<bool> {
+        Ok(self.try_symplectic_product(other)? == 1)
+    }
+
+    pub fn anticommutes_with(&self, other: &Self) -> bool {
+        self.try_anticommutes_with(other)
+            .expect("Pauli widths must match")
+    }
+
+    pub fn to_symplectic_row(&self) -> Vec<u8> {
+        let mut row = Vec::with_capacity(self.n() * 2);
+        row.extend_from_slice(&self.x);
+        row.extend_from_slice(&self.z);
+        row
+    }
+}
+
+fn validate_pauli_bits(which: &'static str, bits: &[u8]) -> Result<()> {
+    for (index, bit) in bits.iter().enumerate() {
+        if *bit > 1 {
+            return Err(QecError::InvalidPauliBit {
+                which,
+                index,
+                value: *bit,
+            });
+        }
+    }
+    Ok(())
+}

--- a/qec-code/tests/binary.rs
+++ b/qec-code/tests/binary.rs
@@ -1,6 +1,9 @@
 use qec_code::Pauli;
 use qec_code::QecError;
-use qec_code::binary::{binary_rank, in_row_span, try_binary_rank, try_in_row_span};
+use qec_code::binary::{
+    binary_rank, eliminate_to_row_echelon, in_row_span, try_binary_rank,
+    try_eliminate_to_row_echelon, try_in_row_span,
+};
 
 #[test]
 fn binary_rank_ignores_dependent_rows() {
@@ -28,6 +31,13 @@ fn in_row_span_for_empty_generator_set_only_contains_zero_vector() {
 
 #[test]
 fn pauli_from_xz_bits_rejects_non_binary_values() {
+    assert_eq!(
+        Pauli::from_xz_bits(vec![1, 0], vec![0]),
+        Err(QecError::InvalidPauliWidth {
+            x_width: 2,
+            z_width: 1,
+        })
+    );
     assert_eq!(
         Pauli::from_xz_bits(vec![2, 0], vec![0, 1]),
         Err(QecError::InvalidPauliBit {
@@ -61,6 +71,40 @@ fn checked_binary_helpers_report_invalid_input_without_panicking() {
             row: 0,
             col: 1,
             value: 2,
+        })
+    );
+}
+
+#[test]
+fn row_echelon_helpers_handle_pivots_elimination_and_input_validation() {
+    let matrix = vec![vec![0, 1, 1], vec![0, 1, 0]];
+
+    assert_eq!(
+        eliminate_to_row_echelon(&matrix),
+        vec![vec![0, 1, 1], vec![0, 0, 1]]
+    );
+    assert_eq!(
+        try_eliminate_to_row_echelon(&matrix),
+        Ok(vec![vec![0, 1, 1], vec![0, 0, 1]])
+    );
+    assert_eq!(
+        try_eliminate_to_row_echelon(&[vec![1, 2]]),
+        Err(QecError::InvalidBinaryEntry {
+            row: 0,
+            col: 1,
+            value: 2,
+        })
+    );
+}
+
+#[test]
+fn checked_row_span_reports_empty_and_width_mismatch_cases() {
+    assert_eq!(try_in_row_span(&[], &[0, 1, 0]), Ok(false));
+    assert_eq!(
+        try_in_row_span(&[vec![1, 0], vec![0, 1]], &[1, 0, 0]),
+        Err(QecError::RowWidthMismatch {
+            expected: 2,
+            actual: 3,
         })
     );
 }

--- a/qec-code/tests/binary.rs
+++ b/qec-code/tests/binary.rs
@@ -1,0 +1,113 @@
+use qec_code::Pauli;
+use qec_code::QecError;
+use qec_code::binary::{binary_rank, in_row_span, try_binary_rank, try_in_row_span};
+
+#[test]
+fn binary_rank_ignores_dependent_rows() {
+    let matrix = vec![vec![1, 0, 1, 1], vec![0, 1, 1, 0], vec![1, 1, 0, 1]];
+
+    assert_eq!(binary_rank(&matrix), 2);
+}
+
+#[test]
+fn in_row_span_detects_membership_and_absence() {
+    let matrix = vec![vec![1, 0, 1, 0], vec![0, 1, 1, 1]];
+
+    assert!(in_row_span(&matrix, &[1, 1, 0, 1]));
+    assert!(!in_row_span(&matrix, &[1, 0, 0, 0]));
+}
+
+#[test]
+fn in_row_span_for_empty_generator_set_only_contains_zero_vector() {
+    let matrix: Vec<Vec<u8>> = vec![];
+
+    assert!(in_row_span(&matrix, &[]));
+    assert!(in_row_span(&matrix, &[0, 0, 0]));
+    assert!(!in_row_span(&matrix, &[0, 1, 0]));
+}
+
+#[test]
+fn pauli_from_xz_bits_rejects_non_binary_values() {
+    assert_eq!(
+        Pauli::from_xz_bits(vec![2, 0], vec![0, 1]),
+        Err(QecError::InvalidPauliBit {
+            which: "X",
+            index: 0,
+            value: 2,
+        })
+    );
+    assert_eq!(
+        Pauli::from_xz_bits(vec![1, 0], vec![0, 3]),
+        Err(QecError::InvalidPauliBit {
+            which: "Z",
+            index: 1,
+            value: 3,
+        })
+    );
+}
+
+#[test]
+fn checked_binary_helpers_report_invalid_input_without_panicking() {
+    assert_eq!(
+        try_binary_rank(&[vec![1, 0], vec![1]]),
+        Err(QecError::RowWidthMismatch {
+            expected: 2,
+            actual: 1,
+        })
+    );
+    assert_eq!(
+        try_in_row_span(&[vec![1, 0], vec![0, 1]], &[1, 2]),
+        Err(QecError::InvalidBinaryEntry {
+            row: 0,
+            col: 1,
+            value: 2,
+        })
+    );
+}
+
+#[test]
+fn checked_pauli_helpers_report_width_mismatch_without_panicking() {
+    let short = Pauli::from_xz_bits(vec![1, 0], vec![0, 1]).unwrap();
+    let long = Pauli::from_xz_bits(vec![1, 0, 0], vec![0, 1, 1]).unwrap();
+
+    assert_eq!(
+        short.try_symplectic_product(&long),
+        Err(QecError::InvalidPauliWidth {
+            x_width: 2,
+            z_width: 3,
+        })
+    );
+    assert_eq!(
+        short.try_commutes_with(&long),
+        Err(QecError::InvalidPauliWidth {
+            x_width: 2,
+            z_width: 3,
+        })
+    );
+    assert_eq!(
+        short.try_anticommutes_with(&long),
+        Err(QecError::InvalidPauliWidth {
+            x_width: 2,
+            z_width: 3,
+        })
+    );
+}
+
+#[test]
+fn pauli_commutation_and_weight_match_symplectic_overlap() {
+    let xz = Pauli::from_xz_bits(vec![1, 0, 1], vec![0, 1, 1]).unwrap();
+    let anticommutes = Pauli::from_xz_bits(vec![0, 0, 0], vec![1, 1, 0]).unwrap();
+    let commuting = Pauli::from_xz_bits(vec![1, 0, 0], vec![0, 1, 0]).unwrap();
+
+    assert_eq!(xz.n(), 3);
+    assert_eq!(xz.x_bits(), &[1, 0, 1]);
+    assert_eq!(xz.z_bits(), &[0, 1, 1]);
+    assert_eq!(xz.to_symplectic_row(), vec![1, 0, 1, 0, 1, 1]);
+    assert_eq!(xz.weight(), 3);
+    assert_eq!(anticommutes.weight(), 2);
+    assert_eq!(xz.symplectic_product(&anticommutes), 1);
+    assert!(!xz.commutes_with(&anticommutes));
+    assert!(xz.anticommutes_with(&anticommutes));
+    assert!(xz.commutes_with(&commuting));
+    assert!(!xz.anticommutes_with(&commuting));
+}

--- a/qec-code/tests/cli.rs
+++ b/qec-code/tests/cli.rs
@@ -37,3 +37,33 @@ fn steane_distance_reports_distance_and_logical_class() {
     assert!(stdout.contains("distance: 3"), "stdout was: {stdout}");
     assert!(stdout.contains("logical_class:"), "stdout was: {stdout}");
 }
+
+#[test]
+fn steane_stabilizers_reports_generator_lines() {
+    let output = Command::new(qec_code_bin())
+        .args(["code", "steane", "stabilizers"])
+        .output()
+        .expect("qec-code binary should run");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid utf-8");
+
+    assert!(stdout.contains("g1:"), "stdout was: {stdout}");
+    assert!(stdout.contains("g6:"), "stdout was: {stdout}");
+}
+
+#[test]
+fn steane_logicals_reports_logical_sections() {
+    let output = Command::new(qec_code_bin())
+        .args(["code", "steane", "logicals"])
+        .output()
+        .expect("qec-code binary should run");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid utf-8");
+
+    assert!(stdout.contains("logical_x:"), "stdout was: {stdout}");
+    assert!(stdout.contains("logical_z:"), "stdout was: {stdout}");
+}

--- a/qec-code/tests/cli.rs
+++ b/qec-code/tests/cli.rs
@@ -1,0 +1,39 @@
+use std::process::Command;
+
+fn qec_code_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_qec-code")
+}
+
+#[test]
+fn steane_summary_reports_basic_code_parameters() {
+    let output = Command::new(qec_code_bin())
+        .args(["code", "steane", "summary"])
+        .output()
+        .expect("qec-code binary should run");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid utf-8");
+
+    assert!(stdout.contains("n: 7"), "stdout was: {stdout}");
+    assert!(
+        stdout.contains("stabilizer_rank: 6"),
+        "stdout was: {stdout}"
+    );
+    assert!(stdout.contains("k: 1"), "stdout was: {stdout}");
+}
+
+#[test]
+fn steane_distance_reports_distance_and_logical_class() {
+    let output = Command::new(qec_code_bin())
+        .args(["code", "steane", "distance"])
+        .output()
+        .expect("qec-code binary should run");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be valid utf-8");
+
+    assert!(stdout.contains("distance: 3"), "stdout was: {stdout}");
+    assert!(stdout.contains("logical_class:"), "stdout was: {stdout}");
+}

--- a/qec-code/tests/code.rs
+++ b/qec-code/tests/code.rs
@@ -1,0 +1,82 @@
+use qec_code::codes::steane::Steane;
+use qec_code::css::CssCode;
+use qec_code::{Pauli, QecError, StabilizerCode};
+
+#[test]
+fn stabilizer_code_rejects_noncommuting_generators() {
+    let x0 = Pauli::from_xz_bits(vec![1], vec![0]).unwrap();
+    let z0 = Pauli::from_xz_bits(vec![0], vec![1]).unwrap();
+
+    assert_eq!(
+        StabilizerCode::from_stabilizers(1, vec![x0, z0]),
+        Err(QecError::NonCommutingStabilizers)
+    );
+}
+
+#[test]
+fn stabilizer_code_rejects_dependent_commuting_generators() {
+    let x0 = Pauli::from_xz_bits(vec![1], vec![0]).unwrap();
+    let duplicate_x0 = Pauli::from_xz_bits(vec![1], vec![0]).unwrap();
+
+    assert_eq!(
+        StabilizerCode::from_stabilizers(1, vec![x0, duplicate_x0]),
+        Err(QecError::DependentStabilizers)
+    );
+}
+
+#[test]
+fn css_code_rejects_non_orthogonal_checks() {
+    assert_eq!(
+        CssCode::from_hx_hz(vec![vec![1]], vec![vec![1]]),
+        Err(QecError::InvalidCssOrthogonality)
+    );
+}
+
+#[test]
+fn css_code_rejects_ragged_row_widths() {
+    assert_eq!(
+        CssCode::from_hx_hz(vec![vec![1, 0], vec![1]], vec![]),
+        Err(QecError::RowWidthMismatch {
+            expected: 2,
+            actual: 1,
+        })
+    );
+    assert_eq!(
+        CssCode::from_hx_hz(vec![], vec![vec![1, 0], vec![0]]),
+        Err(QecError::RowWidthMismatch {
+            expected: 2,
+            actual: 1,
+        })
+    );
+}
+
+#[test]
+fn css_code_rejects_non_binary_matrix_entries() {
+    assert_eq!(
+        CssCode::from_hx_hz(vec![vec![2]], vec![]),
+        Err(QecError::InvalidBinaryEntry {
+            row: 0,
+            col: 0,
+            value: 2,
+        })
+    );
+    assert_eq!(
+        CssCode::from_hx_hz(vec![], vec![vec![3]]),
+        Err(QecError::InvalidBinaryEntry {
+            row: 0,
+            col: 0,
+            value: 3,
+        })
+    );
+}
+
+#[test]
+fn steane_exposes_expected_invariants() {
+    let steane = Steane::new().unwrap();
+    let code = steane.code();
+
+    assert_eq!(code.n(), 7);
+    assert_eq!(code.stabilizer_rank(), 6);
+    assert_eq!(code.num_logical_qubits(), 1);
+    assert_eq!(code.stabilizers().len(), 6);
+}

--- a/qec-code/tests/code.rs
+++ b/qec-code/tests/code.rs
@@ -14,6 +14,19 @@ fn stabilizer_code_rejects_noncommuting_generators() {
 }
 
 #[test]
+fn stabilizer_code_rejects_generators_with_the_wrong_width() {
+    let x0 = Pauli::from_xz_bits(vec![1], vec![0]).unwrap();
+
+    assert_eq!(
+        StabilizerCode::from_stabilizers(2, vec![x0]),
+        Err(QecError::InvalidPauliWidth {
+            x_width: 1,
+            z_width: 2,
+        })
+    );
+}
+
+#[test]
 fn stabilizer_code_rejects_dependent_commuting_generators() {
     let x0 = Pauli::from_xz_bits(vec![1], vec![0]).unwrap();
     let duplicate_x0 = Pauli::from_xz_bits(vec![1], vec![0]).unwrap();
@@ -79,4 +92,6 @@ fn steane_exposes_expected_invariants() {
     assert_eq!(code.stabilizer_rank(), 6);
     assert_eq!(code.num_logical_qubits(), 1);
     assert_eq!(code.stabilizers().len(), 6);
+    assert_eq!(code.stabilizer_rows().len(), 6);
+    assert_eq!(code.stabilizer_rows()[0].len(), 14);
 }

--- a/qec-code/tests/logical_distance.rs
+++ b/qec-code/tests/logical_distance.rs
@@ -1,0 +1,47 @@
+use qec_code::codes::steane::Steane;
+use qec_code::distance::compute_distance;
+use qec_code::logical::extract_logical_basis;
+use qec_code::{QecError, StabilizerCode};
+
+#[test]
+fn steane_logical_basis_contains_one_anticommuting_pair() {
+    let steane = Steane::new().unwrap();
+    let code = steane.code();
+
+    let basis = extract_logical_basis(code).unwrap();
+
+    assert_eq!(basis.k, 1);
+    assert_eq!(basis.logical_x.len(), 1);
+    assert_eq!(basis.logical_z.len(), 1);
+    assert!(basis.logical_x[0].anticommutes_with(&basis.logical_z[0]));
+
+    for stabilizer in code.stabilizers() {
+        assert!(basis.logical_x[0].commutes_with(stabilizer));
+        assert!(basis.logical_z[0].commutes_with(stabilizer));
+    }
+}
+
+#[test]
+fn steane_distance_is_three_with_a_commuting_weight_three_witness() {
+    let steane = Steane::new().unwrap();
+    let code = steane.code();
+
+    let distance = compute_distance(code).unwrap();
+
+    assert_eq!(distance.distance, 3);
+    assert_eq!(distance.witness.weight(), 3);
+
+    for stabilizer in code.stabilizers() {
+        assert!(distance.witness.commutes_with(stabilizer));
+    }
+}
+
+#[test]
+fn logical_basis_rejects_multi_logical_codes_until_supported() {
+    let code = StabilizerCode::from_stabilizers(2, vec![]).unwrap();
+
+    assert_eq!(
+        extract_logical_basis(&code),
+        Err(QecError::UnsupportedLogicalBasis { k: 2 })
+    );
+}

--- a/qec-code/tests/logical_distance.rs
+++ b/qec-code/tests/logical_distance.rs
@@ -1,7 +1,7 @@
 use qec_code::codes::steane::Steane;
 use qec_code::distance::compute_distance;
 use qec_code::logical::extract_logical_basis;
-use qec_code::{QecError, StabilizerCode};
+use qec_code::{Pauli, QecError, StabilizerCode};
 
 #[test]
 fn steane_logical_basis_contains_one_anticommuting_pair() {
@@ -43,5 +43,26 @@ fn logical_basis_rejects_multi_logical_codes_until_supported() {
     assert_eq!(
         extract_logical_basis(&code),
         Err(QecError::UnsupportedLogicalBasis { k: 2 })
+    );
+}
+
+#[test]
+fn exhaustive_logical_and_distance_search_reject_large_codes_instead_of_panicking() {
+    let stabilizers = (0..31)
+        .map(|qubit| {
+            let mut z = vec![0; 32];
+            z[qubit] = 1;
+            Pauli::from_xz_bits(vec![0; 32], z).unwrap()
+        })
+        .collect();
+    let code = StabilizerCode::from_stabilizers(32, stabilizers).unwrap();
+
+    assert_eq!(
+        extract_logical_basis(&code),
+        Err(QecError::UnsupportedExhaustiveEnumeration { n: 32 })
+    );
+    assert_eq!(
+        compute_distance(&code),
+        Err(QecError::UnsupportedExhaustiveEnumeration { n: 32 })
     );
 }

--- a/qec-code/tests/logical_distance.rs
+++ b/qec-code/tests/logical_distance.rs
@@ -47,6 +47,34 @@ fn logical_basis_rejects_multi_logical_codes_until_supported() {
 }
 
 #[test]
+fn logical_basis_for_zero_logical_qubits_is_empty() {
+    let code = StabilizerCode::from_stabilizers(1, vec![
+        Pauli::from_xz_bits(vec![1], vec![0]).unwrap(),
+    ])
+    .unwrap();
+
+    let basis = extract_logical_basis(&code).unwrap();
+
+    assert_eq!(basis.k, 0);
+    assert!(basis.logical_x.is_empty());
+    assert!(basis.logical_z.is_empty());
+}
+
+#[test]
+fn distance_returns_no_witness_for_zero_logical_qubit_code() {
+    let code = StabilizerCode::from_stabilizers(
+        2,
+        vec![
+            Pauli::from_xz_bits(vec![1, 0], vec![0, 0]).unwrap(),
+            Pauli::from_xz_bits(vec![0, 0], vec![0, 1]).unwrap(),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(compute_distance(&code), Err(QecError::DistanceWitnessNotFound));
+}
+
+#[test]
 fn exhaustive_logical_and_distance_search_reject_large_codes_instead_of_panicking() {
     let stabilizers = (0..31)
         .map(|qubit| {


### PR DESCRIPTION
## Summary
- add a new `qec-code` workspace crate with binary symplectic helpers, `Pauli`, `StabilizerCode`, `CssCode`, and built-in `Steane`
- add logical-basis extraction and exact small-code distance analysis for Steane, with an explicit unsupported path for multi-logical basis extraction
- add a `qec-code` CLI for `summary`, `stabilizers`, `logicals`, and `distance`, plus implementation docs and focused tests

## Test Plan
- [x] `cargo test -p qec-code -v`
- [x] `cargo test -p qec-code --test cli -v`
- [x] Manual CLI smoke exercised via `summary`, `stabilizers`, `logicals`, `distance`, and `--help` during task review
