### PR TITLE
[codex] add qec-code core logical basis APIs

### DIFF
--- a/docs/superpowers/specs/2026-06-12-qec-code-core-design.md
+++ b/docs/superpowers/specs/2026-06-12-qec-code-core-design.md
@@ -1,0 +1,318 @@
+# qec-code Core Library Design
+
+Date: 2026-06-12
+Status: Draft accepted in-session, written for review
+Scope: Next milestone for the `qec-code` subpackage
+
+## Summary
+
+The next milestone for `qec-code` should turn it into a stronger research-oriented core library for general stabilizer codes. The main shift is architectural: move logical-operator analysis away from exhaustive Pauli enumeration and toward reusable GF(2) and symplectic linear algebra.
+
+The user-facing goal is a small set of useful high-level APIs on `StabilizerCode`:
+
+- `normalizer_basis()`
+- `logical_basis()`
+- `canonical_logical_basis()`
+
+The implementation goal is to support those APIs with reusable algebraic internals rather than one-off search code.
+
+## Current State
+
+The crate already provides:
+
+- binary linear algebra helpers in `binary.rs`
+- `Pauli`
+- `StabilizerCode`
+- `CssCode`
+- a built-in `Steane` example
+- exact logical-basis extraction
+- exact distance computation
+- a CLI for Steane inspection
+
+The current logical and distance routines rely on exhaustive enumeration over non-identity Paulis. This is acceptable for tiny examples, but it blocks the crate from becoming a general-purpose research core.
+
+## Goals
+
+This milestone should:
+
+1. Replace exhaustive search in logical-operator analysis with symplectic linear algebra.
+2. Support general stabilizer codes rather than using CSS structure as the main abstraction.
+3. Support `k > 1` logical qubits in logical-basis extraction.
+4. Provide a canonical logical basis with guaranteed commutation structure.
+5. Keep the external API small and useful for research scripting.
+
+## Non-Goals
+
+This milestone should not:
+
+1. Promise a scalable new distance algorithm.
+2. Expose a large public matrix framework before the higher-level API stabilizes.
+3. Prioritize adding many new code families.
+4. Expand into decoding, circuits, or syndrome workflows.
+
+`distance` may reuse new internals later, but its behavior is not the primary target of this design.
+
+## Architecture
+
+The crate should move toward four layers.
+
+### 1. `gf2`
+
+Generic GF(2) matrix primitives:
+
+- rank
+- row reduction / RREF or equivalent reduced form
+- nullspace
+- row-span membership
+- independent-row extraction
+
+This layer does not know about Paulis or stabilizer semantics.
+
+### 2. `symplectic`
+
+Binary symplectic utilities over length-`2n` rows:
+
+- symplectic inner product
+- commutation helpers
+- conversions between Pauli data and symplectic rows
+- helpers needed to compute normalizer structure
+
+This layer understands the binary representation of Pauli operators, but it is still lower-level than code analysis.
+
+### 3. `code` / `logical`
+
+`StabilizerCode` remains the high-level entry point. Logical-analysis APIs live here and consume the lower layers.
+
+This layer should expose:
+
+- `normalizer_basis()`
+- `logical_basis()`
+- `canonical_logical_basis()`
+
+### 4. `css` / `codes/*`
+
+These modules remain constructor and example layers.
+
+- `CssCode` stays as a convenient constructor.
+- Built-in code families remain examples and fixtures.
+- CSS should not drive the core abstraction.
+
+## Public API
+
+The next milestone should add a minimal, high-value API surface.
+
+```rust
+impl StabilizerCode {
+    pub fn normalizer_basis(&self) -> Result<Vec<Pauli>>;
+    pub fn logical_basis(&self) -> Result<LogicalBasis>;
+    pub fn canonical_logical_basis(&self) -> Result<LogicalBasis>;
+}
+```
+
+`LogicalBasis` should naturally support arbitrary `k`:
+
+```rust
+pub struct LogicalBasis {
+    pub k: usize,
+    pub logical_x: Vec<Pauli>,
+    pub logical_z: Vec<Pauli>,
+}
+```
+
+One additional low-level constructor should be added:
+
+```rust
+impl Pauli {
+    pub fn from_symplectic_row(row: Vec<u8>) -> Result<Self>;
+}
+```
+
+The `gf2` and `symplectic` modules should initially stay conservative in visibility. Prefer `pub(crate)` or narrowly exposed items until the high-level API has proven stable.
+
+## API Semantics
+
+### `normalizer_basis()`
+
+Returns a generating set for the normalizer of the stabilizer group in binary symplectic form, lifted back to `Pauli` values. The return value does not need to remove stabilizer content; it is a basis for the full normalizer space, not a basis of logical representatives modulo stabilizers.
+
+### `logical_basis()`
+
+Returns `k` logical `X` representatives and `k` logical `Z` representatives such that:
+
+- each operator commutes with every stabilizer
+- the returned representatives are independent modulo the stabilizer space
+- the result is valid for general `k > 1`
+
+This API does not need to enforce canonical pair ordering beyond correctness of the logical representatives.
+
+### `canonical_logical_basis()`
+
+Returns a stronger result with guaranteed canonical pairing:
+
+- `X_i` anticommutes with `Z_i`
+- `X_i` commutes with `Z_j` for `i != j`
+- all `X_i` commute with each other
+- all `Z_i` commute with each other
+
+This should be guaranteed by the algorithm, not obtained by opportunistic search.
+
+## Algorithm Strategy
+
+The design intentionally separates three algebraic objects:
+
+1. the stabilizer row space
+2. the normalizer space
+3. the quotient of normalizer by stabilizer
+
+The implementation should follow that structure.
+
+### Step 1: Build reusable GF(2) infrastructure
+
+Refactor the current free-function style helpers in `binary.rs` into a more reusable internal matrix layer. This does not require a heavy public abstraction, but it should provide a stable internal API for:
+
+- validation
+- reduction
+- rank
+- nullspace
+- span membership
+- extraction of independent generators
+
+### Step 2: Compute the normalizer linearly
+
+The normalizer should be obtained from the symplectic commutation constraints, not from enumerating all Paulis. Concretely, the stabilizer rows define a linear system whose solutions are exactly the symplectic rows commuting with the stabilizer generators.
+
+The implementation should solve that system to obtain a basis for the normalizer space.
+
+### Step 3: Pass to logical representatives
+
+Logical representatives should be chosen from the normalizer space modulo the stabilizer row space. The implementation should explicitly track independence modulo stabilizers rather than checking only raw independence in the ambient `2n`-dimensional space.
+
+### Step 4: Canonicalize pairings
+
+Canonical logical pairs should be produced by a symplectic basis-selection or symplectic reduction procedure on the logical quotient space. The algorithm should enforce the desired commutation pattern rather than hoping an arbitrary basis already has it.
+
+## Compatibility Requirements
+
+This milestone must preserve:
+
+- `CssCode::from_hx_hz(...)`
+- existing `Steane` construction
+- existing `Pauli` behavior
+- current CLI behavior unless a change is directly required by the new API
+
+Where old APIs are currently limited by exhaustive search, behavior may broaden, but existing working cases must remain correct.
+
+## Milestones
+
+### Milestone 1: Internal GF(2) and symplectic primitives
+
+Deliver:
+
+- reusable internal matrix helpers
+- symplectic row conversions
+- nullspace / rank / span utilities
+
+Validation:
+
+- pure algebra unit tests
+- edge-case validation tests
+
+### Milestone 2: `normalizer_basis()`
+
+Deliver:
+
+- normalizer-basis computation on `StabilizerCode`
+- removal of exhaustive search from the normalizer path
+
+Validation:
+
+- every returned element commutes with all stabilizers
+- stabilizers lie in the returned normalizer span
+- basis dimension is correct on small examples
+
+### Milestone 3: general `logical_basis()`
+
+Deliver:
+
+- support for `k > 1`
+- logical representatives chosen from the normalizer quotient
+
+Validation:
+
+- lengths match `k`
+- all representatives commute with stabilizers
+- representatives are independent modulo stabilizers
+
+### Milestone 4: `canonical_logical_basis()`
+
+Deliver:
+
+- canonical anticommuting pairs for general stabilizer codes
+
+Validation:
+
+- pairwise commutation / anticommutation relations hold exactly
+- existing Steane behavior remains correct
+
+## Test Strategy
+
+Testing should scale with the layered design.
+
+### Algebra tests
+
+Keep low-level tests focused on:
+
+- empty matrices
+- zero rows
+- dependent rows
+- rank and nullspace sanity cases
+- width mismatch and invalid bit validation
+
+### Integration tests
+
+Add integration tests that exercise code-analysis behavior through public APIs rather than only testing internals.
+
+At minimum, include:
+
+1. the existing Steane example
+2. one small `k = 2` stabilizer example
+3. one small non-CSS stabilizer example
+
+The second and third cases are important because this milestone is specifically about breaking the current dependence on single-logical or CSS-flavored assumptions.
+
+### Regression policy
+
+Run `cargo test -p qec-code` after each milestone. Prefer adding targeted integration tests over piling every assertion into one existing test file.
+
+## Risks
+
+### Risk 1: Overdesigning the matrix layer
+
+If the internal GF(2) abstraction becomes too generic too early, the milestone will stall in infrastructure work. The matrix layer should exist to serve `StabilizerCode`, not to become a standalone math framework yet.
+
+### Risk 2: Conflating logical basis with distance
+
+Logical-basis extraction and distance are related but not equivalent. Folding distance into this milestone would expand scope and obscure whether the logical APIs themselves are well designed.
+
+### Risk 3: Hidden CSS assumptions
+
+Even with a general stabilizer surface API, it is easy to accidentally bake CSS expectations into the tests or basis-selection logic. This is why at least one non-CSS example must be part of acceptance.
+
+## Success Criteria
+
+This design is successful when:
+
+- `logical_basis()` works for small general stabilizer codes with `k > 1`
+- `canonical_logical_basis()` returns a valid canonical pairing
+- the implementation no longer depends on exhaustive Pauli enumeration for logical analysis
+- existing CSS and Steane constructions still work
+- tests cover at least one multi-logical and one non-CSS example
+
+## Deferred Work
+
+The following are intentionally deferred until after this milestone:
+
+- scalable distance algorithms
+- broader public exposure of `gf2` / `symplectic` APIs
+- more built-in code families
+- decoder-oriented workflows

--- a/qec-code/src/binary.rs
+++ b/qec-code/src/binary.rs
@@ -1,146 +1,27 @@
-use crate::error::{QecError, Result};
-
-fn validate_binary_rows(matrix: &[Vec<u8>]) -> Result<usize> {
-    let width = matrix.first().map_or(0, Vec::len);
-    for (row_index, row) in matrix.iter().enumerate() {
-        if row.len() != width {
-            return Err(QecError::RowWidthMismatch {
-                expected: width,
-                actual: row.len(),
-            });
-        }
-        for (col_index, bit) in row.iter().enumerate() {
-            if *bit > 1 {
-                return Err(QecError::InvalidBinaryEntry {
-                    row: row_index,
-                    col: col_index,
-                    value: *bit,
-                });
-            }
-        }
-    }
-    Ok(width)
-}
-
-fn assert_binary_rows(matrix: &[Vec<u8>]) -> usize {
-    validate_binary_rows(matrix).expect("matrix rows must be rectangular binary vectors")
-}
-
-fn validate_binary_target(target: &[u8]) -> Result<()> {
-    for (index, bit) in target.iter().enumerate() {
-        if *bit > 1 {
-            return Err(QecError::InvalidBinaryEntry {
-                row: 0,
-                col: index,
-                value: *bit,
-            });
-        }
-    }
-    Ok(())
-}
+use crate::error::Result;
+use crate::gf2;
 
 pub fn eliminate_to_row_echelon(matrix: &[Vec<u8>]) -> Vec<Vec<u8>> {
-    let width = assert_binary_rows(matrix);
-    let mut rows = matrix.to_vec();
-    let mut pivot_row = 0;
-
-    for col in 0..width {
-        let Some(pivot) = (pivot_row..rows.len()).find(|&row| rows[row][col] == 1) else {
-            continue;
-        };
-        rows.swap(pivot_row, pivot);
-
-        for row in (pivot_row + 1)..rows.len() {
-            if rows[row][col] == 1 {
-                for k in col..width {
-                    rows[row][k] ^= rows[pivot_row][k];
-                }
-            }
-        }
-
-        pivot_row += 1;
-        if pivot_row == rows.len() {
-            break;
-        }
-    }
-
-    rows
-}
-
-fn row_echelon_rank(rows: &mut [Vec<u8>], width: usize) -> usize {
-    let mut rank = 0;
-    let mut pivot_row = 0;
-
-    for col in 0..width {
-        let Some(pivot) = (pivot_row..rows.len()).find(|&row| rows[row][col] == 1) else {
-            continue;
-        };
-        rows.swap(pivot_row, pivot);
-
-        for row in 0..rows.len() {
-            if row != pivot_row && rows[row][col] == 1 {
-                for k in col..width {
-                    rows[row][k] ^= rows[pivot_row][k];
-                }
-            }
-        }
-
-        rank += 1;
-        pivot_row += 1;
-        if pivot_row == rows.len() {
-            break;
-        }
-    }
-
-    rank
+    gf2::try_row_echelon(matrix).expect("matrix rows must be rectangular binary vectors")
 }
 
 pub fn binary_rank(matrix: &[Vec<u8>]) -> usize {
-    let width = assert_binary_rows(matrix);
-    let mut rows = matrix.to_vec();
-    row_echelon_rank(&mut rows, width)
+    gf2::try_rank(matrix).expect("matrix rows must be rectangular binary vectors")
 }
 
 pub fn try_eliminate_to_row_echelon(matrix: &[Vec<u8>]) -> Result<Vec<Vec<u8>>> {
-    validate_binary_rows(matrix)?;
-    Ok(eliminate_to_row_echelon(matrix))
+    gf2::try_row_echelon(matrix)
 }
 
 pub fn try_binary_rank(matrix: &[Vec<u8>]) -> Result<usize> {
-    validate_binary_rows(matrix)?;
-    Ok(binary_rank(matrix))
+    gf2::try_rank(matrix)
 }
 
 pub fn try_in_row_span(matrix: &[Vec<u8>], target: &[u8]) -> Result<bool> {
-    let width = validate_binary_rows(matrix)?;
-    validate_binary_target(target)?;
-
-    if matrix.is_empty() {
-        return Ok(!target.iter().any(|bit| *bit != 0));
-    }
-
-    if target.len() != width {
-        return Err(QecError::RowWidthMismatch {
-            expected: width,
-            actual: target.len(),
-        });
-    }
-
-    Ok(in_row_span(matrix, target))
+    gf2::try_in_row_span(matrix, target)
 }
 
 pub fn in_row_span(matrix: &[Vec<u8>], target: &[u8]) -> bool {
-    let width = assert_binary_rows(matrix);
-    validate_binary_target(target).expect("target entries must be binary");
-
-    if matrix.is_empty() {
-        return !target.iter().any(|bit| *bit != 0);
-    }
-
-    assert_eq!(target.len(), width, "target length must match matrix width");
-
-    let rank = binary_rank(matrix);
-    let mut augmented = matrix.to_vec();
-    augmented.push(target.to_vec());
-    binary_rank(&augmented) == rank
+    gf2::try_in_row_span(matrix, target)
+        .expect("matrix rows must be rectangular binary vectors and target entries must be binary")
 }

--- a/qec-code/src/cli.rs
+++ b/qec-code/src/cli.rs
@@ -3,7 +3,6 @@ use clap::{Parser, Subcommand};
 use crate::QecError;
 use crate::codes::steane::Steane;
 use crate::distance::compute_distance;
-use crate::logical::extract_logical_basis;
 
 #[derive(Debug, Parser)]
 #[command(name = "qec-code")]
@@ -69,7 +68,7 @@ fn run_steane(command: SteaneCommands) -> Result<String, QecError> {
             Ok(lines.join("\n"))
         }
         SteaneCommands::Logicals => {
-            let basis = extract_logical_basis(code)?;
+            let basis = code.logical_basis()?;
             Ok(format!(
                 "k: {}\nlogical_x:\n{}\nlogical_z:\n{}",
                 basis.k,

--- a/qec-code/src/code.rs
+++ b/qec-code/src/code.rs
@@ -66,6 +66,7 @@ impl StabilizerCode {
         self.n - self.stabilizer_rank
     }
 
+    /// Returns a basis for the full stabilizer normalizer, including stabilizer generators.
     pub fn normalizer_basis(&self) -> Result<Vec<Pauli>> {
         crate::logical::compute_normalizer_basis(self)
     }

--- a/qec-code/src/code.rs
+++ b/qec-code/src/code.rs
@@ -65,4 +65,16 @@ impl StabilizerCode {
     pub fn num_logical_qubits(&self) -> usize {
         self.n - self.stabilizer_rank
     }
+
+    pub fn normalizer_basis(&self) -> Result<Vec<Pauli>> {
+        crate::logical::compute_normalizer_basis(self)
+    }
+
+    pub fn logical_basis(&self) -> Result<crate::logical::LogicalBasis> {
+        crate::logical::compute_logical_basis(self)
+    }
+
+    pub fn canonical_logical_basis(&self) -> Result<crate::logical::LogicalBasis> {
+        crate::logical::compute_canonical_logical_basis(self)
+    }
 }

--- a/qec-code/src/error.rs
+++ b/qec-code/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum QecError {
     #[error("row width mismatch: expected {expected}, got {actual}")]
     RowWidthMismatch { expected: usize, actual: usize },
+    #[error("invalid symplectic row width: expected even width, got {width}")]
+    InvalidSymplecticRowWidth { width: usize },
     #[error("non-binary matrix entry {value} at row {row}, column {col}")]
     InvalidBinaryEntry { row: usize, col: usize, value: u8 },
     #[error("invalid Pauli width: x has {x_width} bits, z has {z_width}")]

--- a/qec-code/src/gf2.rs
+++ b/qec-code/src/gf2.rs
@@ -2,6 +2,173 @@ use crate::error::{QecError, Result};
 
 pub(crate) type BinaryRow = Vec<u8>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReducedRows {
+    pub rows: Vec<BinaryRow>,
+    pub pivot_cols: Vec<usize>,
+    pub width: usize,
+}
+
+pub(crate) fn validate_rows(matrix: &[BinaryRow]) -> Result<usize> {
+    let width = matrix.first().map_or(0, Vec::len);
+    for (row_index, row) in matrix.iter().enumerate() {
+        if row.len() != width {
+            return Err(QecError::RowWidthMismatch {
+                expected: width,
+                actual: row.len(),
+            });
+        }
+        for (col_index, bit) in row.iter().enumerate() {
+            if *bit > 1 {
+                return Err(QecError::InvalidBinaryEntry {
+                    row: row_index,
+                    col: col_index,
+                    value: *bit,
+                });
+            }
+        }
+    }
+    Ok(width)
+}
+
+pub(crate) fn validate_target(target: &[u8]) -> Result<()> {
+    for (index, bit) in target.iter().enumerate() {
+        if *bit > 1 {
+            return Err(QecError::InvalidBinaryEntry {
+                row: 0,
+                col: index,
+                value: *bit,
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn try_row_echelon(matrix: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
+    let width = validate_rows(matrix)?;
+    let mut rows = matrix.to_vec();
+    let mut pivot_row = 0;
+
+    for col in 0..width {
+        let Some(pivot) = (pivot_row..rows.len()).find(|&row| rows[row][col] == 1) else {
+            continue;
+        };
+        rows.swap(pivot_row, pivot);
+
+        for row in (pivot_row + 1)..rows.len() {
+            if rows[row][col] == 1 {
+                for k in col..width {
+                    rows[row][k] ^= rows[pivot_row][k];
+                }
+            }
+        }
+
+        pivot_row += 1;
+        if pivot_row == rows.len() {
+            break;
+        }
+    }
+
+    Ok(rows)
+}
+
+pub(crate) fn try_rref(matrix: &[BinaryRow]) -> Result<ReducedRows> {
+    let width = validate_rows(matrix)?;
+    let mut rows = matrix.to_vec();
+    let mut pivot_cols = Vec::new();
+    let mut pivot_row = 0;
+
+    for col in 0..width {
+        let Some(pivot) = (pivot_row..rows.len()).find(|&row| rows[row][col] == 1) else {
+            continue;
+        };
+        rows.swap(pivot_row, pivot);
+
+        for row in 0..rows.len() {
+            if row != pivot_row && rows[row][col] == 1 {
+                for k in col..width {
+                    rows[row][k] ^= rows[pivot_row][k];
+                }
+            }
+        }
+
+        pivot_cols.push(col);
+        pivot_row += 1;
+        if pivot_row == rows.len() {
+            break;
+        }
+    }
+
+    Ok(ReducedRows {
+        rows,
+        pivot_cols,
+        width,
+    })
+}
+
+pub(crate) fn try_rank(matrix: &[BinaryRow]) -> Result<usize> {
+    Ok(try_rref(matrix)?.pivot_cols.len())
+}
+
+pub(crate) fn try_in_row_span(matrix: &[BinaryRow], target: &[u8]) -> Result<bool> {
+    let width = validate_rows(matrix)?;
+    validate_target(target)?;
+
+    if matrix.is_empty() {
+        return Ok(!target.iter().any(|bit| *bit != 0));
+    }
+
+    if target.len() != width {
+        return Err(QecError::RowWidthMismatch {
+            expected: width,
+            actual: target.len(),
+        });
+    }
+
+    let rank = try_rank(matrix)?;
+    let mut augmented = matrix.to_vec();
+    augmented.push(target.to_vec());
+    Ok(try_rank(&augmented)? == rank)
+}
+
+pub(crate) fn try_select_independent_rows(matrix: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
+    validate_rows(matrix)?;
+    let mut basis = Vec::new();
+
+    for row in matrix {
+        if !try_in_row_span(&basis, row)? {
+            basis.push(row.clone());
+        }
+    }
+
+    Ok(basis)
+}
+
+pub(crate) fn try_nullspace_basis(matrix: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
+    let reduced = try_rref(matrix)?;
+    let width = reduced.width;
+    let pivot_cols = reduced.pivot_cols;
+    let free_cols = (0..width)
+        .filter(|col| !pivot_cols.contains(col))
+        .collect::<Vec<_>>();
+
+    if free_cols.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut basis = Vec::with_capacity(free_cols.len());
+    for free_col in free_cols {
+        let mut vector = vec![0; width];
+        vector[free_col] = 1;
+        for (pivot_row, pivot_col) in pivot_cols.iter().copied().enumerate() {
+            vector[pivot_col] = reduced.rows[pivot_row][free_col];
+        }
+        basis.push(vector);
+    }
+
+    Ok(basis)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{try_nullspace_basis, try_select_independent_rows};

--- a/qec-code/src/gf2.rs
+++ b/qec-code/src/gf2.rs
@@ -11,6 +11,11 @@ pub(crate) struct ReducedRows {
 
 pub(crate) fn validate_rows(matrix: &[BinaryRow]) -> Result<usize> {
     let width = matrix.first().map_or(0, Vec::len);
+    validate_rows_with_width(matrix, width)?;
+    Ok(width)
+}
+
+pub(crate) fn validate_rows_with_width(matrix: &[BinaryRow], width: usize) -> Result<()> {
     for (row_index, row) in matrix.iter().enumerate() {
         if row.len() != width {
             return Err(QecError::RowWidthMismatch {
@@ -28,7 +33,7 @@ pub(crate) fn validate_rows(matrix: &[BinaryRow]) -> Result<usize> {
             }
         }
     }
-    Ok(width)
+    Ok(())
 }
 
 pub(crate) fn validate_target(target: &[u8]) -> Result<()> {
@@ -74,6 +79,11 @@ pub(crate) fn try_row_echelon(matrix: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
 
 pub(crate) fn try_rref(matrix: &[BinaryRow]) -> Result<ReducedRows> {
     let width = validate_rows(matrix)?;
+    try_rref_with_width(matrix, width)
+}
+
+pub(crate) fn try_rref_with_width(matrix: &[BinaryRow], width: usize) -> Result<ReducedRows> {
+    validate_rows_with_width(matrix, width)?;
     let mut rows = matrix.to_vec();
     let mut pivot_cols = Vec::new();
     let mut pivot_row = 0;
@@ -118,6 +128,17 @@ pub(crate) fn try_in_row_span(matrix: &[BinaryRow], target: &[u8]) -> Result<boo
         return Ok(!target.iter().any(|bit| *bit != 0));
     }
 
+    try_in_row_span_with_width(matrix, width, target)
+}
+
+pub(crate) fn try_in_row_span_with_width(
+    matrix: &[BinaryRow],
+    width: usize,
+    target: &[u8],
+) -> Result<bool> {
+    validate_rows_with_width(matrix, width)?;
+    validate_target(target)?;
+
     if target.len() != width {
         return Err(QecError::RowWidthMismatch {
             expected: width,
@@ -125,18 +146,22 @@ pub(crate) fn try_in_row_span(matrix: &[BinaryRow], target: &[u8]) -> Result<boo
         });
     }
 
-    let rank = try_rank(matrix)?;
+    if matrix.is_empty() {
+        return Ok(!target.iter().any(|bit| *bit != 0));
+    }
+
+    let rank = try_rref_with_width(matrix, width)?.pivot_cols.len();
     let mut augmented = matrix.to_vec();
     augmented.push(target.to_vec());
-    Ok(try_rank(&augmented)? == rank)
+    Ok(try_rref_with_width(&augmented, width)?.pivot_cols.len() == rank)
 }
 
 pub(crate) fn try_select_independent_rows(matrix: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
-    validate_rows(matrix)?;
+    let width = validate_rows(matrix)?;
     let mut basis = Vec::new();
 
     for row in matrix {
-        if !try_in_row_span(&basis, row)? {
+        if !try_in_row_span_with_width(&basis, width, row)? {
             basis.push(row.clone());
         }
     }
@@ -145,7 +170,15 @@ pub(crate) fn try_select_independent_rows(matrix: &[BinaryRow]) -> Result<Vec<Bi
 }
 
 pub(crate) fn try_nullspace_basis(matrix: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
-    let reduced = try_rref(matrix)?;
+    let width = validate_rows(matrix)?;
+    try_nullspace_basis_with_width(matrix, width)
+}
+
+pub(crate) fn try_nullspace_basis_with_width(
+    matrix: &[BinaryRow],
+    width: usize,
+) -> Result<Vec<BinaryRow>> {
+    let reduced = try_rref_with_width(matrix, width)?;
     let width = reduced.width;
     let pivot_cols = reduced.pivot_cols;
     let free_cols = (0..width)
@@ -171,7 +204,12 @@ pub(crate) fn try_nullspace_basis(matrix: &[BinaryRow]) -> Result<Vec<BinaryRow>
 
 #[cfg(test)]
 mod tests {
-    use super::{try_nullspace_basis, try_select_independent_rows};
+    use crate::error::QecError;
+
+    use super::{
+        try_in_row_span_with_width, try_nullspace_basis_with_width, try_nullspace_basis,
+        try_select_independent_rows,
+    };
 
     fn dot(lhs: &[u8], rhs: &[u8]) -> u8 {
         lhs.iter()
@@ -200,6 +238,26 @@ mod tests {
         assert_eq!(
             try_select_independent_rows(&rows).unwrap(),
             vec![vec![1, 0, 1], vec![0, 1, 1]]
+        );
+    }
+
+    #[test]
+    fn width_aware_nullspace_basis_for_empty_constraints_spans_full_space() {
+        let basis = try_nullspace_basis_with_width(&[], 3).unwrap();
+
+        assert_eq!(basis, vec![vec![1, 0, 0], vec![0, 1, 0], vec![0, 0, 1]]);
+    }
+
+    #[test]
+    fn width_aware_row_span_path_checks_known_empty_constraint_width() {
+        assert_eq!(try_in_row_span_with_width(&[], 3, &[0, 0, 0]), Ok(true));
+        assert_eq!(try_in_row_span_with_width(&[], 3, &[1, 0, 0]), Ok(false));
+        assert_eq!(
+            try_in_row_span_with_width(&[], 3, &[0, 0]),
+            Err(QecError::RowWidthMismatch {
+                expected: 3,
+                actual: 2,
+            })
         );
     }
 }

--- a/qec-code/src/gf2.rs
+++ b/qec-code/src/gf2.rs
@@ -169,11 +169,6 @@ pub(crate) fn try_select_independent_rows(matrix: &[BinaryRow]) -> Result<Vec<Bi
     Ok(basis)
 }
 
-pub(crate) fn try_nullspace_basis(matrix: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
-    let width = validate_rows(matrix)?;
-    try_nullspace_basis_with_width(matrix, width)
-}
-
 pub(crate) fn try_nullspace_basis_with_width(
     matrix: &[BinaryRow],
     width: usize,
@@ -207,8 +202,7 @@ mod tests {
     use crate::error::QecError;
 
     use super::{
-        try_in_row_span_with_width, try_nullspace_basis_with_width, try_nullspace_basis,
-        try_select_independent_rows,
+        try_in_row_span_with_width, try_nullspace_basis_with_width, try_select_independent_rows,
     };
 
     fn dot(lhs: &[u8], rhs: &[u8]) -> u8 {
@@ -220,7 +214,7 @@ mod tests {
     #[test]
     fn nullspace_basis_annihilates_every_constraint_row() {
         let matrix = vec![vec![1, 0, 1, 0], vec![0, 1, 1, 0]];
-        let basis = try_nullspace_basis(&matrix).unwrap();
+        let basis = try_nullspace_basis_with_width(&matrix, 4).unwrap();
 
         assert_eq!(basis.len(), 2);
         assert!(basis.iter().all(|row| row.len() == 4));

--- a/qec-code/src/gf2.rs
+++ b/qec-code/src/gf2.rs
@@ -1,0 +1,38 @@
+use crate::error::{QecError, Result};
+
+pub(crate) type BinaryRow = Vec<u8>;
+
+#[cfg(test)]
+mod tests {
+    use super::{try_nullspace_basis, try_select_independent_rows};
+
+    fn dot(lhs: &[u8], rhs: &[u8]) -> u8 {
+        lhs.iter()
+            .zip(rhs)
+            .fold(0, |parity, (left, right)| parity ^ (*left & *right))
+    }
+
+    #[test]
+    fn nullspace_basis_annihilates_every_constraint_row() {
+        let matrix = vec![vec![1, 0, 1, 0], vec![0, 1, 1, 0]];
+        let basis = try_nullspace_basis(&matrix).unwrap();
+
+        assert_eq!(basis.len(), 2);
+        assert!(basis.iter().all(|row| row.len() == 4));
+        for row in &matrix {
+            for vector in &basis {
+                assert_eq!(dot(row, vector), 0);
+            }
+        }
+    }
+
+    #[test]
+    fn select_independent_rows_drops_dependent_generators() {
+        let rows = vec![vec![1, 0, 1], vec![0, 1, 1], vec![1, 1, 0]];
+
+        assert_eq!(
+            try_select_independent_rows(&rows).unwrap(),
+            vec![vec![1, 0, 1], vec![0, 1, 1]]
+        );
+    }
+}

--- a/qec-code/src/lib.rs
+++ b/qec-code/src/lib.rs
@@ -5,6 +5,7 @@ pub mod codes;
 pub mod css;
 pub mod distance;
 pub mod error;
+mod gf2;
 pub mod logical;
 pub mod pauli;
 

--- a/qec-code/src/lib.rs
+++ b/qec-code/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 mod gf2;
 pub mod logical;
 pub mod pauli;
+mod symplectic;
 
 pub use code::StabilizerCode;
 pub use error::QecError;

--- a/qec-code/src/logical.rs
+++ b/qec-code/src/logical.rs
@@ -1,7 +1,7 @@
 use crate::Pauli;
-use crate::binary::try_in_row_span;
 use crate::code::StabilizerCode;
-use crate::error::{QecError, Result};
+use crate::error::Result;
+use crate::{gf2, symplectic};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogicalBasis {
@@ -11,104 +11,31 @@ pub struct LogicalBasis {
 }
 
 pub fn extract_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
-    let k = code.num_logical_qubits();
-    if k == 0 {
-        return Ok(LogicalBasis {
-            k,
-            logical_x: Vec::new(),
-            logical_z: Vec::new(),
-        });
-    }
-    if k > 1 {
-        return Err(QecError::UnsupportedLogicalBasis { k });
-    }
+    code.logical_basis()
+}
 
-    let stabilizer_rows = code.stabilizer_rows();
-    let mut logicals = Vec::new();
+pub fn compute_normalizer_basis(code: &StabilizerCode) -> Result<Vec<Pauli>> {
+    normalizer_basis_rows(code)?
+        .into_iter()
+        .map(Pauli::from_symplectic_row)
+        .collect()
+}
 
-    for candidate in all_paulis(code.n())? {
-        if code
-            .stabilizers()
-            .iter()
-            .all(|stabilizer| candidate.commutes_with(stabilizer))
-            && !try_in_row_span(&stabilizer_rows, &candidate.to_symplectic_row())?
-        {
-            logicals.push(candidate);
-        }
-    }
+pub fn compute_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
+    compute_canonical_logical_basis(code)
+}
 
-    let (logical_x, logical_z) = select_anticommuting_pair(&logicals)?;
+pub fn compute_canonical_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
     Ok(LogicalBasis {
-        k,
-        logical_x: vec![logical_x],
-        logical_z: vec![logical_z],
+        k: code.num_logical_qubits(),
+        logical_x: Vec::new(),
+        logical_z: Vec::new(),
     })
 }
 
-fn all_paulis(n: usize) -> Result<Vec<Pauli>> {
-    let symplectic_bits = n
-        .checked_mul(2)
-        .ok_or(QecError::UnsupportedExhaustiveEnumeration { n })?;
-    let total = 1usize
-        .checked_shl(symplectic_bits as u32)
-        .ok_or(QecError::UnsupportedExhaustiveEnumeration { n })?;
-    let mut paulis = Vec::with_capacity(total.saturating_sub(1));
-
-    for mask in 1..total {
-        let mut x = vec![0; n];
-        let mut z = vec![0; n];
-
-        for qubit in 0..n {
-            x[qubit] = ((mask >> qubit) & 1) as u8;
-            z[qubit] = ((mask >> (n + qubit)) & 1) as u8;
-        }
-
-        paulis.push(
-            Pauli::from_xz_bits(x, z).expect("generated Pauli supports must be valid binary rows"),
-        );
-    }
-
-    Ok(paulis)
-}
-
-fn select_anticommuting_pair(logicals: &[Pauli]) -> Result<(Pauli, Pauli)> {
-    for i in 0..logicals.len() {
-        for j in (i + 1)..logicals.len() {
-            if logicals[i].try_anticommutes_with(&logicals[j])? {
-                return Ok((logicals[i].clone(), logicals[j].clone()));
-            }
-        }
-    }
-
-    Err(QecError::LogicalBasisNotFound)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::select_anticommuting_pair;
-    use crate::{Pauli, QecError};
-
-    #[test]
-    fn select_anticommuting_pair_returns_the_first_found_pair() {
-        let logical_x = Pauli::from_xz_bits(vec![1, 1], vec![0, 0]).unwrap();
-        let logical_z = Pauli::from_xz_bits(vec![0, 0], vec![1, 0]).unwrap();
-        let commuting = Pauli::from_xz_bits(vec![0, 0], vec![0, 1]).unwrap();
-
-        let (x, z) = select_anticommuting_pair(&[logical_x.clone(), logical_z.clone(), commuting])
-            .unwrap();
-
-        assert_eq!(x, logical_x);
-        assert_eq!(z, logical_z);
-    }
-
-    #[test]
-    fn select_anticommuting_pair_reports_when_no_pair_exists() {
-        let x0 = Pauli::from_xz_bits(vec![1, 0], vec![0, 0]).unwrap();
-        let x1 = Pauli::from_xz_bits(vec![0, 1], vec![0, 0]).unwrap();
-
-        assert_eq!(
-            select_anticommuting_pair(&[x0, x1]),
-            Err(QecError::LogicalBasisNotFound)
-        );
-    }
+fn normalizer_basis_rows(code: &StabilizerCode) -> Result<Vec<Vec<u8>>> {
+    let width = 2 * code.n();
+    let stabilizer_rows = code.stabilizer_rows();
+    let constraints = symplectic::commutation_constraints_with_width(&stabilizer_rows, width)?;
+    gf2::try_nullspace_basis_with_width(&constraints, width)
 }

--- a/qec-code/src/logical.rs
+++ b/qec-code/src/logical.rs
@@ -1,6 +1,7 @@
 use crate::Pauli;
 use crate::code::StabilizerCode;
 use crate::error::{QecError, Result};
+use crate::gf2::BinaryRow;
 use crate::{gf2, symplectic};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,14 +27,58 @@ pub fn compute_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
 }
 
 pub fn compute_canonical_logical_basis(code: &StabilizerCode) -> Result<LogicalBasis> {
+    let k = code.num_logical_qubits();
+    let logical_rows = logical_quotient_rows(code)?;
+    let pairs = symplectic::symplectic_gram_schmidt(&logical_rows)?;
+
+    if pairs.len() != k {
+        return Err(QecError::LogicalBasisNotFound);
+    }
+
+    let mut logical_x = Vec::with_capacity(k);
+    let mut logical_z = Vec::with_capacity(k);
+    for (x_like, z_like) in pairs {
+        logical_x.push(Pauli::from_symplectic_row(x_like)?);
+        logical_z.push(Pauli::from_symplectic_row(z_like)?);
+    }
+
     Ok(LogicalBasis {
-        k: code.num_logical_qubits(),
-        logical_x: Vec::new(),
-        logical_z: Vec::new(),
+        k,
+        logical_x,
+        logical_z,
     })
 }
 
-fn normalizer_basis_rows(code: &StabilizerCode) -> Result<Vec<Vec<u8>>> {
+fn logical_quotient_rows(code: &StabilizerCode) -> Result<Vec<BinaryRow>> {
+    let width = symplectic_width(code)?;
+    let target_count = code
+        .num_logical_qubits()
+        .checked_mul(2)
+        .ok_or(QecError::UnsupportedExhaustiveEnumeration { n: code.n() })?;
+    let mut span_rows = code.stabilizer_rows();
+    gf2::validate_rows_with_width(&span_rows, width)?;
+
+    let mut logical_rows = Vec::with_capacity(target_count);
+    for row in normalizer_basis_rows(code)? {
+        if gf2::try_in_row_span_with_width(&span_rows, width, &row)? {
+            continue;
+        }
+
+        span_rows.push(row.clone());
+        logical_rows.push(row);
+        if logical_rows.len() == target_count {
+            return Ok(logical_rows);
+        }
+    }
+
+    if logical_rows.len() == target_count {
+        Ok(logical_rows)
+    } else {
+        Err(QecError::LogicalBasisNotFound)
+    }
+}
+
+fn normalizer_basis_rows(code: &StabilizerCode) -> Result<Vec<BinaryRow>> {
     let width = symplectic_width(code)?;
     let stabilizer_rows = code.stabilizer_rows();
     let constraints = symplectic::commutation_constraints_with_width(&stabilizer_rows, width)?;

--- a/qec-code/src/logical.rs
+++ b/qec-code/src/logical.rs
@@ -1,6 +1,6 @@
 use crate::Pauli;
 use crate::code::StabilizerCode;
-use crate::error::Result;
+use crate::error::{QecError, Result};
 use crate::{gf2, symplectic};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,8 +34,14 @@ pub fn compute_canonical_logical_basis(code: &StabilizerCode) -> Result<LogicalB
 }
 
 fn normalizer_basis_rows(code: &StabilizerCode) -> Result<Vec<Vec<u8>>> {
-    let width = 2 * code.n();
+    let width = symplectic_width(code)?;
     let stabilizer_rows = code.stabilizer_rows();
     let constraints = symplectic::commutation_constraints_with_width(&stabilizer_rows, width)?;
     gf2::try_nullspace_basis_with_width(&constraints, width)
+}
+
+fn symplectic_width(code: &StabilizerCode) -> Result<usize> {
+    let n = code.n();
+    n.checked_mul(2)
+        .ok_or(QecError::UnsupportedExhaustiveEnumeration { n })
 }

--- a/qec-code/src/pauli.rs
+++ b/qec-code/src/pauli.rs
@@ -1,4 +1,5 @@
 use crate::error::{QecError, Result};
+use crate::symplectic;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Pauli {
@@ -17,6 +18,16 @@ impl Pauli {
         validate_pauli_bits("X", &x)?;
         validate_pauli_bits("Z", &z)?;
         Ok(Self { x, z })
+    }
+
+    pub fn from_symplectic_row(row: Vec<u8>) -> Result<Self> {
+        if row.len() % 2 != 0 {
+            return Err(QecError::InvalidSymplecticRowWidth { width: row.len() });
+        }
+
+        let qubits = row.len() / 2;
+        let (x, z) = row.split_at(qubits);
+        Self::from_xz_bits(x.to_vec(), z.to_vec())
     }
 
     pub fn n(&self) -> usize {
@@ -39,14 +50,7 @@ impl Pauli {
             });
         }
 
-        Ok(self
-            .x
-            .iter()
-            .zip(&self.z)
-            .zip(other.x.iter().zip(&other.z))
-            .fold(0, |parity, ((x1, z1), (x2, z2))| {
-                parity ^ ((*x1 & *z2) ^ (*z1 & *x2))
-            }))
+        symplectic::symplectic_product(&self.to_symplectic_row(), &other.to_symplectic_row())
     }
 
     pub fn symplectic_product(&self, other: &Self) -> u8 {
@@ -63,7 +67,14 @@ impl Pauli {
     }
 
     pub fn try_commutes_with(&self, other: &Self) -> Result<bool> {
-        Ok(self.try_symplectic_product(other)? == 0)
+        if self.n() != other.n() {
+            return Err(QecError::InvalidPauliWidth {
+                x_width: self.n(),
+                z_width: other.n(),
+            });
+        }
+
+        symplectic::commutes(&self.to_symplectic_row(), &other.to_symplectic_row())
     }
 
     pub fn commutes_with(&self, other: &Self) -> bool {
@@ -72,7 +83,7 @@ impl Pauli {
     }
 
     pub fn try_anticommutes_with(&self, other: &Self) -> Result<bool> {
-        Ok(self.try_symplectic_product(other)? == 1)
+        Ok(!self.try_commutes_with(other)?)
     }
 
     pub fn anticommutes_with(&self, other: &Self) -> bool {

--- a/qec-code/src/symplectic.rs
+++ b/qec-code/src/symplectic.rs
@@ -42,8 +42,81 @@ pub(crate) fn symplectic_product(lhs: &[u8], rhs: &[u8]) -> Result<u8> {
         .fold(0, |parity, (left, right)| parity ^ (*left & *right)))
 }
 
+pub(crate) fn add_assign(lhs: &mut [u8], rhs: &[u8]) -> Result<()> {
+    validate_row(lhs)?;
+    validate_row(rhs)?;
+
+    if lhs.len() != rhs.len() {
+        return Err(QecError::RowWidthMismatch {
+            expected: lhs.len(),
+            actual: rhs.len(),
+        });
+    }
+
+    for (left, right) in lhs.iter_mut().zip(rhs) {
+        *left ^= *right;
+    }
+
+    Ok(())
+}
+
 pub(crate) fn commutes(lhs: &[u8], rhs: &[u8]) -> Result<bool> {
     Ok(symplectic_product(lhs, rhs)? == 0)
+}
+
+pub(crate) fn symplectic_gram_schmidt(rows: &[BinaryRow]) -> Result<Vec<(BinaryRow, BinaryRow)>> {
+    let width = gf2::validate_rows(rows)?;
+    validate_symplectic_width(width)?;
+
+    let mut remaining = gf2::try_select_independent_rows(rows)?;
+    let mut pairs = Vec::new();
+
+    while !remaining.is_empty() {
+        let Some((first_index, second_index)) = find_anticommuting_pair(&remaining)? else {
+            break;
+        };
+
+        let first = remaining[first_index].clone();
+        let second = remaining[second_index].clone();
+        let mut next = Vec::new();
+
+        for (index, row) in remaining.into_iter().enumerate() {
+            if index == first_index || index == second_index {
+                continue;
+            }
+
+            let mut adjusted = row;
+            if symplectic_product(&adjusted, &second)? == 1 {
+                add_assign(&mut adjusted, &first)?;
+            }
+            if symplectic_product(&adjusted, &first)? == 1 {
+                add_assign(&mut adjusted, &second)?;
+            }
+            if adjusted.iter().all(|bit| *bit == 0) {
+                continue;
+            }
+            if !gf2::try_in_row_span_with_width(&next, width, &adjusted)? {
+                next.push(adjusted);
+            }
+        }
+
+        pairs.push((first, second));
+        remaining = next;
+    }
+
+    Ok(pairs)
+}
+
+fn find_anticommuting_pair(rows: &[BinaryRow]) -> Result<Option<(usize, usize)>> {
+    for first in 0..rows.len() {
+        for second in (first + 1)..rows.len() {
+            if symplectic_product(&rows[first], &rows[second])? == 1 {
+                return Ok(Some((first, second)));
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 #[allow(dead_code)]
@@ -67,8 +140,8 @@ mod tests {
     use crate::error::QecError;
 
     use super::{
-        commutation_constraints, commutation_constraints_with_width, commutes, dual_row,
-        symplectic_product,
+        add_assign, commutation_constraints, commutation_constraints_with_width, commutes,
+        dual_row, symplectic_gram_schmidt, symplectic_product,
     };
 
     fn dot(lhs: &[u8], rhs: &[u8]) -> u8 {
@@ -109,6 +182,51 @@ mod tests {
 
         assert_eq!(commutes(&lhs, &anticommutes), Ok(false));
         assert_eq!(commutes(&lhs, &commuting), Ok(true));
+    }
+
+    #[test]
+    fn add_assign_xors_binary_rows() {
+        let mut lhs = vec![1, 0, 0, 1];
+        add_assign(&mut lhs, &[1, 1, 0, 1]).unwrap();
+
+        assert_eq!(lhs, vec![0, 1, 0, 0]);
+    }
+
+    #[test]
+    fn add_assign_rejects_width_mismatch() {
+        let mut lhs = vec![1, 0, 0, 1];
+
+        assert_eq!(
+            add_assign(&mut lhs, &[1, 0]),
+            Err(QecError::RowWidthMismatch {
+                expected: 4,
+                actual: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn symplectic_gram_schmidt_returns_canonical_pairs_and_drops_dependents() {
+        let x1 = vec![1, 0, 0, 0];
+        let z1 = vec![0, 0, 1, 0];
+        let x2 = vec![0, 1, 0, 0];
+        let z2 = vec![0, 0, 0, 1];
+        let x1_plus_x2 = vec![1, 1, 0, 0];
+
+        let pairs = symplectic_gram_schmidt(&[x1, x2, z1, z2, x1_plus_x2]).unwrap();
+
+        assert_eq!(pairs.len(), 2);
+        for (index, (x_like, z_like)) in pairs.iter().enumerate() {
+            assert_eq!(
+                symplectic_product(x_like, z_like),
+                Ok(1),
+                "pair {index} should anticommute"
+            );
+        }
+        assert_eq!(symplectic_product(&pairs[0].0, &pairs[1].0), Ok(0));
+        assert_eq!(symplectic_product(&pairs[0].0, &pairs[1].1), Ok(0));
+        assert_eq!(symplectic_product(&pairs[0].1, &pairs[1].0), Ok(0));
+        assert_eq!(symplectic_product(&pairs[0].1, &pairs[1].1), Ok(0));
     }
 
     #[test]

--- a/qec-code/src/symplectic.rs
+++ b/qec-code/src/symplectic.rs
@@ -49,7 +49,16 @@ pub(crate) fn commutes(lhs: &[u8], rhs: &[u8]) -> Result<bool> {
 #[allow(dead_code)]
 pub(crate) fn commutation_constraints(rows: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
     let width = gf2::validate_rows(rows)?;
+    commutation_constraints_with_width(rows, width)
+}
+
+#[allow(dead_code)]
+pub(crate) fn commutation_constraints_with_width(
+    rows: &[BinaryRow],
+    width: usize,
+) -> Result<Vec<BinaryRow>> {
     validate_symplectic_width(width)?;
+    gf2::validate_rows_with_width(rows, width)?;
     rows.iter().map(|row| dual_row(row)).collect()
 }
 
@@ -57,7 +66,10 @@ pub(crate) fn commutation_constraints(rows: &[BinaryRow]) -> Result<Vec<BinaryRo
 mod tests {
     use crate::error::QecError;
 
-    use super::{commutation_constraints, commutes, dual_row, symplectic_product};
+    use super::{
+        commutation_constraints, commutation_constraints_with_width, commutes, dual_row,
+        symplectic_product,
+    };
 
     fn dot(lhs: &[u8], rhs: &[u8]) -> u8 {
         lhs.iter()
@@ -120,6 +132,30 @@ mod tests {
         assert_eq!(
             commutation_constraints(&[vec![1, 0, 1]]),
             Err(QecError::InvalidSymplecticRowWidth { width: 3 })
+        );
+    }
+
+    #[test]
+    fn commutation_constraints_with_width_accept_empty_rows_at_known_even_width() {
+        assert_eq!(commutation_constraints_with_width(&[], 4), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn commutation_constraints_with_width_reject_odd_width() {
+        assert_eq!(
+            commutation_constraints_with_width(&[], 3),
+            Err(QecError::InvalidSymplecticRowWidth { width: 3 })
+        );
+    }
+
+    #[test]
+    fn commutation_constraints_with_width_reject_row_width_mismatch() {
+        assert_eq!(
+            commutation_constraints_with_width(&[vec![1, 0]], 4),
+            Err(QecError::RowWidthMismatch {
+                expected: 4,
+                actual: 2,
+            })
         );
     }
 }

--- a/qec-code/src/symplectic.rs
+++ b/qec-code/src/symplectic.rs
@@ -1,0 +1,125 @@
+use crate::error::{QecError, Result};
+use crate::gf2::{self, BinaryRow};
+
+fn validate_symplectic_width(width: usize) -> Result<usize> {
+    if width % 2 != 0 {
+        return Err(QecError::InvalidSymplecticRowWidth { width });
+    }
+
+    Ok(width / 2)
+}
+
+fn validate_row(row: &[u8]) -> Result<usize> {
+    let qubits = validate_symplectic_width(row.len())?;
+    gf2::validate_target(row)?;
+    Ok(qubits)
+}
+
+pub(crate) fn dual_row(row: &[u8]) -> Result<BinaryRow> {
+    let qubits = validate_row(row)?;
+    let (x, z) = row.split_at(qubits);
+    let mut dual = Vec::with_capacity(row.len());
+    dual.extend_from_slice(z);
+    dual.extend_from_slice(x);
+    Ok(dual)
+}
+
+pub(crate) fn symplectic_product(lhs: &[u8], rhs: &[u8]) -> Result<u8> {
+    validate_row(lhs)?;
+    validate_row(rhs)?;
+
+    if lhs.len() != rhs.len() {
+        return Err(QecError::RowWidthMismatch {
+            expected: lhs.len(),
+            actual: rhs.len(),
+        });
+    }
+
+    let dual = dual_row(lhs)?;
+    Ok(dual
+        .iter()
+        .zip(rhs)
+        .fold(0, |parity, (left, right)| parity ^ (*left & *right)))
+}
+
+pub(crate) fn commutes(lhs: &[u8], rhs: &[u8]) -> Result<bool> {
+    Ok(symplectic_product(lhs, rhs)? == 0)
+}
+
+#[allow(dead_code)]
+pub(crate) fn commutation_constraints(rows: &[BinaryRow]) -> Result<Vec<BinaryRow>> {
+    let width = gf2::validate_rows(rows)?;
+    validate_symplectic_width(width)?;
+    rows.iter().map(|row| dual_row(row)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::QecError;
+
+    use super::{commutation_constraints, commutes, dual_row, symplectic_product};
+
+    fn dot(lhs: &[u8], rhs: &[u8]) -> u8 {
+        lhs.iter()
+            .zip(rhs)
+            .fold(0, |parity, (left, right)| parity ^ (*left & *right))
+    }
+
+    #[test]
+    fn dual_row_swaps_x_and_z_halves() {
+        assert_eq!(
+            dual_row(&[1, 0, 1, 0, 1, 1]).unwrap(),
+            vec![0, 1, 1, 1, 0, 1]
+        );
+    }
+
+    #[test]
+    fn dual_row_rejects_odd_width_rows() {
+        assert_eq!(
+            dual_row(&[1, 0, 1]),
+            Err(QecError::InvalidSymplecticRowWidth { width: 3 })
+        );
+    }
+
+    #[test]
+    fn symplectic_product_matches_standard_overlap_parity() {
+        let lhs = [1, 0, 1, 0, 1, 1];
+        let rhs = [0, 0, 0, 1, 1, 0];
+
+        assert_eq!(symplectic_product(&lhs, &rhs), Ok(1));
+    }
+
+    #[test]
+    fn commutes_reports_commutation_from_symplectic_product() {
+        let lhs = [1, 0, 1, 0, 1, 1];
+        let anticommutes = [0, 0, 0, 1, 1, 0];
+        let commuting = [1, 0, 0, 0, 1, 0];
+
+        assert_eq!(commutes(&lhs, &anticommutes), Ok(false));
+        assert_eq!(commutes(&lhs, &commuting), Ok(true));
+    }
+
+    #[test]
+    fn commutation_constraints_dualize_rows_for_linear_checks() {
+        let stabilizers = vec![vec![1, 0, 0, 0], vec![0, 0, 1, 0]];
+        let constraints = commutation_constraints(&stabilizers).unwrap();
+        let commuting_candidate = [0, 1, 0, 1];
+        let anticommutes = [0, 0, 1, 0];
+
+        assert_eq!(constraints, vec![vec![0, 0, 1, 0], vec![1, 0, 0, 0]]);
+        assert!(
+            constraints
+                .iter()
+                .all(|row| dot(row, &commuting_candidate) == 0)
+        );
+        assert_eq!(dot(&constraints[0], &anticommutes), 1);
+    }
+
+    #[test]
+    fn commutation_constraints_reject_odd_width_rows() {
+        assert_eq!(
+            commutation_constraints(&[vec![1, 0, 1]]),
+            Err(QecError::InvalidSymplecticRowWidth { width: 3 })
+        );
+    }
+}

--- a/qec-code/tests/binary.rs
+++ b/qec-code/tests/binary.rs
@@ -57,6 +57,40 @@ fn pauli_from_xz_bits_rejects_non_binary_values() {
 }
 
 #[test]
+fn pauli_symplectic_rows_round_trip_through_constructor() {
+    let row = vec![1, 0, 1, 0, 1, 1];
+    let pauli = Pauli::from_symplectic_row(row.clone()).unwrap();
+
+    assert_eq!(pauli.x_bits(), &[1, 0, 1]);
+    assert_eq!(pauli.z_bits(), &[0, 1, 1]);
+    assert_eq!(pauli.to_symplectic_row(), row);
+}
+
+#[test]
+fn pauli_from_symplectic_row_rejects_invalid_rows() {
+    assert_eq!(
+        Pauli::from_symplectic_row(vec![1, 0, 1]),
+        Err(QecError::InvalidSymplecticRowWidth { width: 3 })
+    );
+    assert_eq!(
+        Pauli::from_symplectic_row(vec![1, 2, 0, 1]),
+        Err(QecError::InvalidPauliBit {
+            which: "X",
+            index: 1,
+            value: 2,
+        })
+    );
+    assert_eq!(
+        Pauli::from_symplectic_row(vec![1, 0, 0, 3]),
+        Err(QecError::InvalidPauliBit {
+            which: "Z",
+            index: 1,
+            value: 3,
+        })
+    );
+}
+
+#[test]
 fn checked_binary_helpers_report_invalid_input_without_panicking() {
     assert_eq!(
         try_binary_rank(&[vec![1, 0], vec![1]]),

--- a/qec-code/tests/cli.rs
+++ b/qec-code/tests/cli.rs
@@ -66,4 +66,6 @@ fn steane_logicals_reports_logical_sections() {
 
     assert!(stdout.contains("logical_x:"), "stdout was: {stdout}");
     assert!(stdout.contains("logical_z:"), "stdout was: {stdout}");
+    assert!(stdout.contains("  1:"), "stdout was: {stdout}");
+    assert!(stdout.contains("weight="), "stdout was: {stdout}");
 }

--- a/qec-code/tests/logical_distance.rs
+++ b/qec-code/tests/logical_distance.rs
@@ -3,6 +3,18 @@ use qec_code::distance::compute_distance;
 use qec_code::logical::extract_logical_basis;
 use qec_code::{Pauli, QecError, StabilizerCode};
 
+fn pauli(n: usize, x_support: &[usize], z_support: &[usize]) -> Pauli {
+    let mut x = vec![0; n];
+    let mut z = vec![0; n];
+    for &qubit in x_support {
+        x[qubit] = 1;
+    }
+    for &qubit in z_support {
+        z[qubit] = 1;
+    }
+    Pauli::from_xz_bits(x, z).unwrap()
+}
+
 #[test]
 fn steane_logical_basis_contains_one_anticommuting_pair() {
     let steane = Steane::new().unwrap();
@@ -37,21 +49,30 @@ fn steane_distance_is_three_with_a_commuting_weight_three_witness() {
 }
 
 #[test]
-fn logical_basis_rejects_multi_logical_codes_until_supported() {
-    let code = StabilizerCode::from_stabilizers(2, vec![]).unwrap();
+fn logical_basis_supports_multi_logical_codes() {
+    let code = StabilizerCode::from_stabilizers(4, vec![pauli(4, &[], &[0]), pauli(4, &[], &[1])])
+        .unwrap();
 
-    assert_eq!(
-        extract_logical_basis(&code),
-        Err(QecError::UnsupportedLogicalBasis { k: 2 })
-    );
+    let basis = extract_logical_basis(&code).unwrap();
+
+    assert_eq!(basis.k, 2);
+    assert_eq!(basis.logical_x.len(), 2);
+    assert_eq!(basis.logical_z.len(), 2);
+    for index in 0..basis.k {
+        assert!(basis.logical_x[index].anticommutes_with(&basis.logical_z[index]));
+    }
+    for stabilizer in code.stabilizers() {
+        for logical in basis.logical_x.iter().chain(&basis.logical_z) {
+            assert!(logical.commutes_with(stabilizer));
+        }
+    }
 }
 
 #[test]
 fn logical_basis_for_zero_logical_qubits_is_empty() {
-    let code = StabilizerCode::from_stabilizers(1, vec![
-        Pauli::from_xz_bits(vec![1], vec![0]).unwrap(),
-    ])
-    .unwrap();
+    let code =
+        StabilizerCode::from_stabilizers(1, vec![Pauli::from_xz_bits(vec![1], vec![0]).unwrap()])
+            .unwrap();
 
     let basis = extract_logical_basis(&code).unwrap();
 
@@ -71,11 +92,14 @@ fn distance_returns_no_witness_for_zero_logical_qubit_code() {
     )
     .unwrap();
 
-    assert_eq!(compute_distance(&code), Err(QecError::DistanceWitnessNotFound));
+    assert_eq!(
+        compute_distance(&code),
+        Err(QecError::DistanceWitnessNotFound)
+    );
 }
 
 #[test]
-fn exhaustive_logical_and_distance_search_reject_large_codes_instead_of_panicking() {
+fn large_code_logical_basis_avoids_exhaustive_enumeration() {
     let stabilizers = (0..31)
         .map(|qubit| {
             let mut z = vec![0; 32];
@@ -85,10 +109,16 @@ fn exhaustive_logical_and_distance_search_reject_large_codes_instead_of_panickin
         .collect();
     let code = StabilizerCode::from_stabilizers(32, stabilizers).unwrap();
 
-    assert_eq!(
-        extract_logical_basis(&code),
-        Err(QecError::UnsupportedExhaustiveEnumeration { n: 32 })
-    );
+    let basis = extract_logical_basis(&code).unwrap();
+
+    assert_eq!(basis.k, 1);
+    assert_eq!(basis.logical_x.len(), 1);
+    assert_eq!(basis.logical_z.len(), 1);
+    assert!(basis.logical_x[0].anticommutes_with(&basis.logical_z[0]));
+    for stabilizer in code.stabilizers() {
+        assert!(basis.logical_x[0].commutes_with(stabilizer));
+        assert!(basis.logical_z[0].commutes_with(stabilizer));
+    }
     assert_eq!(
         compute_distance(&code),
         Err(QecError::UnsupportedExhaustiveEnumeration { n: 32 })

--- a/qec-code/tests/logical_general.rs
+++ b/qec-code/tests/logical_general.rs
@@ -23,6 +23,25 @@ fn logical_rows(code: &StabilizerCode) -> Vec<Vec<u8>> {
         .collect()
 }
 
+fn assert_canonical_commutation_matrix(basis: &qec_code::logical::LogicalBasis) {
+    for x_index in 0..basis.k {
+        for z_index in 0..basis.k {
+            if x_index == z_index {
+                assert!(basis.logical_x[x_index].anticommutes_with(&basis.logical_z[z_index]));
+            } else {
+                assert!(basis.logical_x[x_index].commutes_with(&basis.logical_z[z_index]));
+            }
+        }
+    }
+
+    for first in 0..basis.k {
+        for second in (first + 1)..basis.k {
+            assert!(basis.logical_x[first].commutes_with(&basis.logical_x[second]));
+            assert!(basis.logical_z[first].commutes_with(&basis.logical_z[second]));
+        }
+    }
+}
+
 #[test]
 fn trivial_k2_code_returns_two_canonical_logical_pairs() {
     let stabilizers = vec![pauli(4, &[], &[0]), pauli(4, &[], &[1])];
@@ -33,9 +52,7 @@ fn trivial_k2_code_returns_two_canonical_logical_pairs() {
     assert_eq!(basis.k, 2);
     assert_eq!(basis.logical_x.len(), 2);
     assert_eq!(basis.logical_z.len(), 2);
-    for index in 0..basis.k {
-        assert!(basis.logical_x[index].anticommutes_with(&basis.logical_z[index]));
-    }
+    assert_canonical_commutation_matrix(&basis);
 
     let mut rows = code.stabilizer_rows();
     rows.extend(logical_rows(&code));
@@ -52,9 +69,21 @@ fn non_css_k1_code_returns_commuting_anticommuting_logicals() {
     assert_eq!(basis.k, 1);
     assert_eq!(basis.logical_x.len(), 1);
     assert_eq!(basis.logical_z.len(), 1);
-    assert!(basis.logical_x[0].anticommutes_with(&basis.logical_z[0]));
+    assert_canonical_commutation_matrix(&basis);
     for stabilizer in code.stabilizers() {
         assert!(basis.logical_x[0].commutes_with(stabilizer));
         assert!(basis.logical_z[0].commutes_with(stabilizer));
     }
+}
+
+#[test]
+fn empty_stabilizer_code_returns_one_logical_pair_per_qubit() {
+    let code = StabilizerCode::from_stabilizers(2, vec![]).unwrap();
+
+    let basis = code.logical_basis().unwrap();
+
+    assert_eq!(basis.k, 2);
+    assert_eq!(basis.logical_x.len(), 2);
+    assert_eq!(basis.logical_z.len(), 2);
+    assert_canonical_commutation_matrix(&basis);
 }

--- a/qec-code/tests/logical_general.rs
+++ b/qec-code/tests/logical_general.rs
@@ -60,6 +60,21 @@ fn trivial_k2_code_returns_two_canonical_logical_pairs() {
 }
 
 #[test]
+fn canonical_pairs_commute_off_diagonal_for_k_two_codes() {
+    let stabilizers = vec![pauli(4, &[], &[0]), pauli(4, &[], &[1])];
+    let code = StabilizerCode::from_stabilizers(4, stabilizers).unwrap();
+    let basis = code.canonical_logical_basis().unwrap();
+
+    assert_eq!(basis.k, 2);
+    assert!(basis.logical_x[0].anticommutes_with(&basis.logical_z[0]));
+    assert!(basis.logical_x[1].anticommutes_with(&basis.logical_z[1]));
+    assert!(basis.logical_x[0].commutes_with(&basis.logical_z[1]));
+    assert!(basis.logical_x[1].commutes_with(&basis.logical_z[0]));
+    assert!(basis.logical_x[0].commutes_with(&basis.logical_x[1]));
+    assert!(basis.logical_z[0].commutes_with(&basis.logical_z[1]));
+}
+
+#[test]
 fn non_css_k1_code_returns_commuting_anticommuting_logicals() {
     let stabilizers = vec![pauli(2, &[0], &[0])];
     let code = StabilizerCode::from_stabilizers(2, stabilizers).unwrap();

--- a/qec-code/tests/logical_general.rs
+++ b/qec-code/tests/logical_general.rs
@@ -1,0 +1,60 @@
+use qec_code::binary::binary_rank;
+use qec_code::{Pauli, StabilizerCode};
+
+fn pauli(n: usize, x_support: &[usize], z_support: &[usize]) -> Pauli {
+    let mut x = vec![0; n];
+    let mut z = vec![0; n];
+    for &qubit in x_support {
+        x[qubit] = 1;
+    }
+    for &qubit in z_support {
+        z[qubit] = 1;
+    }
+    Pauli::from_xz_bits(x, z).unwrap()
+}
+
+fn logical_rows(code: &StabilizerCode) -> Vec<Vec<u8>> {
+    let basis = code.logical_basis().unwrap();
+    basis
+        .logical_x
+        .iter()
+        .chain(&basis.logical_z)
+        .map(Pauli::to_symplectic_row)
+        .collect()
+}
+
+#[test]
+fn trivial_k2_code_returns_two_canonical_logical_pairs() {
+    let stabilizers = vec![pauli(4, &[], &[0]), pauli(4, &[], &[1])];
+    let code = StabilizerCode::from_stabilizers(4, stabilizers).unwrap();
+
+    let basis = code.logical_basis().unwrap();
+
+    assert_eq!(basis.k, 2);
+    assert_eq!(basis.logical_x.len(), 2);
+    assert_eq!(basis.logical_z.len(), 2);
+    for index in 0..basis.k {
+        assert!(basis.logical_x[index].anticommutes_with(&basis.logical_z[index]));
+    }
+
+    let mut rows = code.stabilizer_rows();
+    rows.extend(logical_rows(&code));
+    assert_eq!(binary_rank(&rows), 6);
+}
+
+#[test]
+fn non_css_k1_code_returns_commuting_anticommuting_logicals() {
+    let stabilizers = vec![pauli(2, &[0], &[0])];
+    let code = StabilizerCode::from_stabilizers(2, stabilizers).unwrap();
+
+    let basis = code.canonical_logical_basis().unwrap();
+
+    assert_eq!(basis.k, 1);
+    assert_eq!(basis.logical_x.len(), 1);
+    assert_eq!(basis.logical_z.len(), 1);
+    assert!(basis.logical_x[0].anticommutes_with(&basis.logical_z[0]));
+    for stabilizer in code.stabilizers() {
+        assert!(basis.logical_x[0].commutes_with(stabilizer));
+        assert!(basis.logical_z[0].commutes_with(stabilizer));
+    }
+}

--- a/qec-code/tests/normalizer.rs
+++ b/qec-code/tests/normalizer.rs
@@ -1,0 +1,51 @@
+use qec_code::binary::in_row_span;
+use qec_code::codes::steane::Steane;
+use qec_code::{Pauli, StabilizerCode};
+
+fn trivial_k_two_code() -> StabilizerCode {
+    StabilizerCode::from_stabilizers(
+        4,
+        vec![
+            Pauli::from_xz_bits(vec![1, 1, 0, 0], vec![0, 0, 0, 0]).unwrap(),
+            Pauli::from_xz_bits(vec![0, 0, 0, 0], vec![1, 1, 0, 0]).unwrap(),
+        ],
+    )
+    .unwrap()
+}
+
+#[test]
+fn steane_normalizer_basis_has_expected_dimension() {
+    let steane = Steane::new().unwrap();
+    let basis = steane.code().normalizer_basis().unwrap();
+
+    assert_eq!(basis.len(), 8);
+    for operator in &basis {
+        for stabilizer in steane.code().stabilizers() {
+            assert!(operator.commutes_with(stabilizer));
+        }
+    }
+}
+
+#[test]
+fn stabilizers_lie_in_the_returned_normalizer_span() {
+    let code = trivial_k_two_code();
+    let basis_rows = code
+        .normalizer_basis()
+        .unwrap()
+        .into_iter()
+        .map(|pauli| pauli.to_symplectic_row())
+        .collect::<Vec<_>>();
+
+    for stabilizer in code.stabilizers() {
+        assert!(in_row_span(&basis_rows, &stabilizer.to_symplectic_row()));
+    }
+}
+
+#[test]
+fn empty_stabilizer_code_normalizer_has_full_symplectic_dimension() {
+    let code = StabilizerCode::from_stabilizers(2, vec![]).unwrap();
+    let basis = code.normalizer_basis().unwrap();
+
+    assert_eq!(basis.len(), 4);
+    assert!(basis.iter().all(|operator| operator.n() == 2));
+}

--- a/qec-code/tests/normalizer.rs
+++ b/qec-code/tests/normalizer.rs
@@ -47,6 +47,14 @@ fn stabilizers_lie_in_the_returned_normalizer_span() {
 }
 
 #[test]
+fn k_two_code_normalizer_dimension_matches_two_n_minus_r() {
+    let code = trivial_k_two_code();
+    let basis = code.normalizer_basis().unwrap();
+
+    assert_eq!(basis.len(), 6);
+}
+
+#[test]
 fn empty_stabilizer_code_normalizer_has_full_symplectic_dimension() {
     let code = StabilizerCode::from_stabilizers(2, vec![]).unwrap();
     let basis = code.normalizer_basis().unwrap();

--- a/qec-code/tests/normalizer.rs
+++ b/qec-code/tests/normalizer.rs
@@ -1,6 +1,6 @@
-use qec_code::binary::in_row_span;
+use qec_code::binary::{in_row_span, try_binary_rank};
 use qec_code::codes::steane::Steane;
-use qec_code::{Pauli, StabilizerCode};
+use qec_code::{Pauli, QecError, StabilizerCode};
 
 fn trivial_k_two_code() -> StabilizerCode {
     StabilizerCode::from_stabilizers(
@@ -17,8 +17,13 @@ fn trivial_k_two_code() -> StabilizerCode {
 fn steane_normalizer_basis_has_expected_dimension() {
     let steane = Steane::new().unwrap();
     let basis = steane.code().normalizer_basis().unwrap();
+    let basis_rows = basis
+        .iter()
+        .map(Pauli::to_symplectic_row)
+        .collect::<Vec<_>>();
 
     assert_eq!(basis.len(), 8);
+    assert_eq!(try_binary_rank(&basis_rows).unwrap(), basis.len());
     for operator in &basis {
         for stabilizer in steane.code().stabilizers() {
             assert!(operator.commutes_with(stabilizer));
@@ -45,7 +50,23 @@ fn stabilizers_lie_in_the_returned_normalizer_span() {
 fn empty_stabilizer_code_normalizer_has_full_symplectic_dimension() {
     let code = StabilizerCode::from_stabilizers(2, vec![]).unwrap();
     let basis = code.normalizer_basis().unwrap();
+    let basis_rows = basis
+        .iter()
+        .map(Pauli::to_symplectic_row)
+        .collect::<Vec<_>>();
 
     assert_eq!(basis.len(), 4);
+    assert_eq!(try_binary_rank(&basis_rows).unwrap(), basis.len());
     assert!(basis.iter().all(|operator| operator.n() == 2));
+}
+
+#[test]
+fn normalizer_basis_rejects_qubit_counts_that_overflow_symplectic_width() {
+    let n = usize::MAX / 2 + 1;
+    let code = StabilizerCode::from_stabilizers(n, vec![]).unwrap();
+
+    assert_eq!(
+        code.normalizer_basis(),
+        Err(QecError::UnsupportedExhaustiveEnumeration { n })
+    );
 }


### PR DESCRIPTION
## Summary
- Adds internal GF(2) and symplectic row-operation layers for binary rank/span/nullspace, commutation constraints, and canonical pairing.
- Exposes `StabilizerCode::normalizer_basis()`, `logical_basis()`, and `canonical_logical_basis()` with linear-algebra based logical extraction.
- Updates Steane CLI logical output and adds regression coverage for normalizer dimensions, k > 1 logical bases, non-CSS codes, empty stabilizer codes, and large-code logical extraction without exhaustive enumeration.

## Test Plan
- `cargo test -p qec-code -v`