### PR TITLE
[codex] Complete rsinter failure taxonomy

### DIFF
--- a/benchmarks/surface_decoder_compare/rust_bridge/src/run.rs
+++ b/benchmarks/surface_decoder_compare/rust_bridge/src/run.rs
@@ -76,9 +76,9 @@ fn run_native_decoder(
     decoder: &dyn Decoder,
 ) -> Result<BridgeResponse, String> {
     let compile_started = Instant::now();
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem)?;
     let compile_us = elapsed_us(compile_started);
-    let summary = decode_batches(&request, &dets, &obs, compiled.as_ref());
+    let summary = decode_batches(&request, &dets, &obs, compiled.as_ref())?;
 
     Ok(build_success_response(
         request.decoder,
@@ -126,7 +126,7 @@ fn decode_batches(
     dets: &[u8],
     obs: &[u8],
     decoder: &dyn CompiledDecoder,
-) -> DecodeSummary {
+) -> Result<DecodeSummary, String> {
     let det_bytes = bytes_per_shot(request.num_dets);
     let obs_bytes = bytes_per_shot(request.num_obs);
     let batch_size = request.batch_size.max(1);
@@ -149,7 +149,7 @@ fn decode_batches(
             shots_in_batch,
             request.num_dets,
             request.num_obs,
-        );
+        )?;
         total_decode_us += elapsed_us(decode_started);
 
         let batch_logical_errors = count_logical_errors(
@@ -162,11 +162,11 @@ fn decode_batches(
         shots_used += shots_in_batch;
     }
 
-    DecodeSummary {
+    Ok(DecodeSummary {
         shots_used,
         logical_errors,
         total_decode_us,
-    }
+    })
 }
 
 fn decode_rilpqec_batches(

--- a/benchmarks/surface_decoder_compare/rust_bridge/src/run.rs
+++ b/benchmarks/surface_decoder_compare/rust_bridge/src/run.rs
@@ -2,8 +2,10 @@ use std::fs;
 use std::time::Instant;
 
 use rbposd::DecoderConfig;
-use rilpqec::backend::{BatchBackend, build_batch_backend};
-use rilpqec::{BackendConfig, BackendKind, IlpDecoderConfig, LoweredDemProblem, lower_dem_to_problem};
+use rilpqec::backend::{build_batch_backend, BatchBackend};
+use rilpqec::{
+    lower_dem_to_problem, BackendConfig, BackendKind, IlpDecoderConfig, LoweredDemProblem,
+};
 use rsinter::decode::{CompiledDecoder, Decoder, RbposdDemDecoder, RmatchingDemDecoder};
 use rstim::dem::DetectorErrorModel;
 
@@ -242,12 +244,7 @@ fn decode_rilpqec_batches(
     })
 }
 
-fn count_logical_errors(
-    predictions: &[u8],
-    obs: &[u8],
-    num_shots: usize,
-    num_obs: usize,
-) -> usize {
+fn count_logical_errors(predictions: &[u8], obs: &[u8], num_shots: usize, num_obs: usize) -> usize {
     let obs_bytes = bytes_per_shot(num_obs);
     let mut logical_errors = 0usize;
 

--- a/docs/superpowers/plans/2026-06-14-rsinter-failure-taxonomy.md
+++ b/docs/superpowers/plans/2026-06-14-rsinter-failure-taxonomy.md
@@ -107,7 +107,7 @@ fn results_jsonl_infers_missing_failure_kind_from_legacy_rows() {
 Run:
 
 ```bash
-cargo test -p rsinter bench_result
+cargo test -p rsinter --test bench_result
 ```
 
 Expected: FAIL to compile because `rsinter::failure::FailureKind` and `BenchmarkResultRow.failure_kind` do not exist.
@@ -361,9 +361,9 @@ failure_kind: FailureKind::SolverFailure,
 Run:
 
 ```bash
-cargo test -p rsinter bench_result
-cargo test -p rsinter bench_merge
-cargo test -p rsinter bench_plot
+cargo test -p rsinter --test bench_result
+cargo test -p rsinter --test bench_merge
+cargo test -p rsinter --test bench_plot
 ```
 
 Expected: PASS.
@@ -452,7 +452,7 @@ fn task_stats_addition_keeps_strongest_failure_kind() {
 Run:
 
 ```bash
-cargo test -p rsinter csv_io
+cargo test -p rsinter --test csv_io
 ```
 
 Expected: FAIL to compile because `TaskStats.failure_kind` is missing.
@@ -641,7 +641,7 @@ use rsinter::failure::FailureKind;
 Run:
 
 ```bash
-cargo test -p rsinter csv_io
+cargo test -p rsinter --test csv_io
 cargo test -p rsinter collect_single_task_vacuous
 ```
 
@@ -961,10 +961,10 @@ to:
 Run:
 
 ```bash
-cargo test -p rsinter decode
-cargo test -p rsinter decode_ilp
-cargo test -p rsinter decode_rbposd
-cargo test -p rsinter decode_rmatching
+cargo test -p rsinter --test decode
+cargo test -p rsinter --test decode_ilp
+cargo test -p rsinter --test decode_rbposd
+cargo test -p rsinter --test decode_rmatching
 ```
 
 Expected: PASS.
@@ -1362,7 +1362,7 @@ Run:
 cargo test -p rsinter failure_kind_is_structured
 cargo test -p rsinter benchmark_runner_records_compile_failure_as_structured_row
 cargo test -p rsinter benchmark_runner_records_decode_failure_as_structured_row
-cargo test -p rsinter bench_runner_wrappers
+cargo test -p rsinter --test bench_runner_wrappers
 ```
 
 Expected: PASS.
@@ -1764,7 +1764,7 @@ fn make_task_stats(
 Run:
 
 ```bash
-cargo test -p rsinter collect
+cargo test -p rsinter --test collect
 ```
 
 Expected: PASS.
@@ -1888,9 +1888,9 @@ Run:
 
 ```bash
 cargo test -p rsinter failure_kind_is_structured
-cargo test -p rsinter bench_result
-cargo test -p rsinter csv_io
-cargo test -p rsinter collect
+cargo test -p rsinter --test bench_result
+cargo test -p rsinter --test csv_io
+cargo test -p rsinter --test collect
 cargo test -p rsinter rilpqec_gurobi_without_feature_records_unsupported_failure_kind
 ```
 

--- a/docs/superpowers/plans/2026-06-14-rsinter-failure-taxonomy.md
+++ b/docs/superpowers/plans/2026-06-14-rsinter-failure-taxonomy.md
@@ -1,0 +1,1961 @@
+# rsinter Failure Taxonomy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add structured `failure_kind` taxonomy to `rsinter` benchmark rows and collection stats so consumers can distinguish logical failures, timeouts, solver failures, unsupported backends, and sampler failures without string matching.
+
+**Architecture:** Introduce one shared `FailureKind` enum in `rsinter/src/failure.rs`, then thread it through JSONL benchmark rows, CSV-backed `TaskStats`, benchmark runner outcomes, and `collect`. Convert `rsinter` decoder traits from panic-oriented adapter calls to `Result` so backend failures can be recorded as structured rows instead of panics. Keep benchmark spec/preflight errors as whole-run `Err` results.
+
+**Tech Stack:** Rust 2024, Cargo workspace, `serde`, `csv`, `toml`, `rsinter` integration tests, existing `rstim` sampler and `rsinter::decode` traits.
+
+---
+
+## File Structure
+
+- Create `rsinter/src/failure.rs`: define `FailureKind`, string parsing/formatting, completed-run classification, error classification, and aggregate combination.
+- Modify `rsinter/src/lib.rs`: export the new `failure` module.
+- Modify `rsinter/src/bench/result.rs`: add `BenchmarkResultRow.failure_kind`, serialize as snake_case, and support legacy JSONL rows that omit the field.
+- Modify `rsinter/tests/bench_result.rs`: cover JSON round trip and legacy JSONL inference.
+- Modify `rsinter/src/task_stats.rs`: add `TaskStats.failure_kind` and combine it conservatively in `Add`.
+- Modify `rsinter/src/csv_io.rs`: write/read the `failure_kind` CSV column and read legacy CSV files without it.
+- Modify `rsinter/tests/csv_io.rs`: cover CSV round trip, legacy CSV inference, and `TaskStats::add` failure-kind priority.
+- Modify `rsinter/src/decode.rs`: change `Decoder` and `CompiledDecoder` methods to return `Result`.
+- Modify `rsinter/src/ilpqec_adapter.rs`, `rsinter/src/rmatching_adapter.rs`, and `rsinter/src/rbposd_adapter.rs`: return adapter errors instead of panicking for normal backend/decode failures.
+- Modify direct decoder tests in `rsinter/tests/decode.rs`, `rsinter/tests/decode_ilp.rs`, `rsinter/tests/decode_rbposd.rs`, `rsinter/tests/decode_rmatching.rs`, and `rsinter/tests/css_surface_special.rs`: unwrap explicit `Result` values.
+- Modify fake decoder implementations in `rsinter/tests/collect.rs` and `rsinter/src/bench/runners/mod.rs`: update trait signatures and add failure tests.
+- Modify `rsinter/src/bench/runners/mod.rs`: classify normal, timeout, decoder, and sampler outcomes into `BenchmarkResultRow.failure_kind`.
+- Modify `rsinter/tests/bench_runner_wrappers.rs` and `rsinter/tests/bench_run.rs`: assert structured benchmark output, including `rilpqec` unsupported Gurobi without the feature.
+- Modify `rsinter/src/collect.rs`: return per-task `TaskStats` for decoder/sampler failures while preserving global setup errors.
+
+---
+
+### Task 1: Add `FailureKind` And Benchmark JSONL Compatibility
+
+**Files:**
+- Create: `rsinter/src/failure.rs`
+- Modify: `rsinter/src/lib.rs`
+- Modify: `rsinter/src/bench/result.rs`
+- Modify: `rsinter/tests/bench_result.rs`
+- Modify: `rsinter/tests/bench_merge.rs`
+- Modify: `rsinter/tests/bench_plot.rs`
+
+- [ ] **Step 1: Write failing JSONL tests**
+
+In `rsinter/tests/bench_result.rs`, add this import:
+
+```rust
+use rsinter::failure::FailureKind;
+```
+
+Add this test after `result_row_serializes_round_trip_as_json`:
+
+```rust
+#[test]
+fn result_row_serializes_failure_kind_as_snake_case() {
+    let row = BenchmarkResultRow {
+        benchmark: "surface_decoder".into(),
+        runner: "rmatching".into(),
+        language: "rust".into(),
+        status: "ok".into(),
+        failure_kind: FailureKind::LogicalFailure,
+        params: ParamMap::from_pairs([("distance", serde_json::json!(3))]),
+        case_summary: CaseSummary::new(),
+        metrics: MetricMap::from_pairs([("logical_errors", 2.0)]),
+        artifacts: std::collections::BTreeMap::new(),
+        error: None,
+    };
+
+    let encoded = serde_json::to_string(&row).unwrap();
+    assert!(encoded.contains("\"failure_kind\":\"logical_failure\""));
+
+    let decoded: BenchmarkResultRow = serde_json::from_str(&encoded).unwrap();
+    assert_eq!(decoded.failure_kind, FailureKind::LogicalFailure);
+}
+```
+
+Add this test after `results_jsonl_ignores_blank_lines`:
+
+```rust
+#[test]
+fn results_jsonl_infers_missing_failure_kind_from_legacy_rows() {
+    let input = concat!(
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"clean\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{\"logical_errors\":0.0},",
+        "\"artifacts\":{},\"error\":null}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"logical\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{\"logical_errors\":3.0},",
+        "\"artifacts\":{},\"error\":null}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"solver\",\"language\":\"rust\",\"status\":\"error\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{},",
+        "\"artifacts\":{},\"error\":\"HiGHS backend error: solve failed\"}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"unsupported\",\"language\":\"rust\",\"status\":\"error\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{},",
+        "\"artifacts\":{},\"error\":\"no ILP backend is available for kind Gurobi\"}\n"
+    );
+
+    let rows = read_results_jsonl(input.as_bytes()).unwrap();
+
+    assert_eq!(rows[0].failure_kind, FailureKind::Ok);
+    assert_eq!(rows[1].failure_kind, FailureKind::LogicalFailure);
+    assert_eq!(rows[2].failure_kind, FailureKind::SolverFailure);
+    assert_eq!(rows[3].failure_kind, FailureKind::Unsupported);
+}
+```
+
+- [ ] **Step 2: Run the failing benchmark result tests**
+
+Run:
+
+```bash
+cargo test -p rsinter bench_result
+```
+
+Expected: FAIL to compile because `rsinter::failure::FailureKind` and `BenchmarkResultRow.failure_kind` do not exist.
+
+- [ ] **Step 3: Add the shared failure module**
+
+Create `rsinter/src/failure.rs` with this content:
+
+```rust
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKind {
+    Ok,
+    LogicalFailure,
+    Timeout,
+    SolverFailure,
+    Unsupported,
+    SamplerError,
+}
+
+impl Default for FailureKind {
+    fn default() -> Self {
+        Self::Ok
+    }
+}
+
+impl FailureKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::LogicalFailure => "logical_failure",
+            Self::Timeout => "timeout",
+            Self::SolverFailure => "solver_failure",
+            Self::Unsupported => "unsupported",
+            Self::SamplerError => "sampler_error",
+        }
+    }
+
+    pub fn status(self) -> &'static str {
+        match self {
+            Self::Ok | Self::LogicalFailure | Self::Timeout => "ok",
+            Self::SolverFailure | Self::Unsupported | Self::SamplerError => "error",
+        }
+    }
+}
+
+impl std::fmt::Display for FailureKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for FailureKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ok" => Ok(Self::Ok),
+            "logical_failure" => Ok(Self::LogicalFailure),
+            "timeout" => Ok(Self::Timeout),
+            "solver_failure" => Ok(Self::SolverFailure),
+            "unsupported" => Ok(Self::Unsupported),
+            "sampler_error" => Ok(Self::SamplerError),
+            other => Err(format!("unknown failure_kind: {other}")),
+        }
+    }
+}
+
+pub fn classify_completed(logical_errors: u64, timed_out: bool) -> FailureKind {
+    if timed_out {
+        FailureKind::Timeout
+    } else if logical_errors > 0 {
+        FailureKind::LogicalFailure
+    } else {
+        FailureKind::Ok
+    }
+}
+
+pub fn classify_error(message: &str, fallback: FailureKind) -> FailureKind {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("backendunavailable")
+        || lower.contains("backend unavailable")
+        || lower.contains("backend is unavailable")
+        || lower.contains("no ilp backend is available")
+        || lower.contains("unsupported")
+    {
+        FailureKind::Unsupported
+    } else {
+        fallback
+    }
+}
+
+pub fn combine_failure_kind(a: FailureKind, b: FailureKind) -> FailureKind {
+    if failure_priority(a) >= failure_priority(b) {
+        a
+    } else {
+        b
+    }
+}
+
+fn failure_priority(kind: FailureKind) -> u8 {
+    match kind {
+        FailureKind::Ok => 0,
+        FailureKind::LogicalFailure => 1,
+        FailureKind::Timeout => 2,
+        FailureKind::SamplerError => 3,
+        FailureKind::SolverFailure => 4,
+        FailureKind::Unsupported => 5,
+    }
+}
+```
+
+In `rsinter/src/lib.rs`, add:
+
+```rust
+pub mod failure;
+```
+
+- [ ] **Step 4: Add `failure_kind` to benchmark rows with legacy deserialization**
+
+In `rsinter/src/bench/result.rs`, add this import:
+
+```rust
+use crate::failure::{FailureKind, classify_error};
+```
+
+Replace the `BenchmarkResultRow` derive and struct with:
+
+```rust
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct BenchmarkResultRow {
+    pub benchmark: String,
+    pub runner: String,
+    pub language: String,
+    pub status: String,
+    pub failure_kind: FailureKind,
+    pub params: ParamMap,
+    pub case_summary: CaseSummary,
+    pub metrics: MetricMap,
+    pub artifacts: ArtifactMap,
+    pub error: Option<String>,
+}
+```
+
+Add this legacy helper and custom deserializer below the struct:
+
+```rust
+#[derive(Deserialize)]
+struct RawBenchmarkResultRow {
+    benchmark: String,
+    runner: String,
+    language: String,
+    status: String,
+    #[serde(default)]
+    failure_kind: Option<FailureKind>,
+    params: ParamMap,
+    case_summary: CaseSummary,
+    metrics: MetricMap,
+    artifacts: ArtifactMap,
+    error: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for BenchmarkResultRow {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawBenchmarkResultRow::deserialize(deserializer)?;
+        let failure_kind = raw.failure_kind.unwrap_or_else(|| {
+            infer_legacy_failure_kind(
+                &raw.status,
+                raw.error.as_deref(),
+                raw.metrics.get("logical_errors").copied(),
+            )
+        });
+        Ok(Self {
+            benchmark: raw.benchmark,
+            runner: raw.runner,
+            language: raw.language,
+            status: raw.status,
+            failure_kind,
+            params: raw.params,
+            case_summary: raw.case_summary,
+            metrics: raw.metrics,
+            artifacts: raw.artifacts,
+            error: raw.error,
+        })
+    }
+}
+
+fn infer_legacy_failure_kind(
+    status: &str,
+    error: Option<&str>,
+    logical_errors: Option<f64>,
+) -> FailureKind {
+    if status == "error" {
+        return error
+            .map(|message| classify_error(message, FailureKind::SolverFailure))
+            .unwrap_or(FailureKind::SolverFailure);
+    }
+    if logical_errors.unwrap_or(0.0) > 0.0 {
+        FailureKind::LogicalFailure
+    } else {
+        FailureKind::Ok
+    }
+}
+```
+
+- [ ] **Step 5: Update existing benchmark row literals**
+
+Add `failure_kind` to every `BenchmarkResultRow` literal in these files:
+
+```text
+rsinter/tests/bench_result.rs
+rsinter/tests/bench_merge.rs
+rsinter/tests/bench_plot.rs
+```
+
+Use `FailureKind::Ok` for rows with `status: "ok".into()` and no logical errors. Use `FailureKind::LogicalFailure` for rows with `status: "ok".into()` and `logical_errors > 0.0`. Use `FailureKind::SolverFailure` for rows with `status: "error".into()`.
+
+In each file that constructs rows, add:
+
+```rust
+use rsinter::failure::FailureKind;
+```
+
+For an ok row, insert:
+
+```rust
+failure_kind: FailureKind::Ok,
+```
+
+For an ok row with a positive `logical_errors` metric, insert:
+
+```rust
+failure_kind: FailureKind::LogicalFailure,
+```
+
+For the existing error row in `rsinter/tests/bench_result.rs` and `rsinter/tests/bench_plot.rs`, insert:
+
+```rust
+failure_kind: FailureKind::SolverFailure,
+```
+
+- [ ] **Step 6: Run benchmark result and plot fixture tests**
+
+Run:
+
+```bash
+cargo test -p rsinter bench_result
+cargo test -p rsinter bench_merge
+cargo test -p rsinter bench_plot
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add rsinter/src/failure.rs rsinter/src/lib.rs rsinter/src/bench/result.rs rsinter/tests/bench_result.rs rsinter/tests/bench_merge.rs rsinter/tests/bench_plot.rs
+git commit -m "feat: add rsinter failure kind model"
+```
+
+---
+
+### Task 2: Add `TaskStats.failure_kind` And CSV Compatibility
+
+**Files:**
+- Modify: `rsinter/src/task_stats.rs`
+- Modify: `rsinter/src/csv_io.rs`
+- Modify: `rsinter/tests/csv_io.rs`
+- Modify: `rsinter/src/collect.rs`
+- Modify: `rsinter/tests/collect.rs`
+- Modify: `rsinter/tests/decode_ilp.rs`
+
+- [ ] **Step 1: Write failing CSV tests**
+
+In `rsinter/tests/csv_io.rs`, add:
+
+```rust
+use rsinter::failure::FailureKind;
+```
+
+Update `sample_stats()` to include:
+
+```rust
+failure_kind: FailureKind::Ok,
+```
+
+In `csv_roundtrip`, add:
+
+```rust
+assert_eq!(recovered[0].failure_kind, FailureKind::Ok);
+```
+
+Append these tests:
+
+```rust
+#[test]
+fn csv_reads_legacy_rows_without_failure_kind() {
+    let input = concat!(
+        "shots,errors,discards,seconds,decoder,strong_id,json_metadata,custom_counts\n",
+        "100,0,0,1.0000,vacuous,clean,\"{\"\"d\"\":3}\",\"{}\"\n",
+        "100,4,0,1.0000,vacuous,logical,\"{\"\"d\"\":3}\",\"{}\"\n"
+    );
+
+    let recovered = read_csv(input.as_bytes()).unwrap();
+
+    assert_eq!(recovered[0].failure_kind, FailureKind::Ok);
+    assert_eq!(recovered[1].failure_kind, FailureKind::LogicalFailure);
+}
+
+#[test]
+fn task_stats_addition_keeps_strongest_failure_kind() {
+    let a = TaskStats {
+        failure_kind: FailureKind::LogicalFailure,
+        ..sample_stats()
+    };
+    let b = TaskStats {
+        shots: 500,
+        errors: 0,
+        seconds: 0.5,
+        failure_kind: FailureKind::Timeout,
+        ..sample_stats()
+    };
+
+    let c = a + b;
+
+    assert_eq!(c.failure_kind, FailureKind::Timeout);
+    assert_eq!(c.shots, 1500);
+}
+```
+
+- [ ] **Step 2: Run the failing CSV tests**
+
+Run:
+
+```bash
+cargo test -p rsinter csv_io
+```
+
+Expected: FAIL to compile because `TaskStats.failure_kind` is missing.
+
+- [ ] **Step 3: Add `failure_kind` to `TaskStats`**
+
+In `rsinter/src/task_stats.rs`, add imports:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::ops::Add;
+
+use crate::failure::{FailureKind, combine_failure_kind};
+```
+
+Replace the struct with:
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TaskStats {
+    pub strong_id: String,
+    pub decoder: String,
+    pub metadata: serde_json::Value,
+    pub shots: u64,
+    pub errors: u64,
+    pub discards: u64,
+    pub seconds: f64,
+    #[serde(default)]
+    pub failure_kind: FailureKind,
+    pub custom_counts: HashMap<String, u64>,
+}
+```
+
+In `impl Add for TaskStats`, include:
+
+```rust
+failure_kind: combine_failure_kind(self.failure_kind, rhs.failure_kind),
+```
+
+The returned `TaskStats` block should contain:
+
+```rust
+TaskStats {
+    strong_id: self.strong_id,
+    decoder: self.decoder,
+    metadata: self.metadata,
+    shots: self.shots + rhs.shots,
+    errors: self.errors + rhs.errors,
+    discards: self.discards + rhs.discards,
+    seconds: self.seconds + rhs.seconds,
+    failure_kind: combine_failure_kind(self.failure_kind, rhs.failure_kind),
+    custom_counts: counts,
+}
+```
+
+- [ ] **Step 4: Write and read the CSV column by header name**
+
+In `rsinter/src/csv_io.rs`, add:
+
+```rust
+use crate::failure::{FailureKind, classify_completed};
+```
+
+Replace `write_csv` with:
+
+```rust
+pub fn write_csv(stats: &[TaskStats], out: &mut dyn Write) -> Result<(), String> {
+    let mut wtr = csv::Writer::from_writer(out);
+    wtr.write_record(&[
+        "shots",
+        "errors",
+        "discards",
+        "seconds",
+        "failure_kind",
+        "decoder",
+        "strong_id",
+        "json_metadata",
+        "custom_counts",
+    ])
+    .map_err(|e| e.to_string())?;
+    for s in stats {
+        wtr.write_record(&[
+            s.shots.to_string(),
+            s.errors.to_string(),
+            s.discards.to_string(),
+            format!("{:.4}", s.seconds),
+            s.failure_kind.to_string(),
+            s.decoder.clone(),
+            s.strong_id.clone(),
+            serde_json::to_string(&s.metadata).unwrap_or_default(),
+            serde_json::to_string(&s.custom_counts).unwrap_or_default(),
+        ])
+        .map_err(|e| e.to_string())?;
+    }
+    wtr.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+```
+
+Replace `read_csv` with:
+
+```rust
+pub fn read_csv(data: &[u8]) -> Result<Vec<TaskStats>, String> {
+    let mut rdr = csv::Reader::from_reader(data);
+    let headers = rdr.headers().map_err(|e| e.to_string())?.clone();
+    let idx = |name: &str| -> Result<usize, String> {
+        headers
+            .iter()
+            .position(|header| header == name)
+            .ok_or_else(|| format!("missing CSV column: {name}"))
+    };
+    let shots_idx = idx("shots")?;
+    let errors_idx = idx("errors")?;
+    let discards_idx = idx("discards")?;
+    let seconds_idx = idx("seconds")?;
+    let decoder_idx = idx("decoder")?;
+    let strong_id_idx = idx("strong_id")?;
+    let metadata_idx = idx("json_metadata")?;
+    let custom_counts_idx = idx("custom_counts")?;
+    let failure_kind_idx = headers
+        .iter()
+        .position(|header| header == "failure_kind");
+
+    let mut results = Vec::new();
+    for record in rdr.records() {
+        let r = record.map_err(|e| e.to_string())?;
+        let get = |index: usize, name: &str| -> Result<&str, String> {
+            r.get(index)
+                .ok_or_else(|| format!("missing CSV value for column: {name}"))
+        };
+        let errors = get(errors_idx, "errors")?
+            .parse()
+            .map_err(|e: std::num::ParseIntError| e.to_string())?;
+        let failure_kind = match failure_kind_idx {
+            Some(index) => get(index, "failure_kind")?.parse::<FailureKind>()?,
+            None => classify_completed(errors, false),
+        };
+        results.push(TaskStats {
+            shots: get(shots_idx, "shots")?
+                .parse()
+                .map_err(|e: std::num::ParseIntError| e.to_string())?,
+            errors,
+            discards: get(discards_idx, "discards")?
+                .parse()
+                .map_err(|e: std::num::ParseIntError| e.to_string())?,
+            seconds: get(seconds_idx, "seconds")?
+                .parse()
+                .map_err(|e: std::num::ParseFloatError| e.to_string())?,
+            failure_kind,
+            decoder: get(decoder_idx, "decoder")?.to_string(),
+            strong_id: get(strong_id_idx, "strong_id")?.to_string(),
+            metadata: serde_json::from_str(get(metadata_idx, "json_metadata")?)
+                .unwrap_or(serde_json::Value::Null),
+            custom_counts: serde_json::from_str(get(custom_counts_idx, "custom_counts")?)
+                .unwrap_or_default(),
+        });
+    }
+    Ok(results)
+}
+```
+
+- [ ] **Step 5: Update existing `TaskStats` literals**
+
+Add `failure_kind: FailureKind::Ok` to direct `TaskStats` literals in:
+
+```text
+rsinter/tests/csv_io.rs
+rsinter/src/collect.rs
+```
+
+Add these imports where needed:
+
+```rust
+use crate::failure::{FailureKind, classify_completed};
+```
+
+or in tests:
+
+```rust
+use rsinter::failure::FailureKind;
+```
+
+- [ ] **Step 6: Run CSV and current collect tests**
+
+Run:
+
+```bash
+cargo test -p rsinter csv_io
+cargo test -p rsinter collect_single_task_vacuous
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run:
+
+```bash
+git add rsinter/src/task_stats.rs rsinter/src/csv_io.rs rsinter/tests/csv_io.rs rsinter/src/collect.rs rsinter/tests/collect.rs rsinter/tests/decode_ilp.rs
+git commit -m "feat: record failure kind in task stats"
+```
+
+---
+
+### Task 3: Convert Decoder Traits To Explicit `Result`
+
+**Files:**
+- Modify: `rsinter/src/decode.rs`
+- Modify: `rsinter/src/ilpqec_adapter.rs`
+- Modify: `rsinter/src/rmatching_adapter.rs`
+- Modify: `rsinter/src/rbposd_adapter.rs`
+- Modify: `rsinter/tests/decode.rs`
+- Modify: `rsinter/tests/decode_ilp.rs`
+- Modify: `rsinter/tests/decode_rbposd.rs`
+- Modify: `rsinter/tests/decode_rmatching.rs`
+- Modify: `rsinter/tests/css_surface_special.rs`
+- Modify: `rsinter/tests/collect.rs`
+- Modify: `rsinter/src/bench/runners/mod.rs`
+
+- [ ] **Step 1: Write a failing `rilpqec` backend-unavailable test**
+
+In `rsinter/tests/decode_ilp.rs`, replace the conditional import with an unconditional one:
+
+```rust
+use rilpqec::{BackendConfig, BackendKind, IlpDecoderConfig};
+```
+
+Append this test:
+
+```rust
+#[cfg(not(feature = "gurobi"))]
+#[test]
+fn ilp_dem_decoder_reports_unavailable_gurobi_backend() {
+    let dem = DetectorErrorModel::parse("error(0.125) D0 L0\n").unwrap();
+    let decoder = RsinterIlpDemDecoder::new(IlpDecoderConfig {
+        backend: BackendConfig {
+            kind: BackendKind::Gurobi,
+            time_limit_seconds: None,
+            mip_gap: None,
+            threads: Some(1),
+            verbose: false,
+        },
+    });
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
+
+    let err = compiled
+        .decode_shots_bit_packed(&[0b0000_0001], 1, 1, 1)
+        .unwrap_err();
+
+    assert!(
+        err.contains("no ILP backend is available"),
+        "error was: {err}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the failing ILP test**
+
+Run:
+
+```bash
+cargo test -p rsinter ilp_dem_decoder_reports_unavailable_gurobi_backend
+```
+
+Expected: FAIL to compile because decoder methods do not return `Result`.
+
+- [ ] **Step 3: Change trait signatures and the vacuous decoder**
+
+In `rsinter/src/decode.rs`, replace the traits and vacuous impls with:
+
+```rust
+pub trait CompiledDecoder: Send {
+    /// Decode bit-packed detection events into bit-packed observable predictions.
+    /// `dets`: `num_shots * ceil(num_dets/8)` bytes, b8 format.
+    /// Returns: `num_shots * ceil(num_obs/8)` bytes, b8 format.
+    fn decode_shots_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Result<Vec<u8>, String>;
+}
+
+pub trait Decoder: Send + Sync {
+    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String>;
+}
+```
+
+Update `VacuousCompiled`:
+
+```rust
+impl CompiledDecoder for VacuousCompiled {
+    fn decode_shots_bit_packed(
+        &self,
+        _dets: &[u8],
+        num_shots: usize,
+        _num_dets: usize,
+        num_obs: usize,
+    ) -> Result<Vec<u8>, String> {
+        let obs_bytes = (num_obs + 7) / 8;
+        Ok(vec![0u8; num_shots * obs_bytes])
+    }
+}
+
+impl Decoder for VacuousDecoder {
+    fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String> {
+        Ok(Box::new(VacuousCompiled))
+    }
+}
+```
+
+- [ ] **Step 4: Return `Result` from real adapters**
+
+In `rsinter/src/ilpqec_adapter.rs`, update compile and decode:
+
+```rust
+impl Decoder for IlpDemDecoder {
+    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String> {
+        let decoder = rilpqec::IlpDemDecoder::from_dem(dem, self.config.clone())
+            .map_err(|error| error.to_string())?;
+        Ok(Box::new(CompiledIlpDemDecoder { decoder }))
+    }
+}
+
+impl CompiledDecoder for CompiledIlpDemDecoder {
+    fn decode_shots_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Result<Vec<u8>, String> {
+        self.decoder
+            .decode_batch_bit_packed(dets, num_shots, num_dets, num_obs)
+            .map_err(|error| error.to_string())
+    }
+}
+```
+
+In `rsinter/src/rmatching_adapter.rs`, update compile and decode:
+
+```rust
+impl Decoder for RmatchingDemDecoder {
+    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String> {
+        let matching = Matching::from_dem(&dem.to_string()).map_err(|error| error.to_string())?;
+        Ok(Box::new(CompiledRmatchingDemDecoder {
+            matching: Mutex::new(matching),
+        }))
+    }
+}
+
+impl CompiledDecoder for CompiledRmatchingDemDecoder {
+    fn decode_shots_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Result<Vec<u8>, String> {
+        Ok(self
+            .matching
+            .lock()
+            .map_err(|error| error.to_string())?
+            .decode_shots_bit_packed(dets, num_shots, num_dets, num_obs))
+    }
+}
+```
+
+In `rsinter/src/rbposd_adapter.rs`, change `compile_for_dem` to return `Result` and replace the two compile-time `expect` calls with `map_err`:
+
+```rust
+let pcm = ParityCheckMatrix::from_sparse_columns(
+    num_dets,
+    filtered_detector_columns.len(),
+    filtered_detector_columns,
+)
+.map_err(|error| format!("invalid rbposd parity matrix: {error}"))?;
+
+Some(
+    BpOsdDecoder::new(
+        pcm,
+        ChannelModel::BitFlipProbabilities(filtered_probabilities),
+        self.config.clone(),
+    )
+    .map_err(|error| format!("failed to compile rbposd decoder: {error}"))?,
+)
+```
+
+Return the boxed compiled decoder with:
+
+```rust
+Ok(Box::new(CompiledRbposdDemDecoder {
+    decoder,
+    num_dets,
+    num_obs,
+    observable_columns: filtered_observable_columns,
+    forced_syndrome,
+    baseline_observables,
+}))
+```
+
+In `CompiledRbposdDemDecoder::decode_shots_bit_packed`, change the return type to `Result<Vec<u8>, String>`, replace `expect("rbposd decode failed")` with:
+
+```rust
+let result = decoder
+    .decode(&Syndrome::from(syndrome_bits))
+    .map_err(|error| format!("rbposd decode failed: {error}"))?;
+```
+
+and return:
+
+```rust
+Ok(out)
+```
+
+- [ ] **Step 5: Update all direct decoder calls**
+
+Apply these mechanical changes in the listed files:
+
+```text
+rsinter/tests/decode.rs
+rsinter/tests/decode_ilp.rs
+rsinter/tests/decode_rbposd.rs
+rsinter/tests/decode_rmatching.rs
+rsinter/tests/css_surface_special.rs
+```
+
+Change:
+
+```rust
+let compiled = decoder.compile_for_dem(&dem);
+```
+
+to:
+
+```rust
+let compiled = decoder.compile_for_dem(&dem).unwrap();
+```
+
+Change direct decode calls used as values:
+
+```rust
+let predictions = compiled.decode_shots_bit_packed(&dets, shots, num_dets, num_obs);
+```
+
+to:
+
+```rust
+let predictions = compiled
+    .decode_shots_bit_packed(&dets, shots, num_dets, num_obs)
+    .unwrap();
+```
+
+For indexed inline calls in `rsinter/tests/decode_rbposd.rs`, change:
+
+```rust
+let predicted = compiled.decode_shots_bit_packed(&[det_byte], 1, 2, 1)[0] & 1 != 0;
+```
+
+to:
+
+```rust
+let predicted = compiled
+    .decode_shots_bit_packed(&[det_byte], 1, 2, 1)
+    .unwrap()[0]
+    & 1
+    != 0;
+```
+
+- [ ] **Step 6: Update fake decoder impl signatures**
+
+In `rsinter/tests/collect.rs` and `rsinter/src/bench/runners/mod.rs`, update fake decoder impls from:
+
+```rust
+fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder>
+```
+
+to:
+
+```rust
+fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String>
+```
+
+and wrap boxed return values in `Ok(...)`.
+
+Update fake `decode_shots_bit_packed` methods from:
+
+```rust
+) -> Vec<u8> {
+    vec![0u8; num_shots * obs_bytes]
+}
+```
+
+to:
+
+```rust
+) -> Result<Vec<u8>, String> {
+    Ok(vec![0u8; num_shots * obs_bytes])
+}
+```
+
+- [ ] **Step 7: Run decoder tests**
+
+Run:
+
+```bash
+cargo test -p rsinter decode
+cargo test -p rsinter decode_ilp
+cargo test -p rsinter decode_rbposd
+cargo test -p rsinter decode_rmatching
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 3**
+
+Run:
+
+```bash
+git add rsinter/src/decode.rs rsinter/src/ilpqec_adapter.rs rsinter/src/rmatching_adapter.rs rsinter/src/rbposd_adapter.rs rsinter/tests/decode.rs rsinter/tests/decode_ilp.rs rsinter/tests/decode_rbposd.rs rsinter/tests/decode_rmatching.rs rsinter/tests/css_surface_special.rs rsinter/tests/collect.rs rsinter/src/bench/runners/mod.rs
+git commit -m "refactor: return decoder failures explicitly"
+```
+
+---
+
+### Task 4: Classify Benchmark Runner Outcomes
+
+**Files:**
+- Modify: `rsinter/src/bench/runners/mod.rs`
+- Modify: `rsinter/src/bench/runners/rmatching.rs`
+- Modify: `rsinter/src/bench/runners/rbposd.rs`
+- Modify: `rsinter/src/bench/runners/rilpqec.rs`
+- Modify: `rsinter/tests/bench_runner_wrappers.rs`
+
+- [ ] **Step 1: Write failing structured failure tests**
+
+In the test module in `rsinter/src/bench/runners/mod.rs`, add:
+
+```rust
+use crate::failure::FailureKind;
+```
+
+Add these fake decoders in the same test module:
+
+```rust
+struct OnePredictionDecoder;
+
+struct OnePredictionCompiled;
+
+impl Decoder for OnePredictionDecoder {
+    fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String> {
+        Ok(Box::new(OnePredictionCompiled))
+    }
+}
+
+impl CompiledDecoder for OnePredictionCompiled {
+    fn decode_shots_bit_packed(
+        &self,
+        _dets: &[u8],
+        num_shots: usize,
+        _num_dets: usize,
+        num_obs: usize,
+    ) -> Result<Vec<u8>, String> {
+        let obs_bytes = num_obs.div_ceil(8);
+        Ok(vec![0xffu8; num_shots * obs_bytes])
+    }
+}
+
+struct CompileErrorDecoder {
+    message: &'static str,
+}
+
+impl Decoder for CompileErrorDecoder {
+    fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String> {
+        Err(self.message.to_string())
+    }
+}
+
+struct DecodeErrorDecoder {
+    message: &'static str,
+}
+
+struct DecodeErrorCompiled {
+    message: &'static str,
+}
+
+impl Decoder for DecodeErrorDecoder {
+    fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String> {
+        Ok(Box::new(DecodeErrorCompiled {
+            message: self.message,
+        }))
+    }
+}
+
+impl CompiledDecoder for DecodeErrorCompiled {
+    fn decode_shots_bit_packed(
+        &self,
+        _dets: &[u8],
+        _num_shots: usize,
+        _num_dets: usize,
+        _num_obs: usize,
+    ) -> Result<Vec<u8>, String> {
+        Err(self.message.to_string())
+    }
+}
+```
+
+Add this helper:
+
+```rust
+fn surface_point(p: f64, max_shots: u64, max_errors: u64) -> BenchCasePoint {
+    BenchCasePoint {
+        input_type: "surface_rotated_memory_x".into(),
+        code_id: None,
+        distance: Some(3),
+        rounds: 3,
+        p,
+        basis: None,
+        schedule: None,
+        hx_path: None,
+        hz_path: None,
+        observables_path: None,
+        max_shots,
+        max_errors,
+        max_wall_seconds: None,
+        batch_size: 1,
+        decoder_params: BTreeMap::new(),
+    }
+}
+```
+
+Add these tests:
+
+```rust
+#[test]
+fn failure_kind_is_structured_for_completed_benchmark_rows() {
+    let ctx = BenchRunContext {
+        benchmark_name: "surface_decoder".into(),
+        runner_name: "fake".into(),
+        language: "rust".into(),
+        seed: 12_345,
+        spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+    };
+    let decoder_params = crate::bench::result::ParamMap::new();
+
+    let ok_row = run_decoder_point(
+        "fake",
+        &SlowPredictionDecoder {
+            sleep: Duration::from_millis(0),
+        },
+        &surface_point(0.0, 2, 10),
+        &ctx,
+        &decoder_params,
+    )
+    .unwrap();
+    assert_eq!(ok_row.failure_kind, FailureKind::Ok);
+
+    let logical_row = run_decoder_point(
+        "fake",
+        &OnePredictionDecoder,
+        &surface_point(0.0, 2, 10),
+        &ctx,
+        &decoder_params,
+    )
+    .unwrap();
+    assert_eq!(logical_row.failure_kind, FailureKind::LogicalFailure);
+
+    let mut timeout_point = surface_point(0.0, 20, 20);
+    timeout_point.max_wall_seconds = Some(0.09);
+    let timeout_row = run_decoder_point(
+        "fake",
+        &SlowPredictionDecoder {
+            sleep: Duration::from_millis(35),
+        },
+        &timeout_point,
+        &ctx,
+        &decoder_params,
+    )
+    .unwrap();
+    assert_eq!(timeout_row.failure_kind, FailureKind::Timeout);
+}
+
+#[test]
+fn benchmark_runner_records_compile_failure_as_structured_row() {
+    let ctx = BenchRunContext {
+        benchmark_name: "surface_decoder".into(),
+        runner_name: "fake".into(),
+        language: "rust".into(),
+        seed: 12_345,
+        spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+    };
+    let decoder_params = crate::bench::result::ParamMap::new();
+
+    let row = run_decoder_point(
+        "fake",
+        &CompileErrorDecoder {
+            message: "no ILP backend is available for kind Gurobi",
+        },
+        &surface_point(0.002, 1, 1),
+        &ctx,
+        &decoder_params,
+    )
+    .unwrap();
+
+    assert_eq!(row.status, "error");
+    assert_eq!(row.failure_kind, FailureKind::Unsupported);
+    assert!(row.error.unwrap().contains("no ILP backend is available"));
+}
+
+#[test]
+fn benchmark_runner_records_decode_failure_as_structured_row() {
+    let ctx = BenchRunContext {
+        benchmark_name: "surface_decoder".into(),
+        runner_name: "fake".into(),
+        language: "rust".into(),
+        seed: 12_345,
+        spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+    };
+    let decoder_params = crate::bench::result::ParamMap::new();
+
+    let row = run_decoder_point(
+        "fake",
+        &DecodeErrorDecoder {
+            message: "HiGHS backend error: solve failed",
+        },
+        &surface_point(0.002, 1, 1),
+        &ctx,
+        &decoder_params,
+    )
+    .unwrap();
+
+    assert_eq!(row.status, "error");
+    assert_eq!(row.failure_kind, FailureKind::SolverFailure);
+    assert!(row.error.unwrap().contains("HiGHS backend error"));
+}
+```
+
+- [ ] **Step 2: Run the failing runner tests**
+
+Run:
+
+```bash
+cargo test -p rsinter failure_kind_is_structured
+cargo test -p rsinter benchmark_runner_records_compile_failure_as_structured_row
+cargo test -p rsinter benchmark_runner_records_decode_failure_as_structured_row
+```
+
+Expected: FAIL because `run_decoder_point` still propagates decoder errors and completed rows do not set `failure_kind`.
+
+- [ ] **Step 3: Classify completed and failed benchmark rows**
+
+In `rsinter/src/bench/runners/mod.rs`, add imports:
+
+```rust
+use crate::failure::{FailureKind, classify_completed, classify_error};
+```
+
+Add this helper near `under_wall_budget`:
+
+```rust
+fn make_result_row(
+    ctx: &BenchRunContext,
+    result_params: crate::bench::result::ParamMap,
+    case_summary: crate::bench::result::CaseSummary,
+    metrics: MetricMap,
+    failure_kind: FailureKind,
+    error: Option<String>,
+) -> BenchmarkResultRow {
+    BenchmarkResultRow {
+        benchmark: ctx.benchmark_name.clone(),
+        runner: ctx.runner_name.clone(),
+        language: ctx.language.clone(),
+        status: failure_kind.status().into(),
+        failure_kind,
+        params: result_params,
+        case_summary,
+        metrics,
+        artifacts: BTreeMap::new(),
+        error,
+    }
+}
+```
+
+In `run_decoder_point`, after building the circuit and DEM, change compile to:
+
+```rust
+let compiled = match decoder.compile_for_dem(&dem) {
+    Ok(compiled) => compiled,
+    Err(error) => {
+        let mut result_params = built.params.clone();
+        for (key, value) in decoder_params {
+            result_params.insert(key.clone(), value.clone());
+        }
+        let mut summary = built.case_summary.clone();
+        summary.insert("num_dets".into(), serde_json::json!(dem.effective_num_detectors()));
+        summary.insert("num_obs".into(), serde_json::json!(dem.num_observables()));
+        summary.insert("num_shots_generated".into(), serde_json::json!(0));
+        return Ok(make_result_row(
+            ctx,
+            result_params,
+            summary,
+            MetricMap::from_pairs([
+                ("shots_used", 0.0),
+                ("logical_errors", 0.0),
+                ("logical_error_rate", 0.0),
+                ("compile_us", compile_us),
+                ("total_decode_us", 0.0),
+                ("wall_seconds", 0.0),
+                ("decode_us_per_shot", 0.0),
+            ]),
+            classify_error(&error, FailureKind::SolverFailure),
+            Some(error),
+        ));
+    }
+};
+```
+
+In the decode loop, change decode to:
+
+```rust
+let predictions = match compiled.decode_shots_bit_packed(&dets, batch_shots, num_dets, num_obs) {
+    Ok(predictions) => predictions,
+    Err(error) => {
+        total_decode_us += decode_started.elapsed().as_secs_f64() * 1e6;
+        wall_seconds += batch_started.elapsed().as_secs_f64();
+        let mut result_params = built.params.clone();
+        for (key, value) in decoder_params {
+            result_params.insert(key.clone(), value.clone());
+        }
+        let mut summary = built.case_summary.clone();
+        summary.insert("num_dets".into(), serde_json::json!(num_dets));
+        summary.insert("num_obs".into(), serde_json::json!(num_obs));
+        summary.insert(
+            "num_shots_generated".into(),
+            serde_json::json!(generated_shots),
+        );
+        return Ok(make_result_row(
+            ctx,
+            result_params,
+            summary,
+            MetricMap::from_pairs([
+                ("shots_used", shots_used as f64),
+                ("logical_errors", logical_errors as f64),
+                (
+                    "logical_error_rate",
+                    if shots_used == 0 {
+                        0.0
+                    } else {
+                        logical_errors as f64 / shots_used as f64
+                    },
+                ),
+                ("compile_us", compile_us),
+                ("total_decode_us", total_decode_us),
+                ("wall_seconds", wall_seconds),
+                (
+                    "decode_us_per_shot",
+                    if shots_used == 0 {
+                        0.0
+                    } else {
+                        total_decode_us / shots_used as f64
+                    },
+                ),
+            ]),
+            classify_error(&error, FailureKind::SolverFailure),
+            Some(error),
+        ));
+    }
+};
+```
+
+For wrong prediction length and wrong observable length, replace `return Err(...)` with structured rows using `FailureKind::SolverFailure` for decoder prediction length and `FailureKind::SamplerError` for observable buffer length.
+
+At the final `Ok(BenchmarkResultRow { ... })`, compute and include:
+
+```rust
+let timed_out = point
+    .max_wall_seconds
+    .is_some_and(|max_seconds| wall_seconds >= max_seconds);
+let failure_kind = classify_completed(logical_errors as u64, timed_out);
+```
+
+and build the return row through `make_result_row(...)` so it includes:
+
+```rust
+failure_kind,
+status: failure_kind.status().into(),
+error: None,
+```
+
+- [ ] **Step 4: Keep runner wrappers passing**
+
+Update any `BenchmarkResultRow` assumptions in `rsinter/tests/bench_runner_wrappers.rs` by adding these assertions:
+
+```rust
+assert_eq!(row.failure_kind, rsinter::failure::FailureKind::Ok);
+```
+
+for the zero-shot `rbposd` and `rilpqec` wrapper tests.
+
+- [ ] **Step 5: Run benchmark runner tests**
+
+Run:
+
+```bash
+cargo test -p rsinter failure_kind_is_structured
+cargo test -p rsinter benchmark_runner_records_compile_failure_as_structured_row
+cargo test -p rsinter benchmark_runner_records_decode_failure_as_structured_row
+cargo test -p rsinter bench_runner_wrappers
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add rsinter/src/bench/runners/mod.rs rsinter/src/bench/runners/rmatching.rs rsinter/src/bench/runners/rbposd.rs rsinter/src/bench/runners/rilpqec.rs rsinter/tests/bench_runner_wrappers.rs
+git commit -m "feat: classify benchmark runner failures"
+```
+
+---
+
+### Task 5: Classify `collect` Outcomes
+
+**Files:**
+- Modify: `rsinter/src/collect.rs`
+- Modify: `rsinter/tests/collect.rs`
+
+- [ ] **Step 1: Write failing collect failure-kind tests**
+
+In `rsinter/tests/collect.rs`, add:
+
+```rust
+use rsinter::failure::FailureKind;
+```
+
+Add these fake decoder helpers below the slow decoder helpers:
+
+```rust
+struct FailingDecoder {
+    message: &'static str,
+}
+
+impl Decoder for FailingDecoder {
+    fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Result<Box<dyn CompiledDecoder>, String> {
+        Err(self.message.to_string())
+    }
+}
+
+fn make_failing_decoders(
+    message: &'static str,
+) -> HashMap<String, Box<dyn rsinter::decode::Decoder>> {
+    let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
+    decoders.insert("vacuous".into(), Box::new(FailingDecoder { message }));
+    decoders
+}
+```
+
+Add this helper:
+
+```rust
+fn make_clean_task() -> Task {
+    let circuit = parse_lines("M 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]").unwrap();
+    let dem = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
+    Task {
+        circuit,
+        decoder: "vacuous".into(),
+        dem,
+        metadata: serde_json::json!({"d": 3, "clean": true}),
+        collection_options: CollectionOptions {
+            max_shots: Some(16),
+            max_errors: None,
+            max_wall_seconds: None,
+        },
+    }
+}
+```
+
+Append these tests:
+
+```rust
+#[test]
+fn collect_reports_ok_failure_kind_for_clean_runs() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(16),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(16),
+        start_batch_size: 16,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let results = collect(vec![make_clean_task()], make_decoders(), &options).unwrap();
+
+    assert_eq!(results[0].failure_kind, FailureKind::Ok);
+}
+
+#[test]
+fn collect_reports_logical_failure_kind_for_logical_errors() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(1000),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(256),
+        start_batch_size: 64,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let results = collect(vec![make_task()], make_decoders(), &options).unwrap();
+
+    assert!(results[0].errors > 0);
+    assert_eq!(results[0].failure_kind, FailureKind::LogicalFailure);
+}
+
+#[test]
+fn collect_reports_timeout_failure_kind_for_wall_clock_stop() {
+    let mut task = make_clean_task();
+    task.collection_options.max_shots = None;
+
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(20),
+        max_errors: None,
+        max_wall_seconds: Some(0.09),
+        max_batch_size: Some(1),
+        start_batch_size: 1,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let results = collect(
+        vec![task],
+        make_slow_decoders(Duration::from_millis(35)),
+        &options,
+    )
+    .unwrap();
+
+    assert_eq!(results[0].failure_kind, FailureKind::Timeout);
+}
+
+#[test]
+fn collect_records_decoder_failure_as_task_stats() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(20),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(1),
+        start_batch_size: 1,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let results = collect(
+        vec![make_clean_task()],
+        make_failing_decoders("HiGHS backend error: compile failed"),
+        &options,
+    )
+    .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::SolverFailure);
+}
+```
+
+- [ ] **Step 2: Run the failing collect taxonomy tests**
+
+Run:
+
+```bash
+cargo test -p rsinter collect_reports_ok_failure_kind_for_clean_runs
+cargo test -p rsinter collect_reports_logical_failure_kind_for_logical_errors
+cargo test -p rsinter collect_reports_timeout_failure_kind_for_wall_clock_stop
+cargo test -p rsinter collect_records_decoder_failure_as_task_stats
+```
+
+Expected: FAIL because `collect` does not yet classify completed runs or convert decoder failures into `TaskStats`.
+
+- [ ] **Step 3: Add classification in `collect`**
+
+In `rsinter/src/collect.rs`, add:
+
+```rust
+use crate::failure::{FailureKind, classify_completed, classify_error};
+```
+
+Replace the parallel body with a result-aware collection:
+
+```rust
+let results: Vec<Result<TaskStats, String>> = pool.install(|| {
+    tasks
+        .par_iter()
+        .map(|task| collect_one_task(task, &decoders, &existing, options))
+        .collect()
+});
+let results: Vec<TaskStats> = results.into_iter().collect::<Result<_, _>>()?;
+```
+
+Move the current per-task logic into a new helper below `collect`:
+
+```rust
+fn collect_one_task(
+    task: &Task,
+    decoders: &HashMap<String, Box<dyn Decoder>>,
+    existing: &HashMap<String, TaskStats>,
+    options: &CollectOptions,
+) -> Result<TaskStats, String> {
+    let strong_id = task.strong_id();
+    let decoder = decoders
+        .get(&task.decoder)
+        .ok_or_else(|| format!("decoder not found: {}", task.decoder))?;
+
+    let mut total_shots: u64 = 0;
+    let mut total_errors: u64 = 0;
+    let mut total_seconds: f64 = 0.0;
+
+    if let Some(prev) = existing.get(&strong_id) {
+        total_shots = prev.shots;
+        total_errors = prev.errors;
+        total_seconds = prev.seconds;
+    }
+
+    let compiled = match decoder.compile_for_dem(&task.dem) {
+        Ok(compiled) => compiled,
+        Err(error) => {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds,
+                classify_error(&error, FailureKind::SolverFailure),
+            ));
+        }
+    };
+
+    let num_dets = task.dem.effective_num_detectors();
+    let num_obs = task.dem.num_observables();
+    let obs_bytes_per_shot = (num_obs + 7) / 8;
+
+    let max_shots = task
+        .collection_options
+        .max_shots
+        .or(options.max_shots)
+        .unwrap_or(u64::MAX);
+    let max_errors = task
+        .collection_options
+        .max_errors
+        .or(options.max_errors)
+        .unwrap_or(u64::MAX);
+    let max_wall_seconds = task
+        .collection_options
+        .max_wall_seconds
+        .or(options.max_wall_seconds);
+
+    let mut batch_size = options.start_batch_size;
+    let mut rng = StdRng::from_entropy();
+
+    while should_continue_collecting(
+        total_shots,
+        total_errors,
+        total_seconds,
+        max_shots,
+        max_errors,
+        max_wall_seconds,
+    ) {
+        let remaining = (max_shots - total_shots) as usize;
+        let n = batch_size.min(remaining);
+        if n == 0 {
+            break;
+        }
+
+        let batch_started = Instant::now();
+        let batch = match sample_batch(&task.circuit, n, &mut rng) {
+            Ok(batch) => batch,
+            Err(_error) => {
+                return Ok(make_task_stats(
+                    task,
+                    strong_id,
+                    total_shots,
+                    total_errors,
+                    total_seconds + batch_started.elapsed().as_secs_f64(),
+                    FailureKind::SamplerError,
+                ));
+            }
+        };
+
+        let mut det_buf = Vec::new();
+        if let Err(_error) = write_shots_b8(&batch.detections, &mut det_buf) {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds + batch_started.elapsed().as_secs_f64(),
+                FailureKind::SamplerError,
+            ));
+        }
+        let mut obs_buf = Vec::new();
+        if let Err(_error) = write_shots_b8(&batch.observable_flips, &mut obs_buf) {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds + batch_started.elapsed().as_secs_f64(),
+                FailureKind::SamplerError,
+            ));
+        }
+
+        let predictions = match compiled.decode_shots_bit_packed(&det_buf, n, num_dets, num_obs) {
+            Ok(predictions) => predictions,
+            Err(error) => {
+                return Ok(make_task_stats(
+                    task,
+                    strong_id,
+                    total_shots,
+                    total_errors,
+                    total_seconds + batch_started.elapsed().as_secs_f64(),
+                    classify_error(&error, FailureKind::SolverFailure),
+                ));
+            }
+        };
+        let expected_len = n * obs_bytes_per_shot;
+        if predictions.len() != expected_len || obs_buf.len() != expected_len {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds + batch_started.elapsed().as_secs_f64(),
+                FailureKind::SolverFailure,
+            ));
+        }
+
+        let mut batch_errors = 0u64;
+        for shot in 0..n {
+            let offset = shot * obs_bytes_per_shot;
+            let mut mismatch = false;
+            for byte in 0..obs_bytes_per_shot {
+                if predictions[offset + byte] != obs_buf[offset + byte] {
+                    mismatch = true;
+                    break;
+                }
+            }
+            if mismatch {
+                batch_errors += 1;
+            }
+        }
+
+        total_shots += n as u64;
+        total_errors += batch_errors;
+        total_seconds += batch_started.elapsed().as_secs_f64();
+
+        if let Some(max) = options.max_batch_size {
+            batch_size = (batch_size * 2).min(max);
+        } else {
+            batch_size *= 2;
+        }
+    }
+
+    let timed_out = max_wall_seconds.is_some_and(|max_seconds| total_seconds >= max_seconds);
+    Ok(make_task_stats(
+        task,
+        strong_id,
+        total_shots,
+        total_errors,
+        total_seconds,
+        classify_completed(total_errors, timed_out),
+    ))
+}
+```
+
+Add this helper below `collect_one_task`:
+
+```rust
+fn make_task_stats(
+    task: &Task,
+    strong_id: String,
+    shots: u64,
+    errors: u64,
+    seconds: f64,
+    failure_kind: FailureKind,
+) -> TaskStats {
+    TaskStats {
+        strong_id,
+        decoder: task.decoder.clone(),
+        metadata: task.metadata.clone(),
+        shots,
+        errors,
+        discards: 0,
+        seconds,
+        failure_kind,
+        custom_counts: HashMap::new(),
+    }
+}
+```
+
+- [ ] **Step 4: Run collect tests**
+
+Run:
+
+```bash
+cargo test -p rsinter collect
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 5**
+
+Run:
+
+```bash
+git add rsinter/src/collect.rs rsinter/tests/collect.rs
+git commit -m "feat: classify collect task failures"
+```
+
+---
+
+### Task 6: Add End-To-End Unsupported Backend Coverage
+
+**Files:**
+- Modify: `rsinter/tests/bench_run.rs`
+
+- [ ] **Step 1: Write the unsupported `rilpqec` benchmark test**
+
+In `rsinter/tests/bench_run.rs`, add:
+
+```rust
+use rsinter::failure::FailureKind;
+```
+
+Append this test near the other `rilpqec` benchmark tests:
+
+```rust
+#[cfg(not(feature = "gurobi"))]
+#[test]
+fn rilpqec_gurobi_without_feature_records_unsupported_failure_kind() {
+    let spec_text = r#"
+name = "surface_decoder"
+version = 1
+mode = "independent"
+
+[[runner]]
+name = "rilpqec_gurobi"
+language = "rust"
+impl_key = "rilpqec"
+
+[runner.params]
+distance = [3]
+rounds = [3]
+p = [0.002]
+max_shots = 1
+max_errors = 1
+batch_size = 1
+backend = "gurobi"
+
+[plot]
+title = "Surface Decoder"
+
+[plot.x]
+field = "params.p"
+scale = "log"
+label = "Physical Error Rate"
+
+[plot.series]
+group_by = ["runner"]
+label_template = "{runner}"
+
+[[plot.panel]]
+metric = "metrics.logical_error_rate"
+scale = "log"
+label = "Logical Error Rate"
+"#;
+
+    let spec: BenchmarkSpec = toml::from_str(spec_text).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let registry = build_default_rust_runner_registry();
+
+    let artifact_root = run_rust_benchmark(
+        &spec,
+        "rust",
+        dir.path(),
+        &registry,
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    )
+    .unwrap();
+    let data = fs::read(
+        artifact_root
+            .join("rilpqec_gurobi")
+            .join("test-run")
+            .join("results.jsonl"),
+    )
+    .unwrap();
+    let rows = read_results_jsonl(&data[..]).unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].status, "error");
+    assert_eq!(rows[0].failure_kind, FailureKind::Unsupported);
+    assert!(
+        rows[0]
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("no ILP backend is available"),
+        "row error was: {:?}",
+        rows[0].error
+    );
+}
+```
+
+- [ ] **Step 2: Run the unsupported backend test**
+
+Run:
+
+```bash
+cargo test -p rsinter rilpqec_gurobi_without_feature_records_unsupported_failure_kind
+```
+
+Expected: PASS when the `gurobi` feature is not enabled. When the feature is enabled, Cargo reports the test as filtered out by `cfg`.
+
+- [ ] **Step 3: Run focused regression checks**
+
+Run:
+
+```bash
+cargo test -p rsinter failure_kind_is_structured
+cargo test -p rsinter bench_result
+cargo test -p rsinter csv_io
+cargo test -p rsinter collect
+cargo test -p rsinter rilpqec_gurobi_without_feature_records_unsupported_failure_kind
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 6**
+
+Run:
+
+```bash
+git add rsinter/tests/bench_run.rs
+git commit -m "test: cover unsupported rilpqec failure kind"
+```
+
+---
+
+### Task 7: Full Verification
+
+**Files:**
+- Verify: all changed `rsinter` files
+
+- [ ] **Step 1: Format the Rust workspace**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: exits 0 with no output on success.
+
+- [ ] **Step 2: Run all `rsinter` tests**
+
+Run:
+
+```bash
+cargo test -p rsinter
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional changes remain. If `cargo fmt` changed files after the last task commit, commit those formatting changes with:
+
+```bash
+git add rsinter
+git commit -m "style: format rsinter failure taxonomy"
+```
+
+- [ ] **Step 4: Final implementation summary**
+
+Record these facts in the final handoff:
+
+```text
+- Benchmark JSONL rows now include failure_kind.
+- Legacy JSONL and CSV rows without failure_kind remain readable.
+- TaskStats and CSV resume data now carry failure_kind.
+- Decoder backend failures return Result and are classified instead of panicking.
+- rilpqec backend=gurobi without the feature records unsupported.
+- cargo test -p rsinter passed.
+```

--- a/docs/superpowers/specs/2026-06-14-rsinter-failure-taxonomy-design.md
+++ b/docs/superpowers/specs/2026-06-14-rsinter-failure-taxonomy-design.md
@@ -1,0 +1,256 @@
+# rsinter Failure Taxonomy Design
+
+## Context
+
+Issue 49 asks `rsinter` benchmark results to expose a structured failure
+taxonomy. Today `BenchmarkResultRow` has only `status: String` and
+`error: Option<String>`, so downstream consumers have to parse strings to
+distinguish ordinary logical failures from crashes, solver backend failures, or
+unsupported decoder configurations.
+
+AutoQEC needs this distinction for its keep/discard/crash loop. A candidate with
+logical errors is a normal discard. A decoder crash, unsupported backend, sampler
+failure, or timeout needs separate handling.
+
+The lower-level `collect` path also only records logical error counts in
+`TaskStats`. This design extends both benchmark JSONL rows and `TaskStats` so
+they use the same taxonomy.
+
+## Goals
+
+- Add a typed `FailureKind` model shared by benchmark rows and task stats.
+- Serialize benchmark `failure_kind` values as stable snake_case strings:
+  `ok`, `logical_failure`, `timeout`, `solver_failure`, `unsupported`, and
+  `sampler_error`.
+- Preserve existing human-readable `status` and `error` fields for compatibility
+  and diagnostics.
+- Record per-point benchmark failures as result rows instead of panicking or
+  producing an empty artifact when a run-time decoder/backend/sampler failure
+  occurs.
+- Add `failure_kind` to `TaskStats` and CSV resume data while keeping old CSV
+  files readable.
+- Keep configuration/spec errors as regular `Err` results that fail the
+  benchmark before artifact writes.
+
+## Non-Goals
+
+- Do not redesign benchmark specs, plotting, or the benchmark artifact layout.
+- Do not add cancellation inside a decoder call; wall-clock timeout remains a
+  stop condition checked between batches.
+- Do not change downstream AutoQEC code in this repository.
+- Do not make every decoder backend expose a rich typed error hierarchy in this
+  issue. Use typed `FailureKind` at the `rsinter` boundary.
+
+## Data Model
+
+Add a public enum in a new shared module, `rsinter/src/failure.rs`, and re-export
+it from `rsinter/src/lib.rs` so both benchmark rows and task stats can use one
+type:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKind {
+    Ok,
+    LogicalFailure,
+    Timeout,
+    SolverFailure,
+    Unsupported,
+    SamplerError,
+}
+```
+
+`BenchmarkResultRow` gains:
+
+```rust
+pub failure_kind: FailureKind,
+```
+
+`TaskStats` gains the same field.
+
+`status` stays for legacy consumers. The intended mapping is:
+
+- `status = "ok"` when `failure_kind` is `ok`, `logical_failure`, or `timeout`
+  and the run completed without a run-time error.
+- `status = "error"` when `failure_kind` is `solver_failure`, `unsupported`, or
+  `sampler_error`.
+
+`error` stays as optional detail. It is `None` for ordinary `ok`,
+`logical_failure`, and `timeout` outcomes unless the implementation has useful
+non-fatal detail to report.
+
+## Compatibility
+
+`read_results_jsonl` should accept older rows with no `failure_kind`. When the
+field is absent, infer:
+
+- `status == "error"`: classify from `error` if possible, otherwise
+  `solver_failure`.
+- `metrics.logical_errors > 0`: `logical_failure`.
+- Otherwise: `ok`.
+
+CSV output adds a `failure_kind` column. `read_csv` should detect whether the
+column is present by header name. If an old CSV lacks the column, infer:
+
+- `errors > 0`: `logical_failure`.
+- Otherwise: `ok`.
+
+`TaskStats::add` should combine compatible stats conservatively. Use this
+priority order, from strongest to weakest:
+
+```text
+unsupported > solver_failure > sampler_error > timeout > logical_failure > ok
+```
+
+This keeps resumed aggregate stats from hiding the most important failure or
+stop condition.
+
+## Run-Time Data Flow
+
+Change the `rsinter` decoder traits from panic-oriented adapters to explicit
+results:
+
+```rust
+pub trait Decoder: Send + Sync {
+    fn compile_for_dem(&self, dem: &DetectorErrorModel)
+        -> Result<Box<dyn CompiledDecoder>, String>;
+}
+
+pub trait CompiledDecoder: Send {
+    fn decode_shots_bit_packed(
+        &self,
+        dets: &[u8],
+        num_shots: usize,
+        num_dets: usize,
+        num_obs: usize,
+    ) -> Result<Vec<u8>, String>;
+}
+```
+
+`rilpqec` should stop using `expect` in its adapter for compile/decode failures.
+It should return the underlying error string. This lets `BackendUnavailable`
+become `unsupported`, and other ILP backend failures become `solver_failure`.
+
+`rmatching` and `rbposd` should wrap compile/decode failures in `Err(String)`
+where the underlying API can fail. Internal invariants that truly indicate a
+programmer bug can remain asserts or expects, but normal backend and decode
+failures should cross the boundary as `Result`.
+
+## Benchmark Semantics
+
+`run_decoder_point` should construct `BenchmarkResultRow` for both normal and
+run-time failure outcomes.
+
+Normal outcomes:
+
+- No logical errors and no timeout: `failure_kind = ok`.
+- Logical errors and no timeout: `failure_kind = logical_failure`.
+- Wall-clock budget reached: `failure_kind = timeout`, even if logical errors
+  were also observed. The logical error count remains in metrics.
+
+Run-time failures:
+
+- Circuit construction or DEM analysis failure: classify as `unsupported` when
+  the input/code family is unsupported; otherwise classify as `solver_failure`.
+- Decoder compile failure: `unsupported` for unavailable/unsupported backend
+  messages, otherwise `solver_failure`.
+- Decoder decode failure: `solver_failure`.
+- `sample_batch`, `write_shots_b8`, or observable buffer mismatch:
+  `sampler_error`.
+
+When a run-time failure happens after partial progress, the row should include
+the partial `shots_used`, `logical_errors`, timing metrics, params, and case
+summary available so far. The `error` field should contain the detail string.
+
+`run_rust_benchmark` should keep preflight behavior for configuration/spec
+errors. Unknown runner params, invalid decoder params like `mip_gap = 1.0`, and
+invalid benchmark point definitions should still fail the whole planned run
+before writing artifacts. Those are authoring errors, not evaluated candidate
+failures.
+
+## Collect Semantics
+
+`collect` should continue to reject global configuration errors with `Err`, such
+as invalid `max_wall_seconds`.
+
+Per-task run-time failures should become `TaskStats` rows:
+
+- Missing decoder in the supplied decoder map is still a caller error and should
+  remain `Err`.
+- Decoder compile failure: return stats for that task with zero or resumed
+  progress and `failure_kind = unsupported` or `solver_failure`.
+- Decode failure during a batch: return stats for that task with progress up to
+  the completed previous batch and `failure_kind = solver_failure`.
+- Sampler or packing failure: return stats for that task with
+  `failure_kind = sampler_error`.
+- Normal completion uses the same `ok`, `logical_failure`, and `timeout`
+  semantics as benchmark rows.
+
+The current parallel collection structure can still return a `Vec<TaskStats>`.
+Only global setup and caller errors need to abort the entire collection.
+
+## Classification Helper
+
+Use a small helper instead of spreading string checks throughout the code. It
+can start simple:
+
+- `classify_error(message: &str, phase: FailurePhase) -> FailureKind`
+- `classify_completed(logical_errors: u64, timed_out: bool) -> FailureKind`
+- `combine_failure_kind(a: FailureKind, b: FailureKind) -> FailureKind`
+
+The first implementation classifies `BackendUnavailable`, `backend is
+unavailable`, and `no ILP backend is available` as `unsupported`. Solver-specific
+errors such as HiGHS, Gurobi, compile, decode, or width mismatch map to
+`solver_failure` unless they clearly originate from sampling/packing.
+
+## Testing
+
+Add focused tests in `rsinter`.
+
+`rsinter/tests/bench_result.rs`:
+
+- Round-trip JSON serialization includes `failure_kind`.
+- Old JSONL rows without `failure_kind` still deserialize and infer `ok` or
+  `logical_failure`.
+
+`rsinter/tests/csv_io.rs`:
+
+- CSV round trip preserves `TaskStats.failure_kind`.
+- Old CSV without a `failure_kind` column remains readable.
+
+`rsinter/src/bench/runners/mod.rs` or `rsinter/tests/bench_runner_wrappers.rs`:
+
+- `failure_kind_is_structured` covers clean `ok`, normal
+  `logical_failure`, and wall-clock `timeout`.
+- A fake decoder compile/decode failure yields a row with `status = "error"`,
+  a structured failure kind, and a non-empty `error`.
+
+`rsinter/tests/bench_run.rs`:
+
+- A `rilpqec` benchmark point with `backend = "gurobi"` and no `gurobi`
+  feature writes a result row with `failure_kind = "unsupported"` rather than
+  panicking or leaving no artifact. Gate this test with
+  `#[cfg(not(feature = "gurobi"))]`.
+
+`rsinter/tests/collect.rs`:
+
+- A normal clean collect returns `ok`.
+- A logical-error collect returns `logical_failure`.
+- A wall-clock-limited collect returns `timeout`.
+- A fake decoder failure returns `TaskStats.failure_kind = solver_failure`
+  without aborting the whole collection.
+
+Run narrow checks first:
+
+```text
+cargo test -p rsinter failure_kind_is_structured
+cargo test -p rsinter bench_result
+cargo test -p rsinter csv_io
+cargo test -p rsinter collect
+```
+
+Then run:
+
+```text
+cargo test -p rsinter
+```

--- a/rsinter/examples/surface_code_threshold.rs
+++ b/rsinter/examples/surface_code_threshold.rs
@@ -29,23 +29,23 @@ fn main() {
     // shots=100_000; errors chosen so errors/shots approximates an illustrative curve.
     let stats = vec![
         // d=3, rounds=9
-        make_stat(0.008, 3, 9,  100_000,  1_050),
-        make_stat(0.009, 3, 9,  100_000,  1_290),
-        make_stat(0.010, 3, 9,  100_000,  1_530),
-        make_stat(0.011, 3, 9,  100_000,  1_830),
-        make_stat(0.012, 3, 9,  100_000,  2_130),
+        make_stat(0.008, 3, 9, 100_000, 1_050),
+        make_stat(0.009, 3, 9, 100_000, 1_290),
+        make_stat(0.010, 3, 9, 100_000, 1_530),
+        make_stat(0.011, 3, 9, 100_000, 1_830),
+        make_stat(0.012, 3, 9, 100_000, 2_130),
         // d=5, rounds=15
-        make_stat(0.008, 5, 15, 100_000,    310),
-        make_stat(0.009, 5, 15, 100_000,    490),
-        make_stat(0.010, 5, 15, 100_000,    780),
-        make_stat(0.011, 5, 15, 100_000,  1_180),
-        make_stat(0.012, 5, 15, 100_000,  1_660),
+        make_stat(0.008, 5, 15, 100_000, 310),
+        make_stat(0.009, 5, 15, 100_000, 490),
+        make_stat(0.010, 5, 15, 100_000, 780),
+        make_stat(0.011, 5, 15, 100_000, 1_180),
+        make_stat(0.012, 5, 15, 100_000, 1_660),
         // d=7, rounds=21
-        make_stat(0.008, 7, 21, 100_000,     72),
-        make_stat(0.009, 7, 21, 100_000,    193),
-        make_stat(0.010, 7, 21, 100_000,    510),
-        make_stat(0.011, 7, 21, 100_000,  1_029),
-        make_stat(0.012, 7, 21, 100_000,  1_684),
+        make_stat(0.008, 7, 21, 100_000, 72),
+        make_stat(0.009, 7, 21, 100_000, 193),
+        make_stat(0.010, 7, 21, 100_000, 510),
+        make_stat(0.011, 7, 21, 100_000, 1_029),
+        make_stat(0.012, 7, 21, 100_000, 1_684),
     ];
 
     let out = Path::new("rstim/doc/surface_code_threshold.svg");
@@ -54,7 +54,8 @@ fn main() {
         |s| s.metadata["p"].as_f64().unwrap(),
         |s| format!("d={}", s.metadata["d"].as_u64().unwrap()),
         out,
-    ).unwrap();
+    )
+    .unwrap();
 
     println!("Written {}", out.display());
 }

--- a/rsinter/examples/surface_code_threshold.rs
+++ b/rsinter/examples/surface_code_threshold.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use rsinter::failure::FailureKind;
 use rsinter::plot::plot_error_rate;
 use rsinter::task_stats::TaskStats;
 
@@ -18,6 +19,7 @@ fn make_stat(p: f64, d: u64, r: u64, shots: u64, errors: u64) -> TaskStats {
         errors,
         discards: 0,
         seconds: 0.0,
+        failure_kind: FailureKind::Ok,
         custom_counts: HashMap::new(),
     }
 }

--- a/rsinter/src/bench/result.rs
+++ b/rsinter/src/bench/result.rs
@@ -4,6 +4,8 @@ use std::io::{BufRead, BufReader, Read, Write};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::failure::{FailureKind, classify_error};
+
 pub type ArtifactMap = BTreeMap<String, String>;
 pub type CaseSummary = BTreeMap<String, Value>;
 pub type ParamMap = BTreeMap<String, Value>;
@@ -52,17 +54,78 @@ impl RunManifest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct BenchmarkResultRow {
     pub benchmark: String,
     pub runner: String,
     pub language: String,
     pub status: String,
+    pub failure_kind: FailureKind,
     pub params: ParamMap,
     pub case_summary: CaseSummary,
     pub metrics: MetricMap,
     pub artifacts: ArtifactMap,
     pub error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawBenchmarkResultRow {
+    benchmark: String,
+    runner: String,
+    language: String,
+    status: String,
+    #[serde(default)]
+    failure_kind: Option<FailureKind>,
+    params: ParamMap,
+    case_summary: CaseSummary,
+    metrics: MetricMap,
+    artifacts: ArtifactMap,
+    error: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for BenchmarkResultRow {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawBenchmarkResultRow::deserialize(deserializer)?;
+        let failure_kind = raw.failure_kind.unwrap_or_else(|| {
+            infer_legacy_failure_kind(
+                &raw.status,
+                raw.error.as_deref(),
+                raw.metrics.get("logical_errors").copied(),
+            )
+        });
+        Ok(Self {
+            benchmark: raw.benchmark,
+            runner: raw.runner,
+            language: raw.language,
+            status: raw.status,
+            failure_kind,
+            params: raw.params,
+            case_summary: raw.case_summary,
+            metrics: raw.metrics,
+            artifacts: raw.artifacts,
+            error: raw.error,
+        })
+    }
+}
+
+fn infer_legacy_failure_kind(
+    status: &str,
+    error: Option<&str>,
+    logical_errors: Option<f64>,
+) -> FailureKind {
+    if status == "error" {
+        return error
+            .map(|message| classify_error(message, FailureKind::SolverFailure))
+            .unwrap_or(FailureKind::SolverFailure);
+    }
+    if logical_errors.unwrap_or(0.0) > 0.0 {
+        FailureKind::LogicalFailure
+    } else {
+        FailureKind::Ok
+    }
 }
 
 pub fn write_results_jsonl(rows: &[BenchmarkResultRow], out: &mut dyn Write) -> Result<(), String> {

--- a/rsinter/src/bench/result.rs
+++ b/rsinter/src/bench/result.rs
@@ -131,9 +131,28 @@ fn legacy_timed_out(params: &ParamMap, metrics: &MetricMap) -> bool {
     let Some(max_wall_seconds) = params.get("max_wall_seconds").and_then(Value::as_f64) else {
         return false;
     };
-    metrics
-        .get("wall_seconds")
-        .is_some_and(|wall_seconds| wall_seconds.is_finite() && *wall_seconds >= max_wall_seconds)
+    let Some(wall_seconds) = metrics.get("wall_seconds") else {
+        return false;
+    };
+    wall_seconds.is_finite()
+        && *wall_seconds >= max_wall_seconds
+        && !legacy_reached_cap(params, metrics, "max_shots", "shots_used")
+        && !legacy_reached_cap(params, metrics, "max_errors", "logical_errors")
+}
+
+fn legacy_reached_cap(
+    params: &ParamMap,
+    metrics: &MetricMap,
+    param_key: &str,
+    metric_key: &str,
+) -> bool {
+    match (
+        params.get(param_key).and_then(Value::as_f64),
+        metrics.get(metric_key).copied(),
+    ) {
+        (Some(cap), Some(value)) => value.is_finite() && value >= cap,
+        _ => false,
+    }
 }
 
 pub fn write_results_jsonl(rows: &[BenchmarkResultRow], out: &mut dyn Write) -> Result<(), String> {

--- a/rsinter/src/bench/result.rs
+++ b/rsinter/src/bench/result.rs
@@ -4,7 +4,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::failure::{FailureKind, classify_error};
+use crate::failure::{classify_error, FailureKind};
 
 pub type ArtifactMap = BTreeMap<String, String>;
 pub type CaseSummary = BTreeMap<String, Value>;

--- a/rsinter/src/bench/result.rs
+++ b/rsinter/src/bench/result.rs
@@ -90,11 +90,7 @@ impl<'de> Deserialize<'de> for BenchmarkResultRow {
     {
         let raw = RawBenchmarkResultRow::deserialize(deserializer)?;
         let failure_kind = raw.failure_kind.unwrap_or_else(|| {
-            infer_legacy_failure_kind(
-                &raw.status,
-                raw.error.as_deref(),
-                raw.metrics.get("logical_errors").copied(),
-            )
+            infer_legacy_failure_kind(&raw.status, raw.error.as_deref(), &raw.params, &raw.metrics)
         });
         Ok(Self {
             benchmark: raw.benchmark,
@@ -114,18 +110,30 @@ impl<'de> Deserialize<'de> for BenchmarkResultRow {
 fn infer_legacy_failure_kind(
     status: &str,
     error: Option<&str>,
-    logical_errors: Option<f64>,
+    params: &ParamMap,
+    metrics: &MetricMap,
 ) -> FailureKind {
     if status == "error" {
         return error
             .map(|message| classify_error(message, FailureKind::SolverFailure))
             .unwrap_or(FailureKind::SolverFailure);
     }
-    if logical_errors.unwrap_or(0.0) > 0.0 {
+    if legacy_timed_out(params, metrics) {
+        FailureKind::Timeout
+    } else if metrics.get("logical_errors").copied().unwrap_or(0.0) > 0.0 {
         FailureKind::LogicalFailure
     } else {
         FailureKind::Ok
     }
+}
+
+fn legacy_timed_out(params: &ParamMap, metrics: &MetricMap) -> bool {
+    let Some(max_wall_seconds) = params.get("max_wall_seconds").and_then(Value::as_f64) else {
+        return false;
+    };
+    metrics
+        .get("wall_seconds")
+        .is_some_and(|wall_seconds| wall_seconds.is_finite() && *wall_seconds >= max_wall_seconds)
 }
 
 pub fn write_results_jsonl(rows: &[BenchmarkResultRow], out: &mut dyn Write) -> Result<(), String> {

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -852,4 +852,91 @@ mod tests {
         assert!(wall_seconds >= 0.09, "wall_seconds={wall_seconds}");
         assert!(wall_seconds.is_finite(), "wall_seconds={wall_seconds}");
     }
+
+    #[test]
+    fn run_decoder_point_reports_sampler_failure_after_partial_progress() {
+        let ctx = BenchRunContext {
+            benchmark_name: "surface_decoder".into(),
+            runner_name: "fake".into(),
+            language: "rust".into(),
+            seed: 12_345,
+            spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        };
+        let mut point = surface_point(0.0, 2, 2);
+        point.batch_size = 1;
+        let built = build_circuit_for_point(&point, &ctx.spec_dir).unwrap();
+        let decoder_params = crate::bench::result::ParamMap::new();
+        let mut calls = 0usize;
+        let mut flaky_batcher =
+            |_circuit: &[rstim::ir::StimInstr], shots: usize, _rng: &mut StdRng| {
+                calls += 1;
+                if calls == 1 {
+                    Ok((Vec::new(), vec![0u8; shots]))
+                } else {
+                    Err("sampler stopped after warmup".to_string())
+                }
+            };
+
+        let row = run_built_decoder_point_with_batcher(
+            "fake",
+            &SlowPredictionDecoder {
+                sleep: Duration::from_millis(0),
+            },
+            built,
+            &point,
+            &ctx,
+            &decoder_params,
+            &mut flaky_batcher,
+        )
+        .unwrap();
+
+        assert_eq!(calls, 2);
+        assert_eq!(row.status, "error");
+        assert_eq!(row.failure_kind, FailureKind::SamplerError);
+        assert_eq!(row.metrics["shots_used"], 1.0);
+        assert_eq!(row.metrics["logical_errors"], 0.0);
+        assert_eq!(
+            row.case_summary["num_shots_generated"],
+            serde_json::json!(1)
+        );
+        assert_eq!(row.error.as_deref(), Some("sampler stopped after warmup"));
+    }
+
+    #[test]
+    fn run_decoder_point_stops_mid_batch_when_logical_error_cap_is_hit() {
+        let ctx = BenchRunContext {
+            benchmark_name: "surface_decoder".into(),
+            runner_name: "fake".into(),
+            language: "rust".into(),
+            seed: 12_345,
+            spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        };
+        let mut point = surface_point(0.0, 4, 1);
+        point.batch_size = 4;
+        let decoder_params = crate::bench::result::ParamMap::new();
+
+        let row = run_decoder_point("fake", &OnePredictionDecoder, &point, &ctx, &decoder_params)
+            .unwrap();
+
+        assert_eq!(row.status, "ok");
+        assert_eq!(row.failure_kind, FailureKind::LogicalFailure);
+        assert_eq!(row.metrics["shots_used"], 1.0);
+        assert_eq!(row.metrics["logical_errors"], 1.0);
+        assert_eq!(
+            row.case_summary["num_shots_generated"],
+            serde_json::json!(4)
+        );
+    }
+
+    #[test]
+    fn sample_and_pack_batch_writes_clean_detector_and_observable_bytes() {
+        let circuit =
+            parse_lines("M 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]\n").unwrap();
+        let mut rng = StdRng::seed_from_u64(7);
+
+        let (dets, obs) = sample_and_pack_batch(&circuit, 3, &mut rng).unwrap();
+
+        assert_eq!(dets, vec![0u8; 3]);
+        assert_eq!(obs, vec![0u8; 3]);
+    }
 }

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -11,6 +11,7 @@ use crate::bench::circuit_source::build_circuit_for_point;
 use crate::bench::registry::{BenchCasePoint, BenchRunContext};
 use crate::bench::result::{BenchmarkResultRow, MetricMap, PairMapExt};
 use crate::decode::Decoder;
+use crate::failure::classify_completed;
 
 pub(crate) mod params;
 pub mod rbposd;
@@ -104,12 +105,17 @@ pub(crate) fn run_decoder_point(
     for (key, value) in decoder_params {
         result_params.insert(key.clone(), value.clone());
     }
+    let timed_out =
+        matches!(point.max_wall_seconds, Some(max_seconds) if wall_seconds >= max_seconds)
+            && shots_used < max_shots
+            && logical_errors < max_errors;
 
     Ok(BenchmarkResultRow {
         benchmark: ctx.benchmark_name.clone(),
         runner: ctx.runner_name.clone(),
         language: ctx.language.clone(),
         status: "ok".into(),
+        failure_kind: classify_completed(logical_errors as u64, timed_out),
         params: result_params,
         case_summary: {
             let mut summary = built.case_summary;

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -724,6 +724,47 @@ mod tests {
     }
 
     #[test]
+    fn run_decoder_point_records_observable_buffer_mismatch_as_sampler_error() {
+        let ctx = BenchRunContext {
+            benchmark_name: "surface_decoder".into(),
+            runner_name: "fake".into(),
+            language: "rust".into(),
+            seed: 12_345,
+            spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        };
+        let point = surface_point(0.002, 1, 1);
+        let built = build_circuit_for_point(&point, &ctx.spec_dir).unwrap();
+        let decoder_params = crate::bench::result::ParamMap::new();
+        let mut short_observables =
+            |_circuit: &[rstim::ir::StimInstr], _shots, _rng: &mut StdRng| {
+                Ok((Vec::new(), Vec::new()))
+            };
+
+        let row = run_built_decoder_point_with_batcher(
+            "fake",
+            &SlowPredictionDecoder {
+                sleep: Duration::from_millis(0),
+            },
+            built,
+            &point,
+            &ctx,
+            &decoder_params,
+            &mut short_observables,
+        )
+        .unwrap();
+
+        assert_eq!(row.status, "error");
+        assert_eq!(row.failure_kind, FailureKind::SamplerError);
+        assert_eq!(row.metrics["shots_used"], 0.0);
+        assert!(
+            row.error
+                .as_deref()
+                .unwrap()
+                .contains("sampler produced 0 observable bytes")
+        );
+    }
+
+    #[test]
     fn run_decoder_point_reports_zero_rates_when_no_shots_are_requested() {
         let point = BenchCasePoint {
             input_type: "surface_rotated_memory_x".into(),

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -4,10 +4,11 @@ use std::time::Instant;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rstim::error_analyzer::ErrorAnalyzer;
+use rstim::ir::StimInstr;
 use rstim::output::write_shots_b8;
 use rstim::sampler::sample_batch;
 
-use crate::bench::circuit_source::build_circuit_for_point;
+use crate::bench::circuit_source::{build_circuit_for_point, BuiltCircuit};
 use crate::bench::registry::{BenchCasePoint, BenchRunContext};
 use crate::bench::result::{BenchmarkResultRow, CaseSummary, MetricMap, PairMapExt, ParamMap};
 use crate::decode::Decoder;
@@ -109,10 +110,72 @@ pub(crate) fn run_decoder_point(
     decoder_params: &crate::bench::result::ParamMap,
 ) -> Result<BenchmarkResultRow, String> {
     let built = build_circuit_for_point(point, &ctx.spec_dir)?;
+    run_built_decoder_point(runner_name, decoder, built, point, ctx, decoder_params)
+}
+
+fn run_built_decoder_point(
+    runner_name: &'static str,
+    decoder: &dyn Decoder,
+    built: BuiltCircuit,
+    point: &BenchCasePoint,
+    ctx: &BenchRunContext,
+    decoder_params: &crate::bench::result::ParamMap,
+) -> Result<BenchmarkResultRow, String> {
+    run_built_decoder_point_with_batcher(
+        runner_name,
+        decoder,
+        built,
+        point,
+        ctx,
+        decoder_params,
+        sample_and_pack_batch,
+    )
+}
+
+fn sample_and_pack_batch(
+    circuit: &[StimInstr],
+    batch_shots: usize,
+    rng: &mut StdRng,
+) -> Result<(Vec<u8>, Vec<u8>), String> {
+    let batch = sample_batch(circuit, batch_shots, rng)?;
+
+    let mut dets = Vec::new();
+    write_shots_b8(&batch.detections, &mut dets).map_err(|error| error.to_string())?;
+    let mut obs = Vec::new();
+    write_shots_b8(&batch.observable_flips, &mut obs).map_err(|error| error.to_string())?;
+
+    Ok((dets, obs))
+}
+
+fn run_built_decoder_point_with_batcher<F>(
+    runner_name: &'static str,
+    decoder: &dyn Decoder,
+    built: BuiltCircuit,
+    point: &BenchCasePoint,
+    ctx: &BenchRunContext,
+    decoder_params: &crate::bench::result::ParamMap,
+    mut sample_and_pack: F,
+) -> Result<BenchmarkResultRow, String>
+where
+    F: FnMut(&[StimInstr], usize, &mut StdRng) -> Result<(Vec<u8>, Vec<u8>), String>,
+{
     let circuit = built.circuit;
     let result_params = merge_decoder_params(built.params, decoder_params);
     let base_case_summary = built.case_summary;
-    let dem = ErrorAnalyzer::circuit_to_dem_decomposed(&circuit)?;
+    let dem = match ErrorAnalyzer::circuit_to_dem_decomposed(&circuit) {
+        Ok(dem) => dem,
+        Err(error) => {
+            let failure_kind = classify_error(&error, FailureKind::SolverFailure);
+            return Ok(benchmark_result_row(
+                ctx,
+                failure_kind,
+                result_params,
+                base_case_summary,
+                benchmark_metrics(0, 0, 0.0, 0.0, 0.0),
+                Some(error),
+            ));
+        }
+    };
     let num_dets = dem.effective_num_detectors();
     let num_obs = dem.num_observables();
 
@@ -153,13 +216,32 @@ pub(crate) fn run_decoder_point(
     {
         let batch_started = Instant::now();
         let batch_shots = point.batch_size.min(max_shots - shots_used);
-        let batch = sample_batch(&circuit, batch_shots, &mut rng)?;
+        let (dets, obs) = match sample_and_pack(&circuit, batch_shots, &mut rng) {
+            Ok(packed) => packed,
+            Err(error) => {
+                let wall_seconds = wall_seconds + batch_started.elapsed().as_secs_f64();
+                return Ok(benchmark_result_row(
+                    ctx,
+                    FailureKind::SamplerError,
+                    result_params,
+                    case_summary_with_progress(
+                        base_case_summary,
+                        num_dets,
+                        num_obs,
+                        generated_shots,
+                    ),
+                    benchmark_metrics(
+                        shots_used,
+                        logical_errors,
+                        compile_us,
+                        total_decode_us,
+                        wall_seconds,
+                    ),
+                    Some(error),
+                ));
+            }
+        };
         generated_shots += batch_shots;
-
-        let mut dets = Vec::new();
-        write_shots_b8(&batch.detections, &mut dets).map_err(|e| e.to_string())?;
-        let mut obs = Vec::new();
-        write_shots_b8(&batch.observable_flips, &mut obs).map_err(|e| e.to_string())?;
 
         let decode_started = Instant::now();
         let predictions =
@@ -274,10 +356,12 @@ pub(crate) fn run_decoder_point(
 #[cfg(test)]
 mod tests {
     use rstim::dem::DetectorErrorModel;
+    use rstim::parser::parse_lines;
     use std::thread;
     use std::time::Duration;
 
     use super::*;
+    use crate::bench::circuit_source::BuiltCircuit;
     use crate::decode::{CompiledDecoder, Decoder};
     use crate::failure::FailureKind;
 
@@ -572,6 +656,71 @@ mod tests {
         assert_eq!(row.status, "error");
         assert_eq!(row.failure_kind, FailureKind::SolverFailure);
         assert!(row.error.unwrap().contains("decoder fake produced 0 bytes"));
+    }
+
+    #[test]
+    fn run_decoder_point_records_dem_analysis_failures_as_structured_rows() {
+        let ctx = BenchRunContext {
+            benchmark_name: "surface_decoder".into(),
+            runner_name: "fake".into(),
+            language: "rust".into(),
+            seed: 12_345,
+            spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        };
+        let built = BuiltCircuit {
+            circuit: parse_lines("ML 0\nDETECTOR rec[-2]\n").unwrap(),
+            params: ParamMap::from_pairs([("input_type", serde_json::json!("custom"))]),
+            case_summary: CaseSummary::new(),
+        };
+        let decoder_params = crate::bench::result::ParamMap::new();
+
+        let row = run_built_decoder_point(
+            "fake",
+            &EmptyPredictionDecoder,
+            built,
+            &surface_point(0.002, 1, 1),
+            &ctx,
+            &decoder_params,
+        )
+        .unwrap();
+
+        assert_eq!(row.status, "error");
+        assert_eq!(row.failure_kind, FailureKind::Unsupported);
+        assert_eq!(row.metrics["shots_used"], 0.0);
+        assert!(row.error.unwrap().contains("unsupported instruction ML"));
+    }
+
+    #[test]
+    fn run_decoder_point_records_sampler_failures_as_structured_rows() {
+        let ctx = BenchRunContext {
+            benchmark_name: "surface_decoder".into(),
+            runner_name: "fake".into(),
+            language: "rust".into(),
+            seed: 12_345,
+            spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        };
+        let point = surface_point(0.002, 1, 1);
+        let built = build_circuit_for_point(&point, &ctx.spec_dir).unwrap();
+        let decoder_params = crate::bench::result::ParamMap::new();
+        let mut failing_batcher = |_circuit: &[rstim::ir::StimInstr], _shots, _rng: &mut StdRng| {
+            Err("sampler exploded".to_string())
+        };
+
+        let row = run_built_decoder_point_with_batcher(
+            "fake",
+            &EmptyPredictionDecoder,
+            built,
+            &point,
+            &ctx,
+            &decoder_params,
+            &mut failing_batcher,
+        )
+        .unwrap();
+
+        assert_eq!(row.status, "error");
+        assert_eq!(row.failure_kind, FailureKind::SamplerError);
+        assert_eq!(row.metrics["shots_used"], 0.0);
+        assert_eq!(row.error.as_deref(), Some("sampler exploded"));
     }
 
     #[test]

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -163,6 +163,7 @@ mod tests {
 
     use super::*;
     use crate::decode::{CompiledDecoder, Decoder};
+    use crate::failure::FailureKind;
 
     struct EmptyPredictionDecoder;
 
@@ -338,6 +339,7 @@ mod tests {
 
         assert!(shots_used > 0.0, "shots_used={shots_used}");
         assert!(shots_used < 20.0, "shots_used={shots_used}");
+        assert_eq!(row.failure_kind, FailureKind::Timeout);
         assert!(wall_seconds >= 0.09, "wall_seconds={wall_seconds}");
         assert!(wall_seconds.is_finite(), "wall_seconds={wall_seconds}");
     }

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::time::Instant;
 
-use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rand::SeedableRng;
 use rstim::error_analyzer::ErrorAnalyzer;
 use rstim::output::write_shots_b8;
 use rstim::sampler::sample_batch;
@@ -11,7 +11,7 @@ use crate::bench::circuit_source::build_circuit_for_point;
 use crate::bench::registry::{BenchCasePoint, BenchRunContext};
 use crate::bench::result::{BenchmarkResultRow, CaseSummary, MetricMap, PairMapExt, ParamMap};
 use crate::decode::Decoder;
-use crate::failure::{FailureKind, classify_completed, classify_error};
+use crate::failure::{classify_completed, classify_error, FailureKind};
 
 pub(crate) mod params;
 pub mod rbposd;

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -1,17 +1,17 @@
 use std::collections::BTreeMap;
 use std::time::Instant;
 
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use rstim::error_analyzer::ErrorAnalyzer;
 use rstim::output::write_shots_b8;
 use rstim::sampler::sample_batch;
 
 use crate::bench::circuit_source::build_circuit_for_point;
 use crate::bench::registry::{BenchCasePoint, BenchRunContext};
-use crate::bench::result::{BenchmarkResultRow, MetricMap, PairMapExt};
+use crate::bench::result::{BenchmarkResultRow, CaseSummary, MetricMap, PairMapExt, ParamMap};
 use crate::decode::Decoder;
-use crate::failure::classify_completed;
+use crate::failure::{FailureKind, classify_completed, classify_error};
 
 pub(crate) mod params;
 pub mod rbposd;
@@ -25,6 +25,82 @@ fn under_wall_budget(total_seconds: f64, max_wall_seconds: Option<f64>) -> bool 
     }
 }
 
+fn benchmark_result_row(
+    ctx: &BenchRunContext,
+    failure_kind: FailureKind,
+    params: ParamMap,
+    case_summary: CaseSummary,
+    metrics: MetricMap,
+    error: Option<String>,
+) -> BenchmarkResultRow {
+    BenchmarkResultRow {
+        benchmark: ctx.benchmark_name.clone(),
+        runner: ctx.runner_name.clone(),
+        language: ctx.language.clone(),
+        status: failure_kind.status().into(),
+        failure_kind,
+        params,
+        case_summary,
+        metrics,
+        artifacts: BTreeMap::new(),
+        error,
+    }
+}
+
+fn merge_decoder_params(mut params: ParamMap, decoder_params: &ParamMap) -> ParamMap {
+    for (key, value) in decoder_params {
+        params.insert(key.clone(), value.clone());
+    }
+    params
+}
+
+fn case_summary_with_progress(
+    mut summary: CaseSummary,
+    num_dets: usize,
+    num_obs: usize,
+    generated_shots: usize,
+) -> CaseSummary {
+    summary.insert("num_dets".into(), serde_json::json!(num_dets));
+    summary.insert("num_obs".into(), serde_json::json!(num_obs));
+    summary.insert(
+        "num_shots_generated".into(),
+        serde_json::json!(generated_shots),
+    );
+    summary
+}
+
+fn benchmark_metrics(
+    shots_used: usize,
+    logical_errors: usize,
+    compile_us: f64,
+    total_decode_us: f64,
+    wall_seconds: f64,
+) -> MetricMap {
+    MetricMap::from_pairs([
+        ("shots_used", shots_used as f64),
+        ("logical_errors", logical_errors as f64),
+        (
+            "logical_error_rate",
+            if shots_used == 0 {
+                0.0
+            } else {
+                logical_errors as f64 / shots_used as f64
+            },
+        ),
+        ("compile_us", compile_us),
+        ("total_decode_us", total_decode_us),
+        ("wall_seconds", wall_seconds),
+        (
+            "decode_us_per_shot",
+            if shots_used == 0 {
+                0.0
+            } else {
+                total_decode_us / shots_used as f64
+            },
+        ),
+    ])
+}
+
 pub(crate) fn run_decoder_point(
     runner_name: &'static str,
     decoder: &dyn Decoder,
@@ -34,18 +110,33 @@ pub(crate) fn run_decoder_point(
 ) -> Result<BenchmarkResultRow, String> {
     let built = build_circuit_for_point(point, &ctx.spec_dir)?;
     let circuit = built.circuit;
+    let result_params = merge_decoder_params(built.params, decoder_params);
+    let base_case_summary = built.case_summary;
     let dem = ErrorAnalyzer::circuit_to_dem_decomposed(&circuit)?;
+    let num_dets = dem.effective_num_detectors();
+    let num_obs = dem.num_observables();
 
     let compile_started = Instant::now();
-    let compiled = decoder.compile_for_dem(&dem)?;
+    let compiled = match decoder.compile_for_dem(&dem) {
+        Ok(compiled) => compiled,
+        Err(error) => {
+            let failure_kind = classify_error(&error, FailureKind::SolverFailure);
+            return Ok(benchmark_result_row(
+                ctx,
+                failure_kind,
+                result_params,
+                case_summary_with_progress(base_case_summary, num_dets, num_obs, 0),
+                benchmark_metrics(0, 0, 0.0, 0.0, 0.0),
+                Some(error),
+            ));
+        }
+    };
     let compile_us = compile_started.elapsed().as_secs_f64() * 1e6;
 
     let max_shots = usize::try_from(point.max_shots)
         .map_err(|_| "max_shots exceeds supported usize range".to_string())?;
     let max_errors = usize::try_from(point.max_errors)
         .map_err(|_| "max_errors exceeds supported usize range".to_string())?;
-    let num_dets = dem.effective_num_detectors();
-    let num_obs = dem.num_observables();
     let obs_bytes = num_obs.div_ceil(8);
 
     let mut rng = StdRng::seed_from_u64(ctx.seed);
@@ -71,20 +162,76 @@ pub(crate) fn run_decoder_point(
 
         let decode_started = Instant::now();
         let predictions =
-            compiled.decode_shots_bit_packed(&dets, batch_shots, num_dets, num_obs)?;
+            match compiled.decode_shots_bit_packed(&dets, batch_shots, num_dets, num_obs) {
+                Ok(predictions) => predictions,
+                Err(error) => {
+                    total_decode_us += decode_started.elapsed().as_secs_f64() * 1e6;
+                    let wall_seconds = wall_seconds + batch_started.elapsed().as_secs_f64();
+                    let failure_kind = classify_error(&error, FailureKind::SolverFailure);
+                    return Ok(benchmark_result_row(
+                        ctx,
+                        failure_kind,
+                        result_params,
+                        case_summary_with_progress(
+                            base_case_summary,
+                            num_dets,
+                            num_obs,
+                            generated_shots,
+                        ),
+                        benchmark_metrics(
+                            shots_used,
+                            logical_errors,
+                            compile_us,
+                            total_decode_us,
+                            wall_seconds,
+                        ),
+                        Some(error),
+                    ));
+                }
+            };
         total_decode_us += decode_started.elapsed().as_secs_f64() * 1e6;
 
         let expected_len = batch_shots * obs_bytes;
         if predictions.len() != expected_len {
-            return Err(format!(
+            let error = format!(
                 "decoder {runner_name} produced {} bytes, expected {expected_len}",
                 predictions.len()
+            );
+            let wall_seconds = wall_seconds + batch_started.elapsed().as_secs_f64();
+            return Ok(benchmark_result_row(
+                ctx,
+                FailureKind::SolverFailure,
+                result_params,
+                case_summary_with_progress(base_case_summary, num_dets, num_obs, generated_shots),
+                benchmark_metrics(
+                    shots_used,
+                    logical_errors,
+                    compile_us,
+                    total_decode_us,
+                    wall_seconds,
+                ),
+                Some(error),
             ));
         }
         if obs.len() != expected_len {
-            return Err(format!(
+            let error = format!(
                 "sampler produced {} observable bytes, expected {expected_len}",
                 obs.len()
+            );
+            let wall_seconds = wall_seconds + batch_started.elapsed().as_secs_f64();
+            return Ok(benchmark_result_row(
+                ctx,
+                FailureKind::SamplerError,
+                result_params,
+                case_summary_with_progress(base_case_summary, num_dets, num_obs, generated_shots),
+                benchmark_metrics(
+                    shots_used,
+                    logical_errors,
+                    compile_us,
+                    total_decode_us,
+                    wall_seconds,
+                ),
+                Some(error),
             ));
         }
 
@@ -102,57 +249,25 @@ pub(crate) fn run_decoder_point(
         wall_seconds += batch_started.elapsed().as_secs_f64();
     }
 
-    let mut result_params = built.params;
-    for (key, value) in decoder_params {
-        result_params.insert(key.clone(), value.clone());
-    }
     let timed_out = matches!(point.max_wall_seconds, Some(max_seconds) if wall_seconds >= max_seconds)
         && shots_used < max_shots
         && logical_errors < max_errors;
+    let failure_kind = classify_completed(logical_errors as u64, timed_out);
 
-    Ok(BenchmarkResultRow {
-        benchmark: ctx.benchmark_name.clone(),
-        runner: ctx.runner_name.clone(),
-        language: ctx.language.clone(),
-        status: "ok".into(),
-        failure_kind: classify_completed(logical_errors as u64, timed_out),
-        params: result_params,
-        case_summary: {
-            let mut summary = built.case_summary;
-            summary.insert("num_dets".into(), serde_json::json!(num_dets));
-            summary.insert("num_obs".into(), serde_json::json!(num_obs));
-            summary.insert(
-                "num_shots_generated".into(),
-                serde_json::json!(generated_shots),
-            );
-            summary
-        },
-        metrics: MetricMap::from_pairs([
-            ("shots_used", shots_used as f64),
-            ("logical_errors", logical_errors as f64),
-            (
-                "logical_error_rate",
-                if shots_used == 0 {
-                    0.0
-                } else {
-                    logical_errors as f64 / shots_used as f64
-                },
-            ),
-            ("compile_us", compile_us),
-            ("total_decode_us", total_decode_us),
-            ("wall_seconds", wall_seconds),
-            (
-                "decode_us_per_shot",
-                if shots_used == 0 {
-                    0.0
-                } else {
-                    total_decode_us / shots_used as f64
-                },
-            ),
-        ]),
-        artifacts: BTreeMap::new(),
-        error: None,
-    })
+    Ok(benchmark_result_row(
+        ctx,
+        failure_kind,
+        result_params,
+        case_summary_with_progress(base_case_summary, num_dets, num_obs, generated_shots),
+        benchmark_metrics(
+            shots_used,
+            logical_errors,
+            compile_us,
+            total_decode_us,
+            wall_seconds,
+        ),
+        None,
+    ))
 }
 
 #[cfg(test)]
@@ -221,6 +336,198 @@ mod tests {
         }
     }
 
+    struct OnePredictionDecoder;
+
+    struct OnePredictionCompiled;
+
+    impl Decoder for OnePredictionDecoder {
+        fn compile_for_dem(
+            &self,
+            _dem: &DetectorErrorModel,
+        ) -> Result<Box<dyn CompiledDecoder>, String> {
+            Ok(Box::new(OnePredictionCompiled))
+        }
+    }
+
+    impl CompiledDecoder for OnePredictionCompiled {
+        fn decode_shots_bit_packed(
+            &self,
+            _dets: &[u8],
+            num_shots: usize,
+            _num_dets: usize,
+            num_obs: usize,
+        ) -> Result<Vec<u8>, String> {
+            let obs_bytes = num_obs.div_ceil(8);
+            Ok(vec![0xffu8; num_shots * obs_bytes])
+        }
+    }
+
+    struct CompileErrorDecoder {
+        message: &'static str,
+    }
+
+    impl Decoder for CompileErrorDecoder {
+        fn compile_for_dem(
+            &self,
+            _dem: &DetectorErrorModel,
+        ) -> Result<Box<dyn CompiledDecoder>, String> {
+            Err(self.message.to_string())
+        }
+    }
+
+    struct DecodeErrorDecoder {
+        message: &'static str,
+    }
+
+    struct DecodeErrorCompiled {
+        message: &'static str,
+    }
+
+    impl Decoder for DecodeErrorDecoder {
+        fn compile_for_dem(
+            &self,
+            _dem: &DetectorErrorModel,
+        ) -> Result<Box<dyn CompiledDecoder>, String> {
+            Ok(Box::new(DecodeErrorCompiled {
+                message: self.message,
+            }))
+        }
+    }
+
+    impl CompiledDecoder for DecodeErrorCompiled {
+        fn decode_shots_bit_packed(
+            &self,
+            _dets: &[u8],
+            _num_shots: usize,
+            _num_dets: usize,
+            _num_obs: usize,
+        ) -> Result<Vec<u8>, String> {
+            Err(self.message.to_string())
+        }
+    }
+
+    fn surface_point(p: f64, max_shots: u64, max_errors: u64) -> BenchCasePoint {
+        BenchCasePoint {
+            input_type: "surface_rotated_memory_x".into(),
+            code_id: None,
+            distance: Some(3),
+            rounds: 3,
+            p,
+            basis: None,
+            schedule: None,
+            hx_path: None,
+            hz_path: None,
+            observables_path: None,
+            max_shots,
+            max_errors,
+            max_wall_seconds: None,
+            batch_size: 1,
+            decoder_params: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn failure_kind_is_structured_for_completed_benchmark_rows() {
+        let ctx = BenchRunContext {
+            benchmark_name: "surface_decoder".into(),
+            runner_name: "fake".into(),
+            language: "rust".into(),
+            seed: 12_345,
+            spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        };
+        let decoder_params = crate::bench::result::ParamMap::new();
+
+        let ok_row = run_decoder_point(
+            "fake",
+            &SlowPredictionDecoder {
+                sleep: Duration::from_millis(0),
+            },
+            &surface_point(0.0, 2, 10),
+            &ctx,
+            &decoder_params,
+        )
+        .unwrap();
+        assert_eq!(ok_row.failure_kind, FailureKind::Ok);
+
+        let logical_row = run_decoder_point(
+            "fake",
+            &OnePredictionDecoder,
+            &surface_point(0.0, 2, 10),
+            &ctx,
+            &decoder_params,
+        )
+        .unwrap();
+        assert_eq!(logical_row.failure_kind, FailureKind::LogicalFailure);
+
+        let mut timeout_point = surface_point(0.0, 20, 20);
+        timeout_point.max_wall_seconds = Some(0.09);
+        let timeout_row = run_decoder_point(
+            "fake",
+            &SlowPredictionDecoder {
+                sleep: Duration::from_millis(35),
+            },
+            &timeout_point,
+            &ctx,
+            &decoder_params,
+        )
+        .unwrap();
+        assert_eq!(timeout_row.failure_kind, FailureKind::Timeout);
+    }
+
+    #[test]
+    fn benchmark_runner_records_compile_failure_as_structured_row() {
+        let ctx = BenchRunContext {
+            benchmark_name: "surface_decoder".into(),
+            runner_name: "fake".into(),
+            language: "rust".into(),
+            seed: 12_345,
+            spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        };
+        let decoder_params = crate::bench::result::ParamMap::new();
+
+        let row = run_decoder_point(
+            "fake",
+            &CompileErrorDecoder {
+                message: "no ILP backend is available for kind Gurobi",
+            },
+            &surface_point(0.002, 1, 1),
+            &ctx,
+            &decoder_params,
+        )
+        .unwrap();
+
+        assert_eq!(row.status, "error");
+        assert_eq!(row.failure_kind, FailureKind::Unsupported);
+        assert!(row.error.unwrap().contains("no ILP backend is available"));
+    }
+
+    #[test]
+    fn benchmark_runner_records_decode_failure_as_structured_row() {
+        let ctx = BenchRunContext {
+            benchmark_name: "surface_decoder".into(),
+            runner_name: "fake".into(),
+            language: "rust".into(),
+            seed: 12_345,
+            spec_dir: std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        };
+        let decoder_params = crate::bench::result::ParamMap::new();
+
+        let row = run_decoder_point(
+            "fake",
+            &DecodeErrorDecoder {
+                message: "HiGHS backend error: solve failed",
+            },
+            &surface_point(0.002, 1, 1),
+            &ctx,
+            &decoder_params,
+        )
+        .unwrap();
+
+        assert_eq!(row.status, "error");
+        assert_eq!(row.failure_kind, FailureKind::SolverFailure);
+        assert!(row.error.unwrap().contains("HiGHS backend error"));
+    }
+
     #[test]
     fn run_decoder_point_rejects_prediction_buffers_with_wrong_length() {
         let point = BenchCasePoint {
@@ -249,16 +556,18 @@ mod tests {
         };
 
         let decoder_params = crate::bench::result::ParamMap::new();
-        let err = run_decoder_point(
+        let row = run_decoder_point(
             "fake",
             &EmptyPredictionDecoder,
             &point,
             &ctx,
             &decoder_params,
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert!(err.contains("decoder fake produced 0 bytes"));
+        assert_eq!(row.status, "error");
+        assert_eq!(row.failure_kind, FailureKind::SolverFailure);
+        assert!(row.error.unwrap().contains("decoder fake produced 0 bytes"));
     }
 
     #[test]

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -120,13 +120,14 @@ pub(crate) fn run_decoder_point(
     let compiled = match decoder.compile_for_dem(&dem) {
         Ok(compiled) => compiled,
         Err(error) => {
+            let compile_us = compile_started.elapsed().as_secs_f64() * 1e6;
             let failure_kind = classify_error(&error, FailureKind::SolverFailure);
             return Ok(benchmark_result_row(
                 ctx,
                 failure_kind,
                 result_params,
                 case_summary_with_progress(base_case_summary, num_dets, num_obs, 0),
-                benchmark_metrics(0, 0, 0.0, 0.0, 0.0),
+                benchmark_metrics(0, 0, compile_us, 0.0, 0.0),
                 Some(error),
             ));
         }
@@ -371,6 +372,7 @@ mod tests {
             &self,
             _dem: &DetectorErrorModel,
         ) -> Result<Box<dyn CompiledDecoder>, String> {
+            thread::sleep(Duration::from_millis(1));
             Err(self.message.to_string())
         }
     }
@@ -498,6 +500,8 @@ mod tests {
 
         assert_eq!(row.status, "error");
         assert_eq!(row.failure_kind, FailureKind::Unsupported);
+        assert!(row.metrics["compile_us"].is_finite());
+        assert!(row.metrics["compile_us"] > 0.0);
         assert!(row.error.unwrap().contains("no ILP backend is available"));
     }
 

--- a/rsinter/src/bench/runners/mod.rs
+++ b/rsinter/src/bench/runners/mod.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::time::Instant;
 
-use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rand::SeedableRng;
 use rstim::error_analyzer::ErrorAnalyzer;
 use rstim::output::write_shots_b8;
 use rstim::sampler::sample_batch;
@@ -37,7 +37,7 @@ pub(crate) fn run_decoder_point(
     let dem = ErrorAnalyzer::circuit_to_dem_decomposed(&circuit)?;
 
     let compile_started = Instant::now();
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem)?;
     let compile_us = compile_started.elapsed().as_secs_f64() * 1e6;
 
     let max_shots = usize::try_from(point.max_shots)
@@ -70,7 +70,8 @@ pub(crate) fn run_decoder_point(
         write_shots_b8(&batch.observable_flips, &mut obs).map_err(|e| e.to_string())?;
 
         let decode_started = Instant::now();
-        let predictions = compiled.decode_shots_bit_packed(&dets, batch_shots, num_dets, num_obs);
+        let predictions =
+            compiled.decode_shots_bit_packed(&dets, batch_shots, num_dets, num_obs)?;
         total_decode_us += decode_started.elapsed().as_secs_f64() * 1e6;
 
         let expected_len = batch_shots * obs_bytes;
@@ -105,10 +106,9 @@ pub(crate) fn run_decoder_point(
     for (key, value) in decoder_params {
         result_params.insert(key.clone(), value.clone());
     }
-    let timed_out =
-        matches!(point.max_wall_seconds, Some(max_seconds) if wall_seconds >= max_seconds)
-            && shots_used < max_shots
-            && logical_errors < max_errors;
+    let timed_out = matches!(point.max_wall_seconds, Some(max_seconds) if wall_seconds >= max_seconds)
+        && shots_used < max_shots
+        && logical_errors < max_errors;
 
     Ok(BenchmarkResultRow {
         benchmark: ctx.benchmark_name.clone(),
@@ -170,8 +170,11 @@ mod tests {
     struct EmptyPredictionCompiled;
 
     impl Decoder for EmptyPredictionDecoder {
-        fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
-            Box::new(EmptyPredictionCompiled)
+        fn compile_for_dem(
+            &self,
+            _dem: &DetectorErrorModel,
+        ) -> Result<Box<dyn CompiledDecoder>, String> {
+            Ok(Box::new(EmptyPredictionCompiled))
         }
     }
 
@@ -182,8 +185,8 @@ mod tests {
             _num_shots: usize,
             _num_dets: usize,
             _num_obs: usize,
-        ) -> Vec<u8> {
-            Vec::new()
+        ) -> Result<Vec<u8>, String> {
+            Ok(Vec::new())
         }
     }
 
@@ -196,8 +199,11 @@ mod tests {
     }
 
     impl Decoder for SlowPredictionDecoder {
-        fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
-            Box::new(SlowPredictionCompiled { sleep: self.sleep })
+        fn compile_for_dem(
+            &self,
+            _dem: &DetectorErrorModel,
+        ) -> Result<Box<dyn CompiledDecoder>, String> {
+            Ok(Box::new(SlowPredictionCompiled { sleep: self.sleep }))
         }
     }
 
@@ -208,10 +214,10 @@ mod tests {
             num_shots: usize,
             _num_dets: usize,
             num_obs: usize,
-        ) -> Vec<u8> {
+        ) -> Result<Vec<u8>, String> {
             thread::sleep(self.sleep);
             let obs_bytes = num_obs.div_ceil(8);
-            vec![0u8; num_shots * obs_bytes]
+            Ok(vec![0u8; num_shots * obs_bytes])
         }
     }
 

--- a/rsinter/src/collect.rs
+++ b/rsinter/src/collect.rs
@@ -11,7 +11,7 @@ use rstim::sampler::sample_batch;
 
 use crate::csv_io;
 use crate::decode::Decoder;
-use crate::failure::FailureKind;
+use crate::failure::{classify_completed, classify_error, FailureKind};
 use crate::task::Task;
 use crate::task_stats::TaskStats;
 
@@ -55,6 +55,215 @@ fn should_continue_collecting(
         && under_wall_budget(total_seconds, max_wall_seconds)
 }
 
+fn make_task_stats(
+    task: &Task,
+    strong_id: String,
+    shots: u64,
+    errors: u64,
+    seconds: f64,
+    failure_kind: FailureKind,
+) -> TaskStats {
+    TaskStats {
+        strong_id,
+        decoder: task.decoder.clone(),
+        metadata: task.metadata.clone(),
+        shots,
+        errors,
+        discards: 0,
+        seconds,
+        failure_kind,
+        custom_counts: HashMap::new(),
+    }
+}
+
+fn collect_one_task(
+    task: &Task,
+    decoders: &HashMap<String, Box<dyn Decoder>>,
+    existing: &HashMap<String, TaskStats>,
+    options: &CollectOptions,
+) -> Result<TaskStats, String> {
+    let strong_id = task.strong_id();
+
+    let mut total_shots: u64 = 0;
+    let mut total_errors: u64 = 0;
+    let mut total_seconds: f64 = 0.0;
+
+    if let Some(prev) = existing.get(&strong_id) {
+        total_shots = prev.shots;
+        total_errors = prev.errors;
+        total_seconds = prev.seconds;
+    }
+
+    let decoder = decoders
+        .get(&task.decoder)
+        .ok_or_else(|| format!("decoder not found: {}", task.decoder))?;
+    let compiled = match decoder.compile_for_dem(&task.dem) {
+        Ok(compiled) => compiled,
+        Err(error) => {
+            let failure_kind = classify_error(&error, FailureKind::SolverFailure);
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds,
+                failure_kind,
+            ));
+        }
+    };
+
+    let num_dets = task.dem.effective_num_detectors();
+    let num_obs = task.dem.num_observables();
+    let obs_bytes_per_shot = (num_obs + 7) / 8;
+
+    let max_shots = task
+        .collection_options
+        .max_shots
+        .or(options.max_shots)
+        .unwrap_or(u64::MAX);
+    let max_errors = task
+        .collection_options
+        .max_errors
+        .or(options.max_errors)
+        .unwrap_or(u64::MAX);
+    let max_wall_seconds = task
+        .collection_options
+        .max_wall_seconds
+        .or(options.max_wall_seconds);
+
+    let mut batch_size = options.start_batch_size;
+    let mut rng = StdRng::from_entropy();
+
+    while should_continue_collecting(
+        total_shots,
+        total_errors,
+        total_seconds,
+        max_shots,
+        max_errors,
+        max_wall_seconds,
+    ) {
+        let remaining = (max_shots - total_shots) as usize;
+        let n = batch_size.min(remaining);
+        if n == 0 {
+            break;
+        }
+
+        let batch_started = Instant::now();
+        let batch = match sample_batch(&task.circuit, n, &mut rng) {
+            Ok(batch) => batch,
+            Err(_) => {
+                return Ok(make_task_stats(
+                    task,
+                    strong_id,
+                    total_shots,
+                    total_errors,
+                    total_seconds + batch_started.elapsed().as_secs_f64(),
+                    FailureKind::SamplerError,
+                ));
+            }
+        };
+
+        let mut det_buf = Vec::new();
+        if write_shots_b8(&batch.detections, &mut det_buf).is_err() {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds + batch_started.elapsed().as_secs_f64(),
+                FailureKind::SamplerError,
+            ));
+        }
+        let mut obs_buf = Vec::new();
+        if write_shots_b8(&batch.observable_flips, &mut obs_buf).is_err() {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds + batch_started.elapsed().as_secs_f64(),
+                FailureKind::SamplerError,
+            ));
+        }
+
+        let predictions = match compiled.decode_shots_bit_packed(&det_buf, n, num_dets, num_obs) {
+            Ok(predictions) => predictions,
+            Err(error) => {
+                let failure_kind = classify_error(&error, FailureKind::SolverFailure);
+                return Ok(make_task_stats(
+                    task,
+                    strong_id,
+                    total_shots,
+                    total_errors,
+                    total_seconds + batch_started.elapsed().as_secs_f64(),
+                    failure_kind,
+                ));
+            }
+        };
+
+        let expected_len = n * obs_bytes_per_shot;
+        if predictions.len() != expected_len {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds + batch_started.elapsed().as_secs_f64(),
+                FailureKind::SolverFailure,
+            ));
+        }
+        if obs_buf.len() != expected_len {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds + batch_started.elapsed().as_secs_f64(),
+                FailureKind::SamplerError,
+            ));
+        }
+
+        let mut batch_errors = 0u64;
+        for shot in 0..n {
+            let offset = shot * obs_bytes_per_shot;
+            let mut mismatch = false;
+            for byte in 0..obs_bytes_per_shot {
+                if predictions[offset + byte] != obs_buf[offset + byte] {
+                    mismatch = true;
+                    break;
+                }
+            }
+            if mismatch {
+                batch_errors += 1;
+            }
+        }
+
+        total_shots += n as u64;
+        total_errors += batch_errors;
+        total_seconds += batch_started.elapsed().as_secs_f64();
+
+        if let Some(max) = options.max_batch_size {
+            batch_size = (batch_size * 2).min(max);
+        } else {
+            batch_size *= 2;
+        }
+    }
+
+    let timed_out = max_wall_seconds.is_some_and(|max_seconds| {
+        total_seconds >= max_seconds && total_shots < max_shots && total_errors < max_errors
+    });
+    let failure_kind = classify_completed(total_errors, timed_out);
+
+    Ok(make_task_stats(
+        task,
+        strong_id,
+        total_shots,
+        total_errors,
+        total_seconds,
+        failure_kind,
+    ))
+}
+
 pub fn collect(
     tasks: Vec<Task>,
     decoders: HashMap<String, Box<dyn Decoder>>,
@@ -90,108 +299,7 @@ pub fn collect(
     let results: Result<Vec<TaskStats>, String> = pool.install(|| {
         tasks
             .par_iter()
-            .map(|task| -> Result<TaskStats, String> {
-                let strong_id = task.strong_id();
-                let compiled = decoders
-                    .get(&task.decoder)
-                    .expect("decoder not found")
-                    .compile_for_dem(&task.dem)?;
-
-                let num_dets = task.dem.effective_num_detectors();
-                let num_obs = task.dem.num_observables();
-                let obs_bytes_per_shot = (num_obs + 7) / 8;
-
-                let mut total_shots: u64 = 0;
-                let mut total_errors: u64 = 0;
-                let mut total_seconds: f64 = 0.0;
-
-                if let Some(prev) = existing.get(&strong_id) {
-                    total_shots = prev.shots;
-                    total_errors = prev.errors;
-                    total_seconds = prev.seconds;
-                }
-
-                let max_shots = task
-                    .collection_options
-                    .max_shots
-                    .or(options.max_shots)
-                    .unwrap_or(u64::MAX);
-                let max_errors = task
-                    .collection_options
-                    .max_errors
-                    .or(options.max_errors)
-                    .unwrap_or(u64::MAX);
-                let max_wall_seconds = task
-                    .collection_options
-                    .max_wall_seconds
-                    .or(options.max_wall_seconds);
-
-                let mut batch_size = options.start_batch_size;
-                let mut rng = StdRng::from_entropy();
-
-                while should_continue_collecting(
-                    total_shots,
-                    total_errors,
-                    total_seconds,
-                    max_shots,
-                    max_errors,
-                    max_wall_seconds,
-                ) {
-                    let remaining = (max_shots - total_shots) as usize;
-                    let n = batch_size.min(remaining);
-                    if n == 0 {
-                        break;
-                    }
-
-                    let batch_started = Instant::now();
-                    let batch = sample_batch(&task.circuit, n, &mut rng).unwrap();
-
-                    let mut det_buf = Vec::new();
-                    write_shots_b8(&batch.detections, &mut det_buf).unwrap();
-                    let mut obs_buf = Vec::new();
-                    write_shots_b8(&batch.observable_flips, &mut obs_buf).unwrap();
-
-                    let predictions =
-                        compiled.decode_shots_bit_packed(&det_buf, n, num_dets, num_obs)?;
-
-                    let mut batch_errors = 0u64;
-                    for shot in 0..n {
-                        let offset = shot * obs_bytes_per_shot;
-                        let mut mismatch = false;
-                        for byte in 0..obs_bytes_per_shot {
-                            if predictions[offset + byte] != obs_buf[offset + byte] {
-                                mismatch = true;
-                                break;
-                            }
-                        }
-                        if mismatch {
-                            batch_errors += 1;
-                        }
-                    }
-
-                    total_shots += n as u64;
-                    total_errors += batch_errors;
-                    total_seconds += batch_started.elapsed().as_secs_f64();
-
-                    if let Some(max) = options.max_batch_size {
-                        batch_size = (batch_size * 2).min(max);
-                    } else {
-                        batch_size *= 2;
-                    }
-                }
-
-                Ok(TaskStats {
-                    strong_id,
-                    decoder: task.decoder.clone(),
-                    metadata: task.metadata.clone(),
-                    shots: total_shots,
-                    errors: total_errors,
-                    discards: 0,
-                    seconds: total_seconds,
-                    failure_kind: FailureKind::Ok,
-                    custom_counts: HashMap::new(),
-                })
-            })
+            .map(|task| collect_one_task(task, &decoders, &existing, options))
             .collect()
     });
     let results = results?;

--- a/rsinter/src/collect.rs
+++ b/rsinter/src/collect.rs
@@ -114,6 +114,7 @@ fn collect_one_task(
 
     let num_dets = task.dem.effective_num_detectors();
     let num_obs = task.dem.num_observables();
+    let det_bytes_per_shot = num_dets.div_ceil(8);
     let obs_bytes_per_shot = (num_obs + 7) / 8;
 
     let max_shots = task
@@ -165,6 +166,16 @@ fn collect_one_task(
 
         let mut det_buf = Vec::new();
         if write_shots_b8(&batch.detections, &mut det_buf).is_err() {
+            return Ok(make_task_stats(
+                task,
+                strong_id,
+                total_shots,
+                total_errors,
+                total_seconds + batch_started.elapsed().as_secs_f64(),
+                FailureKind::SamplerError,
+            ));
+        }
+        if det_buf.len() != n * det_bytes_per_shot {
             return Ok(make_task_stats(
                 task,
                 strong_id,

--- a/rsinter/src/collect.rs
+++ b/rsinter/src/collect.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rand::SeedableRng;
 use rayon::prelude::*;
 
 use rstim::output::write_shots_b8;
@@ -87,15 +87,15 @@ pub fn collect(
         .build()
         .map_err(|e| e.to_string())?;
 
-    let results: Vec<TaskStats> = pool.install(|| {
+    let results: Result<Vec<TaskStats>, String> = pool.install(|| {
         tasks
             .par_iter()
-            .map(|task| {
+            .map(|task| -> Result<TaskStats, String> {
                 let strong_id = task.strong_id();
                 let compiled = decoders
                     .get(&task.decoder)
                     .expect("decoder not found")
-                    .compile_for_dem(&task.dem);
+                    .compile_for_dem(&task.dem)?;
 
                 let num_dets = task.dem.effective_num_detectors();
                 let num_obs = task.dem.num_observables();
@@ -152,7 +152,7 @@ pub fn collect(
                     write_shots_b8(&batch.observable_flips, &mut obs_buf).unwrap();
 
                     let predictions =
-                        compiled.decode_shots_bit_packed(&det_buf, n, num_dets, num_obs);
+                        compiled.decode_shots_bit_packed(&det_buf, n, num_dets, num_obs)?;
 
                     let mut batch_errors = 0u64;
                     for shot in 0..n {
@@ -180,7 +180,7 @@ pub fn collect(
                     }
                 }
 
-                TaskStats {
+                Ok(TaskStats {
                     strong_id,
                     decoder: task.decoder.clone(),
                     metadata: task.metadata.clone(),
@@ -190,10 +190,11 @@ pub fn collect(
                     seconds: total_seconds,
                     failure_kind: FailureKind::Ok,
                     custom_counts: HashMap::new(),
-                }
+                })
             })
             .collect()
     });
+    let results = results?;
 
     // Save to CSV if path specified
     if let Some(ref path) = options.save_resume_filepath {

--- a/rsinter/src/collect.rs
+++ b/rsinter/src/collect.rs
@@ -11,6 +11,7 @@ use rstim::sampler::sample_batch;
 
 use crate::csv_io;
 use crate::decode::Decoder;
+use crate::failure::FailureKind;
 use crate::task::Task;
 use crate::task_stats::TaskStats;
 
@@ -187,6 +188,7 @@ pub fn collect(
                     errors: total_errors,
                     discards: 0,
                     seconds: total_seconds,
+                    failure_kind: FailureKind::Ok,
                     custom_counts: HashMap::new(),
                 }
             })

--- a/rsinter/src/csv_io.rs
+++ b/rsinter/src/csv_io.rs
@@ -35,6 +35,10 @@ pub fn write_csv(stats: &[TaskStats], out: &mut dyn Write) -> Result<(), String>
 }
 
 pub fn read_csv(data: &[u8]) -> Result<Vec<TaskStats>, String> {
+    if data.is_empty() {
+        return Ok(Vec::new());
+    }
+
     let mut rdr = csv::Reader::from_reader(data);
     let headers = rdr.headers().map_err(|e| e.to_string())?.clone();
     let required_index = |name: &str| {

--- a/rsinter/src/csv_io.rs
+++ b/rsinter/src/csv_io.rs
@@ -1,23 +1,34 @@
+use crate::failure::{FailureKind, classify_completed};
 use crate::task_stats::TaskStats;
 use std::io::Write;
 
 pub fn write_csv(stats: &[TaskStats], out: &mut dyn Write) -> Result<(), String> {
     let mut wtr = csv::Writer::from_writer(out);
     wtr.write_record(&[
-        "shots", "errors", "discards", "seconds",
-        "decoder", "strong_id", "json_metadata", "custom_counts",
-    ]).map_err(|e| e.to_string())?;
+        "shots",
+        "errors",
+        "discards",
+        "seconds",
+        "failure_kind",
+        "decoder",
+        "strong_id",
+        "json_metadata",
+        "custom_counts",
+    ])
+    .map_err(|e| e.to_string())?;
     for s in stats {
         wtr.write_record(&[
             s.shots.to_string(),
             s.errors.to_string(),
             s.discards.to_string(),
             format!("{:.4}", s.seconds),
+            s.failure_kind.to_string(),
             s.decoder.clone(),
             s.strong_id.clone(),
             serde_json::to_string(&s.metadata).unwrap_or_default(),
             serde_json::to_string(&s.custom_counts).unwrap_or_default(),
-        ]).map_err(|e| e.to_string())?;
+        ])
+        .map_err(|e| e.to_string())?;
     }
     wtr.flush().map_err(|e| e.to_string())?;
     Ok(())
@@ -25,18 +36,60 @@ pub fn write_csv(stats: &[TaskStats], out: &mut dyn Write) -> Result<(), String>
 
 pub fn read_csv(data: &[u8]) -> Result<Vec<TaskStats>, String> {
     let mut rdr = csv::Reader::from_reader(data);
+    let headers = rdr.headers().map_err(|e| e.to_string())?.clone();
+    let required_index = |name: &str| {
+        headers
+            .iter()
+            .position(|header| header == name)
+            .ok_or_else(|| format!("missing required CSV column: {name}"))
+    };
+
+    let shots_idx = required_index("shots")?;
+    let errors_idx = required_index("errors")?;
+    let discards_idx = required_index("discards")?;
+    let seconds_idx = required_index("seconds")?;
+    let decoder_idx = required_index("decoder")?;
+    let strong_id_idx = required_index("strong_id")?;
+    let metadata_idx = required_index("json_metadata")?;
+    let custom_counts_idx = required_index("custom_counts")?;
+    let failure_kind_idx = headers.iter().position(|header| header == "failure_kind");
+
     let mut results = Vec::new();
     for record in rdr.records() {
         let r = record.map_err(|e| e.to_string())?;
+        let get = |idx: usize, name: &str| {
+            r.get(idx)
+                .ok_or_else(|| format!("missing CSV value for column: {name}"))
+        };
+        let shots = get(shots_idx, "shots")?
+            .parse()
+            .map_err(|e: std::num::ParseIntError| e.to_string())?;
+        let errors = get(errors_idx, "errors")?
+            .parse()
+            .map_err(|e: std::num::ParseIntError| e.to_string())?;
+        let discards = get(discards_idx, "discards")?
+            .parse()
+            .map_err(|e: std::num::ParseIntError| e.to_string())?;
+        let seconds = get(seconds_idx, "seconds")?
+            .parse()
+            .map_err(|e: std::num::ParseFloatError| e.to_string())?;
+        let failure_kind = match failure_kind_idx {
+            Some(idx) => get(idx, "failure_kind")?.parse::<FailureKind>()?,
+            None => classify_completed(errors, false),
+        };
+
         results.push(TaskStats {
-            shots: r[0].parse().map_err(|e: std::num::ParseIntError| e.to_string())?,
-            errors: r[1].parse().map_err(|e: std::num::ParseIntError| e.to_string())?,
-            discards: r[2].parse().map_err(|e: std::num::ParseIntError| e.to_string())?,
-            seconds: r[3].parse().map_err(|e: std::num::ParseFloatError| e.to_string())?,
-            decoder: r[4].to_string(),
-            strong_id: r[5].to_string(),
-            metadata: serde_json::from_str(&r[6]).unwrap_or(serde_json::Value::Null),
-            custom_counts: serde_json::from_str(&r[7]).unwrap_or_default(),
+            shots,
+            errors,
+            discards,
+            seconds,
+            decoder: get(decoder_idx, "decoder")?.to_string(),
+            strong_id: get(strong_id_idx, "strong_id")?.to_string(),
+            metadata: serde_json::from_str(get(metadata_idx, "json_metadata")?)
+                .unwrap_or(serde_json::Value::Null),
+            failure_kind,
+            custom_counts: serde_json::from_str(get(custom_counts_idx, "custom_counts")?)
+                .unwrap_or_default(),
         });
     }
     Ok(results)

--- a/rsinter/src/csv_io.rs
+++ b/rsinter/src/csv_io.rs
@@ -1,4 +1,4 @@
-use crate::failure::{FailureKind, classify_completed};
+use crate::failure::{classify_completed, FailureKind};
 use crate::task_stats::TaskStats;
 use std::io::Write;
 

--- a/rsinter/src/decode.rs
+++ b/rsinter/src/decode.rs
@@ -14,11 +14,12 @@ pub trait CompiledDecoder: Send {
         num_shots: usize,
         num_dets: usize,
         num_obs: usize,
-    ) -> Vec<u8>;
+    ) -> Result<Vec<u8>, String>;
 }
 
 pub trait Decoder: Send + Sync {
-    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder>;
+    fn compile_for_dem(&self, dem: &DetectorErrorModel)
+        -> Result<Box<dyn CompiledDecoder>, String>;
 }
 
 /// Always predicts no observable flips. Useful for testing the pipeline.
@@ -33,14 +34,17 @@ impl CompiledDecoder for VacuousCompiled {
         num_shots: usize,
         _num_dets: usize,
         num_obs: usize,
-    ) -> Vec<u8> {
+    ) -> Result<Vec<u8>, String> {
         let obs_bytes = (num_obs + 7) / 8;
-        vec![0u8; num_shots * obs_bytes]
+        Ok(vec![0u8; num_shots * obs_bytes])
     }
 }
 
 impl Decoder for VacuousDecoder {
-    fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
-        Box::new(VacuousCompiled)
+    fn compile_for_dem(
+        &self,
+        _dem: &DetectorErrorModel,
+    ) -> Result<Box<dyn CompiledDecoder>, String> {
+        Ok(Box::new(VacuousCompiled))
     }
 }

--- a/rsinter/src/failure.rs
+++ b/rsinter/src/failure.rs
@@ -103,3 +103,58 @@ fn failure_priority(kind: FailureKind) -> u8 {
         FailureKind::Unsupported => 5,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn failure_kind_status_groups_completed_and_error_kinds() {
+        assert_eq!(FailureKind::Ok.status(), "ok");
+        assert_eq!(FailureKind::LogicalFailure.status(), "ok");
+        assert_eq!(FailureKind::Timeout.status(), "ok");
+        assert_eq!(FailureKind::SolverFailure.status(), "error");
+        assert_eq!(FailureKind::Unsupported.status(), "error");
+        assert_eq!(FailureKind::SamplerError.status(), "error");
+    }
+
+    #[test]
+    fn failure_kind_parses_snake_case_values() {
+        assert_eq!(FailureKind::from_str("ok").unwrap(), FailureKind::Ok);
+        assert_eq!(
+            FailureKind::from_str("logical_failure").unwrap(),
+            FailureKind::LogicalFailure
+        );
+        assert_eq!(
+            FailureKind::from_str("solver_failure").unwrap(),
+            FailureKind::SolverFailure
+        );
+        assert!(FailureKind::from_str("logical-failure").is_err());
+    }
+
+    #[test]
+    fn classify_completed_prioritizes_timeout_then_logical_failure() {
+        assert_eq!(classify_completed(0, false), FailureKind::Ok);
+        assert_eq!(classify_completed(1, false), FailureKind::LogicalFailure);
+        assert_eq!(classify_completed(0, true), FailureKind::Timeout);
+        assert_eq!(classify_completed(1, true), FailureKind::Timeout);
+    }
+
+    #[test]
+    fn combine_failure_kind_uses_failure_priority_order() {
+        assert_eq!(
+            combine_failure_kind(FailureKind::Ok, FailureKind::LogicalFailure),
+            FailureKind::LogicalFailure
+        );
+        assert_eq!(
+            combine_failure_kind(FailureKind::Timeout, FailureKind::SamplerError),
+            FailureKind::SamplerError
+        );
+        assert_eq!(
+            combine_failure_kind(FailureKind::SolverFailure, FailureKind::Unsupported),
+            FailureKind::Unsupported
+        );
+    }
+}

--- a/rsinter/src/failure.rs
+++ b/rsinter/src/failure.rs
@@ -1,0 +1,105 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKind {
+    Ok,
+    LogicalFailure,
+    Timeout,
+    SolverFailure,
+    Unsupported,
+    SamplerError,
+}
+
+impl Default for FailureKind {
+    fn default() -> Self {
+        Self::Ok
+    }
+}
+
+impl FailureKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::LogicalFailure => "logical_failure",
+            Self::Timeout => "timeout",
+            Self::SolverFailure => "solver_failure",
+            Self::Unsupported => "unsupported",
+            Self::SamplerError => "sampler_error",
+        }
+    }
+
+    pub fn status(self) -> &'static str {
+        match self {
+            Self::Ok | Self::LogicalFailure | Self::Timeout => "ok",
+            Self::SolverFailure | Self::Unsupported | Self::SamplerError => "error",
+        }
+    }
+}
+
+impl std::fmt::Display for FailureKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for FailureKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ok" => Ok(Self::Ok),
+            "logical_failure" => Ok(Self::LogicalFailure),
+            "timeout" => Ok(Self::Timeout),
+            "solver_failure" => Ok(Self::SolverFailure),
+            "unsupported" => Ok(Self::Unsupported),
+            "sampler_error" => Ok(Self::SamplerError),
+            other => Err(format!("unknown failure_kind: {other}")),
+        }
+    }
+}
+
+pub fn classify_completed(logical_errors: u64, timed_out: bool) -> FailureKind {
+    if timed_out {
+        FailureKind::Timeout
+    } else if logical_errors > 0 {
+        FailureKind::LogicalFailure
+    } else {
+        FailureKind::Ok
+    }
+}
+
+pub fn classify_error(message: &str, fallback: FailureKind) -> FailureKind {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("backendunavailable")
+        || lower.contains("backend unavailable")
+        || lower.contains("backend is unavailable")
+        || lower.contains("no ilp backend is available")
+        || lower.contains("unsupported")
+    {
+        FailureKind::Unsupported
+    } else {
+        fallback
+    }
+}
+
+pub fn combine_failure_kind(a: FailureKind, b: FailureKind) -> FailureKind {
+    if failure_priority(a) >= failure_priority(b) {
+        a
+    } else {
+        b
+    }
+}
+
+fn failure_priority(kind: FailureKind) -> u8 {
+    match kind {
+        FailureKind::Ok => 0,
+        FailureKind::LogicalFailure => 1,
+        FailureKind::Timeout => 2,
+        FailureKind::SamplerError => 3,
+        FailureKind::SolverFailure => 4,
+        FailureKind::Unsupported => 5,
+    }
+}

--- a/rsinter/src/failure.rs
+++ b/rsinter/src/failure.rs
@@ -121,6 +121,17 @@ mod tests {
     }
 
     #[test]
+    fn failure_kind_default_and_display_cover_all_variants() {
+        assert_eq!(FailureKind::default(), FailureKind::Ok);
+        assert_eq!(FailureKind::Ok.to_string(), "ok");
+        assert_eq!(FailureKind::LogicalFailure.to_string(), "logical_failure");
+        assert_eq!(FailureKind::Timeout.to_string(), "timeout");
+        assert_eq!(FailureKind::SolverFailure.to_string(), "solver_failure");
+        assert_eq!(FailureKind::Unsupported.to_string(), "unsupported");
+        assert_eq!(FailureKind::SamplerError.to_string(), "sampler_error");
+    }
+
+    #[test]
     fn failure_kind_parses_snake_case_values() {
         assert_eq!(FailureKind::from_str("ok").unwrap(), FailureKind::Ok);
         assert_eq!(

--- a/rsinter/src/ilpqec_adapter.rs
+++ b/rsinter/src/ilpqec_adapter.rs
@@ -26,10 +26,13 @@ struct CompiledIlpDemDecoder {
 }
 
 impl Decoder for IlpDemDecoder {
-    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
+    fn compile_for_dem(
+        &self,
+        dem: &DetectorErrorModel,
+    ) -> Result<Box<dyn CompiledDecoder>, String> {
         let decoder = rilpqec::IlpDemDecoder::from_dem(dem, self.config.clone())
-            .expect("failed to compile ILP DEM decoder");
-        Box::new(CompiledIlpDemDecoder { decoder })
+            .map_err(|error| error.to_string())?;
+        Ok(Box::new(CompiledIlpDemDecoder { decoder }))
     }
 }
 
@@ -40,9 +43,9 @@ impl CompiledDecoder for CompiledIlpDemDecoder {
         num_shots: usize,
         num_dets: usize,
         num_obs: usize,
-    ) -> Vec<u8> {
+    ) -> Result<Vec<u8>, String> {
         self.decoder
             .decode_batch_bit_packed(dets, num_shots, num_dets, num_obs)
-            .expect("ILP DEM decode failed")
+            .map_err(|error| error.to_string())
     }
 }

--- a/rsinter/src/lib.rs
+++ b/rsinter/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bench;
 pub mod collect;
 pub mod csv_io;
 pub mod decode;
+pub mod failure;
 pub mod plot;
 pub mod stats;
 pub mod task;

--- a/rsinter/src/plot.rs
+++ b/rsinter/src/plot.rs
@@ -240,6 +240,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::failure::FailureKind;
     use crate::stats::shot_error_rate_to_piece_error_rate;
     use std::collections::HashMap;
     use tempfile::tempdir;
@@ -253,6 +254,7 @@ mod tests {
             errors,
             discards: 0,
             seconds: 0.0,
+            failure_kind: FailureKind::Ok,
             custom_counts: HashMap::new(),
         }
     }

--- a/rsinter/src/rbposd_adapter.rs
+++ b/rsinter/src/rbposd_adapter.rs
@@ -25,7 +25,10 @@ struct CompiledRbposdDemDecoder {
 }
 
 impl Decoder for RbposdDemDecoder {
-    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
+    fn compile_for_dem(
+        &self,
+        dem: &DetectorErrorModel,
+    ) -> Result<Box<dyn CompiledDecoder>, String> {
         let (detector_columns, probabilities, observable_columns, num_dets, num_obs) =
             dem_to_matrix_problem(dem);
 
@@ -70,7 +73,7 @@ impl Decoder for RbposdDemDecoder {
                 filtered_detector_columns.len(),
                 filtered_detector_columns,
             )
-            .expect("generated DEM matrix should be valid");
+            .map_err(|error| format!("invalid rbposd parity matrix: {error}"))?;
 
             Some(
                 BpOsdDecoder::new(
@@ -78,18 +81,18 @@ impl Decoder for RbposdDemDecoder {
                     ChannelModel::BitFlipProbabilities(filtered_probabilities),
                     self.config.clone(),
                 )
-                .expect("DEM lowering produced an invalid rbposd problem"),
+                .map_err(|error| format!("failed to compile rbposd decoder: {error}"))?,
             )
         };
 
-        Box::new(CompiledRbposdDemDecoder {
+        Ok(Box::new(CompiledRbposdDemDecoder {
             decoder,
             num_dets,
             num_obs,
             observable_columns: filtered_observable_columns,
             forced_syndrome,
             baseline_observables,
-        })
+        }))
     }
 }
 
@@ -100,7 +103,7 @@ impl CompiledDecoder for CompiledRbposdDemDecoder {
         num_shots: usize,
         num_dets: usize,
         num_obs: usize,
-    ) -> Vec<u8> {
+    ) -> Result<Vec<u8>, String> {
         let det_bytes = num_dets.div_ceil(8);
         let obs_bytes = num_obs.div_ceil(8);
         let mut out = vec![0u8; num_shots * obs_bytes];
@@ -119,7 +122,7 @@ impl CompiledDecoder for CompiledRbposdDemDecoder {
             if let Some(decoder) = &self.decoder {
                 let result = decoder
                     .decode(&Syndrome::from(syndrome_bits))
-                    .expect("rbposd decode failed");
+                    .map_err(|error| format!("rbposd decode failed: {error}"))?;
                 let decoded_observables = correction_to_observables(
                     &result.correction,
                     &self.observable_columns,
@@ -135,7 +138,7 @@ impl CompiledDecoder for CompiledRbposdDemDecoder {
             }
         }
 
-        out
+        Ok(out)
     }
 }
 
@@ -298,6 +301,9 @@ mod tests {
         assert_eq!(num_obs, 1);
         assert_eq!(detector_columns, vec![vec![1, 2], vec![4, 5]]);
         assert_eq!(probabilities, vec![0.25, 0.25]);
-        assert_eq!(observable_columns, vec![Vec::<usize>::new(), Vec::<usize>::new()]);
+        assert_eq!(
+            observable_columns,
+            vec![Vec::<usize>::new(), Vec::<usize>::new()]
+        );
     }
 }

--- a/rsinter/src/rmatching_adapter.rs
+++ b/rsinter/src/rmatching_adapter.rs
@@ -12,12 +12,14 @@ struct CompiledRmatchingDemDecoder {
 }
 
 impl Decoder for RmatchingDemDecoder {
-    fn compile_for_dem(&self, dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
-        let matching =
-            Matching::from_dem(&dem.to_string()).expect("failed to compile rmatching decoder");
-        Box::new(CompiledRmatchingDemDecoder {
+    fn compile_for_dem(
+        &self,
+        dem: &DetectorErrorModel,
+    ) -> Result<Box<dyn CompiledDecoder>, String> {
+        let matching = Matching::from_dem(&dem.to_string()).map_err(|error| error.to_string())?;
+        Ok(Box::new(CompiledRmatchingDemDecoder {
             matching: Mutex::new(matching),
-        })
+        }))
     }
 }
 
@@ -28,10 +30,11 @@ impl CompiledDecoder for CompiledRmatchingDemDecoder {
         num_shots: usize,
         num_dets: usize,
         num_obs: usize,
-    ) -> Vec<u8> {
-        self.matching
+    ) -> Result<Vec<u8>, String> {
+        Ok(self
+            .matching
             .lock()
-            .unwrap()
-            .decode_shots_bit_packed(dets, num_shots, num_dets, num_obs)
+            .map_err(|error| error.to_string())?
+            .decode_shots_bit_packed(dets, num_shots, num_dets, num_obs))
     }
 }

--- a/rsinter/src/task_stats.rs
+++ b/rsinter/src/task_stats.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::Add;
-use serde::{Serialize, Deserialize};
+
+use crate::failure::{FailureKind, combine_failure_kind};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TaskStats {
@@ -11,6 +13,8 @@ pub struct TaskStats {
     pub errors: u64,
     pub discards: u64,
     pub seconds: f64,
+    #[serde(default)]
+    pub failure_kind: FailureKind,
     pub custom_counts: HashMap<String, u64>,
 }
 
@@ -29,6 +33,7 @@ impl Add for TaskStats {
             errors: self.errors + rhs.errors,
             discards: self.discards + rhs.discards,
             seconds: self.seconds + rhs.seconds,
+            failure_kind: combine_failure_kind(self.failure_kind, rhs.failure_kind),
             custom_counts: counts,
         }
     }

--- a/rsinter/src/task_stats.rs
+++ b/rsinter/src/task_stats.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::Add;
 
-use crate::failure::{FailureKind, combine_failure_kind};
+use crate::failure::{combine_failure_kind, FailureKind};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TaskStats {

--- a/rsinter/tests/bench_merge.rs
+++ b/rsinter/tests/bench_merge.rs
@@ -1,5 +1,6 @@
 use rsinter::bench::merge::merge_result_rows;
 use rsinter::bench::result::{BenchmarkResultRow, CaseSummary, MetricMap, PairMapExt, ParamMap};
+use rsinter::failure::FailureKind;
 
 #[test]
 fn merge_result_rows_concatenates_and_sorts_by_runner_then_distance_then_p() {
@@ -9,6 +10,7 @@ fn merge_result_rows_concatenates_and_sorts_by_runner_then_distance_then_p() {
             runner: "pymatching".into(),
             language: "python".into(),
             status: "ok".into(),
+            failure_kind: FailureKind::Ok,
             params: ParamMap::from_pairs([
                 ("distance", serde_json::json!(5)),
                 ("p", serde_json::json!(0.005)),
@@ -23,6 +25,7 @@ fn merge_result_rows_concatenates_and_sorts_by_runner_then_distance_then_p() {
             runner: "rmatching".into(),
             language: "rust".into(),
             status: "ok".into(),
+            failure_kind: FailureKind::Ok,
             params: ParamMap::from_pairs([
                 ("distance", serde_json::json!(3)),
                 ("p", serde_json::json!(0.002)),

--- a/rsinter/tests/bench_plot.rs
+++ b/rsinter/tests/bench_plot.rs
@@ -1,6 +1,7 @@
 use rsinter::bench::plot::render_benchmark_plot;
 use rsinter::bench::result::{BenchmarkResultRow, CaseSummary, MetricMap, PairMapExt, ParamMap};
 use rsinter::bench::spec::BenchmarkSpec;
+use rsinter::failure::FailureKind;
 
 #[test]
 fn render_benchmark_plot_writes_svg_for_ok_rows() {
@@ -49,6 +50,7 @@ label = "Logical Error Rate"
             runner: "rmatching".into(),
             language: "rust".into(),
             status: "ok".into(),
+            failure_kind: FailureKind::LogicalFailure,
             params: ParamMap::from_pairs([
                 ("distance", serde_json::json!(3)),
                 ("p", serde_json::json!(0.002)),
@@ -67,6 +69,7 @@ label = "Logical Error Rate"
             runner: "rmatching".into(),
             language: "rust".into(),
             status: "ok".into(),
+            failure_kind: FailureKind::LogicalFailure,
             params: ParamMap::from_pairs([
                 ("distance", serde_json::json!(3)),
                 ("p", serde_json::json!(0.005)),
@@ -139,6 +142,7 @@ label = "Decode Time Per Shot"
         runner: "rmatching".into(),
         language: "rust".into(),
         status: "ok".into(),
+        failure_kind: FailureKind::LogicalFailure,
         params: ParamMap::from_pairs([
             ("distance", serde_json::json!(3)),
             ("p", serde_json::json!(0.002)),
@@ -207,6 +211,7 @@ label = "Logical Error Rate"
         runner: "rmatching".into(),
         language: "rust".into(),
         status: "error".into(),
+        failure_kind: FailureKind::SolverFailure,
         params: ParamMap::from_pairs([
             ("distance", serde_json::json!(3)),
             ("p", serde_json::json!(0.002)),
@@ -270,6 +275,7 @@ label = "Logical Error Rate"
         runner: "rmatching".into(),
         language: "rust".into(),
         status: "ok".into(),
+        failure_kind: FailureKind::Ok,
         params: ParamMap::from_pairs([
             ("distance", serde_json::json!(3)),
             ("p", serde_json::json!(0.002)),
@@ -338,6 +344,7 @@ label = "Decode Time Per Shot"
             runner: "rmatching".into(),
             language: "rust".into(),
             status: "ok".into(),
+            failure_kind: FailureKind::LogicalFailure,
             params: ParamMap::from_pairs([
                 ("distance", serde_json::json!(3)),
                 ("p", serde_json::json!(0.002)),
@@ -357,6 +364,7 @@ label = "Decode Time Per Shot"
             runner: "rmatching".into(),
             language: "rust".into(),
             status: "ok".into(),
+            failure_kind: FailureKind::LogicalFailure,
             params: ParamMap::from_pairs([
                 ("distance", serde_json::json!(3)),
                 ("p", serde_json::json!(0.005)),
@@ -814,6 +822,11 @@ fn ok_row(
         runner: runner.into(),
         language: "rust".into(),
         status: "ok".into(),
+        failure_kind: if logical_errors > 0.0 {
+            FailureKind::LogicalFailure
+        } else {
+            FailureKind::Ok
+        },
         params: ParamMap::from_pairs([
             ("distance", serde_json::json!(distance)),
             ("p", serde_json::json!(p)),

--- a/rsinter/tests/bench_result.rs
+++ b/rsinter/tests/bench_result.rs
@@ -164,3 +164,24 @@ fn results_jsonl_infers_missing_failure_kind_from_legacy_timeout_row() {
 
     assert_eq!(rows[0].failure_kind, FailureKind::Timeout);
 }
+
+#[test]
+fn results_jsonl_does_not_infer_timeout_when_legacy_rows_hit_caps() {
+    let input = concat!(
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"shot_cap\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{\"max_wall_seconds\":0.25,\"max_shots\":100,\"max_errors\":20},",
+        "\"case_summary\":{},",
+        "\"metrics\":{\"wall_seconds\":0.25,\"shots_used\":100.0,\"logical_errors\":0.0},",
+        "\"artifacts\":{},\"error\":null}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"error_cap\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{\"max_wall_seconds\":0.25,\"max_shots\":100,\"max_errors\":20},",
+        "\"case_summary\":{},",
+        "\"metrics\":{\"wall_seconds\":0.25,\"shots_used\":40.0,\"logical_errors\":20.0},",
+        "\"artifacts\":{},\"error\":null}\n"
+    );
+
+    let rows = read_results_jsonl(input.as_bytes()).unwrap();
+
+    assert_eq!(rows[0].failure_kind, FailureKind::Ok);
+    assert_eq!(rows[1].failure_kind, FailureKind::LogicalFailure);
+}

--- a/rsinter/tests/bench_result.rs
+++ b/rsinter/tests/bench_result.rs
@@ -150,3 +150,17 @@ fn results_jsonl_infers_missing_failure_kind_from_legacy_rows() {
     assert_eq!(rows[2].failure_kind, FailureKind::SolverFailure);
     assert_eq!(rows[3].failure_kind, FailureKind::Unsupported);
 }
+
+#[test]
+fn results_jsonl_infers_missing_failure_kind_from_legacy_timeout_row() {
+    let input = concat!(
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"timeout\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{\"max_wall_seconds\":0.25},\"case_summary\":{},",
+        "\"metrics\":{\"wall_seconds\":0.25,\"logical_errors\":0.0},",
+        "\"artifacts\":{},\"error\":null}\n"
+    );
+
+    let rows = read_results_jsonl(input.as_bytes()).unwrap();
+
+    assert_eq!(rows[0].failure_kind, FailureKind::Timeout);
+}

--- a/rsinter/tests/bench_result.rs
+++ b/rsinter/tests/bench_result.rs
@@ -166,6 +166,20 @@ fn results_jsonl_infers_missing_failure_kind_from_legacy_timeout_row() {
 }
 
 #[test]
+fn results_jsonl_does_not_infer_timeout_without_wall_seconds_metric() {
+    let input = concat!(
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"missing_wall\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{\"max_wall_seconds\":0.25},\"case_summary\":{},",
+        "\"metrics\":{\"logical_errors\":0.0},",
+        "\"artifacts\":{},\"error\":null}\n"
+    );
+
+    let rows = read_results_jsonl(input.as_bytes()).unwrap();
+
+    assert_eq!(rows[0].failure_kind, FailureKind::Ok);
+}
+
+#[test]
 fn results_jsonl_does_not_infer_timeout_when_legacy_rows_hit_caps() {
     let input = concat!(
         "{\"benchmark\":\"surface_decoder\",\"runner\":\"shot_cap\",\"language\":\"rust\",\"status\":\"ok\",",

--- a/rsinter/tests/bench_result.rs
+++ b/rsinter/tests/bench_result.rs
@@ -1,6 +1,6 @@
 use rsinter::bench::result::{
-    BenchmarkResultRow, CaseSummary, MetricMap, PairMapExt, ParamMap, RunManifest,
-    read_results_jsonl, write_results_jsonl,
+    read_results_jsonl, write_results_jsonl, BenchmarkResultRow, CaseSummary, MetricMap,
+    PairMapExt, ParamMap, RunManifest,
 };
 use rsinter::failure::FailureKind;
 

--- a/rsinter/tests/bench_result.rs
+++ b/rsinter/tests/bench_result.rs
@@ -152,6 +152,29 @@ fn results_jsonl_infers_missing_failure_kind_from_legacy_rows() {
 }
 
 #[test]
+fn results_jsonl_preserves_explicit_failure_kind_over_legacy_inference() {
+    let input = concat!(
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"explicit_timeout\",\"language\":\"rust\",",
+        "\"status\":\"ok\",\"failure_kind\":\"timeout\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{\"logical_errors\":0.0},",
+        "\"artifacts\":{},\"error\":null}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"explicit_sampler\",\"language\":\"rust\",",
+        "\"status\":\"error\",\"failure_kind\":\"sampler_error\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{},",
+        "\"artifacts\":{},\"error\":\"sample failed\"}\n"
+    );
+
+    let rows = read_results_jsonl(input.as_bytes()).unwrap();
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].status, "ok");
+    assert_eq!(rows[0].failure_kind, FailureKind::Timeout);
+    assert_eq!(rows[1].status, "error");
+    assert_eq!(rows[1].failure_kind, FailureKind::SamplerError);
+    assert_eq!(rows[1].error.as_deref(), Some("sample failed"));
+}
+
+#[test]
 fn results_jsonl_infers_missing_failure_kind_from_legacy_timeout_row() {
     let input = concat!(
         "{\"benchmark\":\"surface_decoder\",\"runner\":\"timeout\",\"language\":\"rust\",\"status\":\"ok\",",

--- a/rsinter/tests/bench_result.rs
+++ b/rsinter/tests/bench_result.rs
@@ -180,6 +180,29 @@ fn results_jsonl_does_not_infer_timeout_without_wall_seconds_metric() {
 }
 
 #[test]
+fn results_jsonl_keeps_more_legacy_timeout_edges_as_non_timeouts() {
+    let input = concat!(
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"no_limit\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{},\"case_summary\":{},",
+        "\"metrics\":{\"wall_seconds\":99.0,\"logical_errors\":0.0},",
+        "\"artifacts\":{},\"error\":null}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"under_limit\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{\"max_wall_seconds\":0.25},\"case_summary\":{},",
+        "\"metrics\":{\"wall_seconds\":0.24,\"logical_errors\":0.0},",
+        "\"artifacts\":{},\"error\":null}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"error_without_message\",\"language\":\"rust\",",
+        "\"status\":\"error\",\"params\":{},\"case_summary\":{},\"metrics\":{},",
+        "\"artifacts\":{},\"error\":null}\n"
+    );
+
+    let rows = read_results_jsonl(input.as_bytes()).unwrap();
+
+    assert_eq!(rows[0].failure_kind, FailureKind::Ok);
+    assert_eq!(rows[1].failure_kind, FailureKind::Ok);
+    assert_eq!(rows[2].failure_kind, FailureKind::SolverFailure);
+}
+
+#[test]
 fn results_jsonl_does_not_infer_timeout_when_legacy_rows_hit_caps() {
     let input = concat!(
         "{\"benchmark\":\"surface_decoder\",\"runner\":\"shot_cap\",\"language\":\"rust\",\"status\":\"ok\",",

--- a/rsinter/tests/bench_result.rs
+++ b/rsinter/tests/bench_result.rs
@@ -1,13 +1,8 @@
 use rsinter::bench::result::{
-    read_results_jsonl,
-    write_results_jsonl,
-    BenchmarkResultRow,
-    CaseSummary,
-    MetricMap,
-    PairMapExt,
-    ParamMap,
-    RunManifest,
+    BenchmarkResultRow, CaseSummary, MetricMap, PairMapExt, ParamMap, RunManifest,
+    read_results_jsonl, write_results_jsonl,
 };
+use rsinter::failure::FailureKind;
 
 #[test]
 fn result_row_serializes_round_trip_as_json() {
@@ -16,6 +11,7 @@ fn result_row_serializes_round_trip_as_json() {
         runner: "rmatching".into(),
         language: "rust".into(),
         status: "ok".into(),
+        failure_kind: FailureKind::Ok,
         params: ParamMap::from_pairs([
             ("distance", serde_json::json!(3)),
             ("p", serde_json::json!(0.002)),
@@ -24,10 +20,7 @@ fn result_row_serializes_round_trip_as_json() {
             ("num_dets", serde_json::json!(24)),
             ("num_obs", serde_json::json!(1)),
         ]),
-        metrics: MetricMap::from_pairs([
-            ("shots_used", 2000.0),
-            ("logical_error_rate", 0.001),
-        ]),
+        metrics: MetricMap::from_pairs([("shots_used", 2000.0), ("logical_error_rate", 0.001)]),
         artifacts: std::collections::BTreeMap::new(),
         error: None,
     };
@@ -36,6 +29,28 @@ fn result_row_serializes_round_trip_as_json() {
     let decoded: BenchmarkResultRow = serde_json::from_str(&encoded).unwrap();
     assert_eq!(decoded.runner, "rmatching");
     assert_eq!(decoded.metrics["logical_error_rate"], 0.001);
+}
+
+#[test]
+fn result_row_serializes_failure_kind_as_snake_case() {
+    let row = BenchmarkResultRow {
+        benchmark: "surface_decoder".into(),
+        runner: "rmatching".into(),
+        language: "rust".into(),
+        status: "ok".into(),
+        failure_kind: FailureKind::LogicalFailure,
+        params: ParamMap::from_pairs([("distance", serde_json::json!(3))]),
+        case_summary: CaseSummary::new(),
+        metrics: MetricMap::from_pairs([("logical_errors", 2.0)]),
+        artifacts: std::collections::BTreeMap::new(),
+        error: None,
+    };
+
+    let encoded = serde_json::to_string(&row).unwrap();
+    assert!(encoded.contains("\"failure_kind\":\"logical_failure\""));
+
+    let decoded: BenchmarkResultRow = serde_json::from_str(&encoded).unwrap();
+    assert_eq!(decoded.failure_kind, FailureKind::LogicalFailure);
 }
 
 #[test]
@@ -62,6 +77,7 @@ fn results_jsonl_round_trip_multiple_rows() {
             runner: "rmatching".into(),
             language: "rust".into(),
             status: "ok".into(),
+            failure_kind: FailureKind::Ok,
             params: ParamMap::from_pairs([("distance", serde_json::json!(3))]),
             case_summary: CaseSummary::from_pairs([("num_dets", serde_json::json!(24))]),
             metrics: MetricMap::from_pairs([("shots_used", 2000.0)]),
@@ -73,6 +89,7 @@ fn results_jsonl_round_trip_multiple_rows() {
             runner: "pymatching".into(),
             language: "python".into(),
             status: "error".into(),
+            failure_kind: FailureKind::SolverFailure,
             params: ParamMap::from_pairs([("distance", serde_json::json!(5))]),
             case_summary: CaseSummary::from_pairs([("num_dets", serde_json::json!(120))]),
             metrics: MetricMap::from_pairs([("shots_used", 0.0)]),
@@ -107,4 +124,29 @@ fn results_jsonl_ignores_blank_lines() {
     assert_eq!(decoded.len(), 2);
     assert_eq!(decoded[0].runner, "rmatching");
     assert_eq!(decoded[1].runner, "pymatching");
+}
+
+#[test]
+fn results_jsonl_infers_missing_failure_kind_from_legacy_rows() {
+    let input = concat!(
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"clean\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{\"logical_errors\":0.0},",
+        "\"artifacts\":{},\"error\":null}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"logical\",\"language\":\"rust\",\"status\":\"ok\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{\"logical_errors\":3.0},",
+        "\"artifacts\":{},\"error\":null}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"solver\",\"language\":\"rust\",\"status\":\"error\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{},",
+        "\"artifacts\":{},\"error\":\"HiGHS backend error: solve failed\"}\n",
+        "{\"benchmark\":\"surface_decoder\",\"runner\":\"unsupported\",\"language\":\"rust\",\"status\":\"error\",",
+        "\"params\":{},\"case_summary\":{},\"metrics\":{},",
+        "\"artifacts\":{},\"error\":\"no ILP backend is available for kind Gurobi\"}\n"
+    );
+
+    let rows = read_results_jsonl(input.as_bytes()).unwrap();
+
+    assert_eq!(rows[0].failure_kind, FailureKind::Ok);
+    assert_eq!(rows[1].failure_kind, FailureKind::LogicalFailure);
+    assert_eq!(rows[2].failure_kind, FailureKind::SolverFailure);
+    assert_eq!(rows[3].failure_kind, FailureKind::Unsupported);
 }

--- a/rsinter/tests/bench_run.rs
+++ b/rsinter/tests/bench_run.rs
@@ -2,6 +2,7 @@ use rsinter::bench::registry::build_default_rust_runner_registry;
 use rsinter::bench::result::read_results_jsonl;
 use rsinter::bench::run::run_rust_benchmark;
 use rsinter::bench::spec::BenchmarkSpec;
+use rsinter::failure::FailureKind;
 use std::fs;
 use std::path::Path;
 
@@ -523,6 +524,81 @@ label = "Logical Error Rate"
     assert_eq!(rows[0].params["mip_gap"], serde_json::json!(0.01));
     assert_eq!(rows[0].params["threads"], serde_json::json!(1));
     assert_eq!(rows[0].params["verbose"], serde_json::json!(true));
+}
+
+#[cfg(not(feature = "gurobi"))]
+#[test]
+fn rilpqec_gurobi_without_feature_records_unsupported_failure_kind() {
+    let spec_text = r#"
+name = "surface_decoder"
+version = 1
+mode = "independent"
+
+[[runner]]
+name = "rilpqec_gurobi"
+language = "rust"
+impl_key = "rilpqec"
+
+[runner.params]
+distance = [3]
+rounds = [3]
+p = [0.002]
+max_shots = 1
+max_errors = 1
+batch_size = 1
+backend = "gurobi"
+
+[plot]
+title = "Surface Decoder"
+
+[plot.x]
+field = "params.p"
+scale = "log"
+label = "Physical Error Rate"
+
+[plot.series]
+group_by = ["runner"]
+label_template = "{runner}"
+
+[[plot.panel]]
+metric = "metrics.logical_error_rate"
+scale = "log"
+label = "Logical Error Rate"
+"#;
+
+    let spec: BenchmarkSpec = toml::from_str(spec_text).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let registry = build_default_rust_runner_registry();
+
+    let artifact_root = run_rust_benchmark(
+        &spec,
+        "rust",
+        dir.path(),
+        &registry,
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    )
+    .unwrap();
+    let data = fs::read(
+        artifact_root
+            .join("rilpqec_gurobi")
+            .join("test-run")
+            .join("results.jsonl"),
+    )
+    .unwrap();
+    let rows = read_results_jsonl(&data[..]).unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].status, "error");
+    assert_eq!(rows[0].failure_kind, FailureKind::Unsupported);
+    assert!(
+        rows[0]
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("no ILP backend is available"),
+        "row error was: {:?}",
+        rows[0].error
+    );
 }
 
 #[test]

--- a/rsinter/tests/bench_runner_wrappers.rs
+++ b/rsinter/tests/bench_runner_wrappers.rs
@@ -34,6 +34,7 @@ fn rbposd_runner_handles_zero_shot_benchmark_points() {
 
     assert_eq!(runner.name(), "rbposd");
     assert_eq!(row.runner, "rbposd_alias");
+    assert_eq!(row.failure_kind, rsinter::failure::FailureKind::Ok);
     assert_eq!(row.metrics["shots_used"], 0.0);
 }
 
@@ -69,5 +70,6 @@ fn rilpqec_runner_handles_zero_shot_benchmark_points() {
 
     assert_eq!(runner.name(), "rilpqec");
     assert_eq!(row.runner, "rilpqec_alias");
+    assert_eq!(row.failure_kind, rsinter::failure::FailureKind::Ok);
     assert_eq!(row.metrics["shots_used"], 0.0);
 }

--- a/rsinter/tests/collect.rs
+++ b/rsinter/tests/collect.rs
@@ -511,3 +511,26 @@ fn collect_grows_batch_size_without_an_explicit_cap() {
     assert_eq!(results[0].shots, 2);
     assert_eq!(results[0].failure_kind, FailureKind::Ok);
 }
+
+#[test]
+fn collect_prefers_task_specific_shot_limit_over_global_limit() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(20),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(8),
+        start_batch_size: 8,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let mut task = make_clean_task();
+    task.collection_options.max_shots = Some(3);
+    let results = collect(vec![task], make_decoders(), &options).unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 3);
+    assert_eq!(results[0].errors, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::Ok);
+}

--- a/rsinter/tests/collect.rs
+++ b/rsinter/tests/collect.rs
@@ -304,6 +304,26 @@ fn collect_rejects_non_positive_wall_clock() {
 }
 
 #[test]
+fn collect_rejects_task_specific_non_positive_wall_clock() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(20),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(1),
+        start_batch_size: 1,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+    let mut task = make_task();
+    task.collection_options.max_wall_seconds = Some(-0.5);
+
+    let err = collect(vec![task], make_decoders(), &options).unwrap_err();
+
+    assert!(err.contains("max_wall_seconds must be positive"), "{err}");
+}
+
+#[test]
 fn collect_reports_ok_failure_kind_for_clean_runs() {
     let options = CollectOptions {
         num_workers: 1,

--- a/rsinter/tests/collect.rs
+++ b/rsinter/tests/collect.rs
@@ -90,6 +90,14 @@ struct FailingDecoder {
     message: &'static str,
 }
 
+struct DecodeErrorDecoder;
+
+struct DecodeErrorCompiledDecoder;
+
+struct WrongPredictionLengthDecoder;
+
+struct WrongPredictionLengthCompiledDecoder;
+
 impl Decoder for FailingDecoder {
     fn compile_for_dem(
         &self,
@@ -99,12 +107,79 @@ impl Decoder for FailingDecoder {
     }
 }
 
+impl Decoder for DecodeErrorDecoder {
+    fn compile_for_dem(
+        &self,
+        _dem: &DetectorErrorModel,
+    ) -> Result<Box<dyn CompiledDecoder>, String> {
+        Ok(Box::new(DecodeErrorCompiledDecoder))
+    }
+}
+
+impl CompiledDecoder for DecodeErrorCompiledDecoder {
+    fn decode_shots_bit_packed(
+        &self,
+        _dets: &[u8],
+        _num_shots: usize,
+        _num_dets: usize,
+        _num_obs: usize,
+    ) -> Result<Vec<u8>, String> {
+        Err("decode failed".into())
+    }
+}
+
+impl Decoder for WrongPredictionLengthDecoder {
+    fn compile_for_dem(
+        &self,
+        _dem: &DetectorErrorModel,
+    ) -> Result<Box<dyn CompiledDecoder>, String> {
+        Ok(Box::new(WrongPredictionLengthCompiledDecoder))
+    }
+}
+
+impl CompiledDecoder for WrongPredictionLengthCompiledDecoder {
+    fn decode_shots_bit_packed(
+        &self,
+        _dets: &[u8],
+        _num_shots: usize,
+        _num_dets: usize,
+        _num_obs: usize,
+    ) -> Result<Vec<u8>, String> {
+        Ok(Vec::new())
+    }
+}
+
 fn make_failing_decoders(
     message: &'static str,
 ) -> HashMap<String, Box<dyn rsinter::decode::Decoder>> {
     let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
     decoders.insert("vacuous".into(), Box::new(FailingDecoder { message }));
     decoders
+}
+
+fn make_decode_error_decoders() -> HashMap<String, Box<dyn rsinter::decode::Decoder>> {
+    let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
+    decoders.insert("vacuous".into(), Box::new(DecodeErrorDecoder));
+    decoders
+}
+
+fn make_wrong_prediction_length_decoders() -> HashMap<String, Box<dyn rsinter::decode::Decoder>> {
+    let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
+    decoders.insert("vacuous".into(), Box::new(WrongPredictionLengthDecoder));
+    decoders
+}
+
+fn collect_branch_options() -> CollectOptions {
+    CollectOptions {
+        num_workers: 1,
+        max_shots: Some(1),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(1),
+        start_batch_size: 1,
+        save_resume_filepath: None,
+        print_progress: false,
+    }
 }
 
 #[test]
@@ -314,4 +389,55 @@ fn collect_records_decoder_failure_as_task_stats() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].shots, 0);
     assert_eq!(results[0].failure_kind, FailureKind::SolverFailure);
+}
+
+#[test]
+fn collect_missing_decoder_remains_caller_error() {
+    let mut task = make_clean_task();
+    task.decoder = "missing".into();
+
+    let err = collect(vec![task], make_decoders(), &collect_branch_options()).unwrap_err();
+
+    assert_eq!(err, "decoder not found: missing");
+}
+
+#[test]
+fn collect_records_decode_error_as_solver_failure_task_stats() {
+    let results = collect(
+        vec![make_clean_task()],
+        make_decode_error_decoders(),
+        &collect_branch_options(),
+    )
+    .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::SolverFailure);
+}
+
+#[test]
+fn collect_records_wrong_prediction_length_as_solver_failure_task_stats() {
+    let results = collect(
+        vec![make_clean_task()],
+        make_wrong_prediction_length_decoders(),
+        &collect_branch_options(),
+    )
+    .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::SolverFailure);
+}
+
+#[test]
+fn collect_records_detector_buffer_mismatch_as_sampler_error_task_stats() {
+    let mut task = make_clean_task();
+    task.collection_options.max_shots = Some(1);
+    task.dem.set_min_counts(9, 1);
+
+    let results = collect(vec![task], make_decoders(), &collect_branch_options()).unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::SamplerError);
 }

--- a/rsinter/tests/collect.rs
+++ b/rsinter/tests/collect.rs
@@ -1,5 +1,6 @@
 use rsinter::collect::{collect, CollectOptions};
 use rsinter::decode::{CompiledDecoder, Decoder, VacuousDecoder};
+use rsinter::failure::FailureKind;
 use rsinter::task::{CollectionOptions, Task};
 use rstim::dem::DetectorErrorModel;
 use rstim::error_analyzer::ErrorAnalyzer;
@@ -57,6 +58,22 @@ fn make_task() -> Task {
     }
 }
 
+fn make_clean_task() -> Task {
+    let circuit = parse_lines("M 0\nDETECTOR rec[-1]\nOBSERVABLE_INCLUDE(0) rec[-1]").unwrap();
+    let dem = ErrorAnalyzer::circuit_to_dem(&circuit).unwrap();
+    Task {
+        circuit,
+        decoder: "vacuous".into(),
+        dem,
+        metadata: serde_json::json!({"d": 3, "clean": true}),
+        collection_options: CollectionOptions {
+            max_shots: Some(16),
+            max_errors: None,
+            max_wall_seconds: None,
+        },
+    }
+}
+
 fn make_decoders() -> HashMap<String, Box<dyn rsinter::decode::Decoder>> {
     let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
     decoders.insert("vacuous".into(), Box::new(VacuousDecoder));
@@ -66,6 +83,27 @@ fn make_decoders() -> HashMap<String, Box<dyn rsinter::decode::Decoder>> {
 fn make_slow_decoders(sleep: Duration) -> HashMap<String, Box<dyn rsinter::decode::Decoder>> {
     let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
     decoders.insert("vacuous".into(), Box::new(SlowDecoder { sleep }));
+    decoders
+}
+
+struct FailingDecoder {
+    message: &'static str,
+}
+
+impl Decoder for FailingDecoder {
+    fn compile_for_dem(
+        &self,
+        _dem: &DetectorErrorModel,
+    ) -> Result<Box<dyn CompiledDecoder>, String> {
+        Err(self.message.to_string())
+    }
+}
+
+fn make_failing_decoders(
+    message: &'static str,
+) -> HashMap<String, Box<dyn rsinter::decode::Decoder>> {
+    let mut decoders: HashMap<String, Box<dyn rsinter::decode::Decoder>> = HashMap::new();
+    decoders.insert("vacuous".into(), Box::new(FailingDecoder { message }));
     decoders
 }
 
@@ -188,4 +226,92 @@ fn collect_rejects_non_positive_wall_clock() {
     let err = collect(vec![make_task()], make_decoders(), &options).unwrap_err();
 
     assert!(err.contains("max_wall_seconds must be positive"), "{err}");
+}
+
+#[test]
+fn collect_reports_ok_failure_kind_for_clean_runs() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(16),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(16),
+        start_batch_size: 16,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let results = collect(vec![make_clean_task()], make_decoders(), &options).unwrap();
+
+    assert_eq!(results[0].failure_kind, FailureKind::Ok);
+}
+
+#[test]
+fn collect_reports_logical_failure_kind_for_logical_errors() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(1000),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(256),
+        start_batch_size: 64,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let results = collect(vec![make_task()], make_decoders(), &options).unwrap();
+
+    assert!(results[0].errors > 0);
+    assert_eq!(results[0].failure_kind, FailureKind::LogicalFailure);
+}
+
+#[test]
+fn collect_reports_timeout_failure_kind_for_wall_clock_stop() {
+    let mut task = make_clean_task();
+    task.collection_options.max_shots = None;
+
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(20),
+        max_errors: None,
+        max_wall_seconds: Some(0.09),
+        max_batch_size: Some(1),
+        start_batch_size: 1,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let results = collect(
+        vec![task],
+        make_slow_decoders(Duration::from_millis(35)),
+        &options,
+    )
+    .unwrap();
+
+    assert_eq!(results[0].failure_kind, FailureKind::Timeout);
+}
+
+#[test]
+fn collect_records_decoder_failure_as_task_stats() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(20),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: Some(1),
+        start_batch_size: 1,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let results = collect(
+        vec![make_clean_task()],
+        make_failing_decoders("HiGHS backend error: compile failed"),
+        &options,
+    )
+    .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::SolverFailure);
 }

--- a/rsinter/tests/collect.rs
+++ b/rsinter/tests/collect.rs
@@ -441,3 +441,73 @@ fn collect_records_detector_buffer_mismatch_as_sampler_error_task_stats() {
     assert_eq!(results[0].shots, 0);
     assert_eq!(results[0].failure_kind, FailureKind::SamplerError);
 }
+
+#[test]
+fn collect_records_sampler_failure_as_sampler_error_task_stats() {
+    let mut task = make_clean_task();
+    task.collection_options.max_shots = Some(1);
+    task.circuit = parse_lines("ML 0\n").unwrap();
+
+    let results = collect(vec![task], make_decoders(), &collect_branch_options()).unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::SamplerError);
+}
+
+#[test]
+fn collect_records_observable_buffer_mismatch_as_sampler_error_task_stats() {
+    let mut task = make_clean_task();
+    task.collection_options.max_shots = Some(1);
+    task.dem.set_min_counts(1, 9);
+
+    let results = collect(vec![task], make_decoders(), &collect_branch_options()).unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::SamplerError);
+}
+
+#[test]
+fn collect_zero_start_batch_size_finishes_without_collecting() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(1),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: None,
+        start_batch_size: 0,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let mut task = make_clean_task();
+    task.collection_options.max_shots = None;
+    let results = collect(vec![task], make_decoders(), &options).unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 0);
+    assert_eq!(results[0].failure_kind, FailureKind::Ok);
+}
+
+#[test]
+fn collect_grows_batch_size_without_an_explicit_cap() {
+    let options = CollectOptions {
+        num_workers: 1,
+        max_shots: Some(2),
+        max_errors: None,
+        max_wall_seconds: None,
+        max_batch_size: None,
+        start_batch_size: 1,
+        save_resume_filepath: None,
+        print_progress: false,
+    };
+
+    let mut task = make_clean_task();
+    task.collection_options.max_shots = None;
+    let results = collect(vec![task], make_decoders(), &options).unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].shots, 2);
+    assert_eq!(results[0].failure_kind, FailureKind::Ok);
+}

--- a/rsinter/tests/collect.rs
+++ b/rsinter/tests/collect.rs
@@ -1,4 +1,4 @@
-use rsinter::collect::{CollectOptions, collect};
+use rsinter::collect::{collect, CollectOptions};
 use rsinter::decode::{CompiledDecoder, Decoder, VacuousDecoder};
 use rsinter::task::{CollectionOptions, Task};
 use rstim::dem::DetectorErrorModel;
@@ -17,8 +17,11 @@ struct SlowCompiledDecoder {
 }
 
 impl Decoder for SlowDecoder {
-    fn compile_for_dem(&self, _dem: &DetectorErrorModel) -> Box<dyn CompiledDecoder> {
-        Box::new(SlowCompiledDecoder { sleep: self.sleep })
+    fn compile_for_dem(
+        &self,
+        _dem: &DetectorErrorModel,
+    ) -> Result<Box<dyn CompiledDecoder>, String> {
+        Ok(Box::new(SlowCompiledDecoder { sleep: self.sleep }))
     }
 }
 
@@ -29,10 +32,10 @@ impl CompiledDecoder for SlowCompiledDecoder {
         num_shots: usize,
         _num_dets: usize,
         num_obs: usize,
-    ) -> Vec<u8> {
+    ) -> Result<Vec<u8>, String> {
         thread::sleep(self.sleep);
         let obs_bytes = num_obs.div_ceil(8);
-        vec![0u8; num_shots * obs_bytes]
+        Ok(vec![0u8; num_shots * obs_bytes])
     }
 }
 

--- a/rsinter/tests/css_surface_special.rs
+++ b/rsinter/tests/css_surface_special.rs
@@ -67,7 +67,7 @@ fn bb72_css_smoke_builds_dem_with_twelve_observables() {
 fn logical_error_rate(circuit: &[rstim::ir::StimInstr], shots: usize, seed: u64) -> f64 {
     let dem = ErrorAnalyzer::circuit_to_dem_decomposed(circuit).unwrap();
     let decoder = RmatchingDemDecoder;
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
     let num_dets = dem.effective_num_detectors();
     let num_obs = dem.num_observables();
     let obs_bytes = num_obs.div_ceil(8);
@@ -77,7 +77,9 @@ fn logical_error_rate(circuit: &[rstim::ir::StimInstr], shots: usize, seed: u64)
     write_shots_b8(&batch.detections, &mut dets).unwrap();
     let mut obs = Vec::new();
     write_shots_b8(&batch.observable_flips, &mut obs).unwrap();
-    let predictions = compiled.decode_shots_bit_packed(&dets, shots, num_dets, num_obs);
+    let predictions = compiled
+        .decode_shots_bit_packed(&dets, shots, num_dets, num_obs)
+        .unwrap();
     let mut errors = 0usize;
     for shot in 0..shots {
         let start = shot * obs_bytes;

--- a/rsinter/tests/csv_io.rs
+++ b/rsinter/tests/csv_io.rs
@@ -1,5 +1,6 @@
+use rsinter::csv_io::{read_csv, write_csv};
+use rsinter::failure::FailureKind;
 use rsinter::task_stats::TaskStats;
-use rsinter::csv_io::{write_csv, read_csv};
 use std::collections::HashMap;
 
 fn sample_stats() -> TaskStats {
@@ -11,6 +12,7 @@ fn sample_stats() -> TaskStats {
         errors: 5,
         discards: 0,
         seconds: 1.23,
+        failure_kind: FailureKind::Ok,
         custom_counts: HashMap::new(),
     }
 }
@@ -24,15 +26,55 @@ fn csv_roundtrip() {
     assert_eq!(recovered.len(), 1);
     assert_eq!(recovered[0].shots, 1000);
     assert_eq!(recovered[0].errors, 5);
+    assert_eq!(recovered[0].failure_kind, FailureKind::Ok);
     assert_eq!(recovered[0].strong_id, "abc123");
+}
+
+#[test]
+fn csv_reads_legacy_rows_without_failure_kind() {
+    let input = concat!(
+        "shots,errors,discards,seconds,decoder,strong_id,json_metadata,custom_counts\n",
+        "100,0,0,1.0000,vacuous,clean,\"{\"\"d\"\":3}\",\"{}\"\n",
+        "100,4,0,1.0000,vacuous,logical,\"{\"\"d\"\":3}\",\"{}\"\n"
+    );
+
+    let recovered = read_csv(input.as_bytes()).unwrap();
+
+    assert_eq!(recovered[0].failure_kind, FailureKind::Ok);
+    assert_eq!(recovered[1].failure_kind, FailureKind::LogicalFailure);
 }
 
 #[test]
 fn task_stats_addition() {
     let a = sample_stats();
-    let b = TaskStats { shots: 500, errors: 2, seconds: 0.5, ..sample_stats() };
+    let b = TaskStats {
+        shots: 500,
+        errors: 2,
+        seconds: 0.5,
+        ..sample_stats()
+    };
     let c = a + b;
     assert_eq!(c.shots, 1500);
     assert_eq!(c.errors, 7);
     assert!((c.seconds - 1.73).abs() < 0.01);
+}
+
+#[test]
+fn task_stats_addition_keeps_strongest_failure_kind() {
+    let a = TaskStats {
+        failure_kind: FailureKind::LogicalFailure,
+        ..sample_stats()
+    };
+    let b = TaskStats {
+        shots: 500,
+        errors: 0,
+        seconds: 0.5,
+        failure_kind: FailureKind::Timeout,
+        ..sample_stats()
+    };
+
+    let c = a + b;
+
+    assert_eq!(c.failure_kind, FailureKind::Timeout);
+    assert_eq!(c.shots, 1500);
 }

--- a/rsinter/tests/csv_io.rs
+++ b/rsinter/tests/csv_io.rs
@@ -45,6 +45,30 @@ fn csv_reads_legacy_rows_without_failure_kind() {
 }
 
 #[test]
+fn csv_reads_empty_input_as_empty_stats() {
+    let recovered = read_csv(b"").unwrap();
+
+    assert!(recovered.is_empty());
+}
+
+#[test]
+fn csv_reads_columns_by_header_name() {
+    let input = concat!(
+        "strong_id,failure_kind,custom_counts,decoder,seconds,json_metadata,errors,discards,shots\n",
+        "sid-7,timeout,\"{}\",mwpm,2.5000,\"{\"\"d\"\":5}\",3,1,42\n"
+    );
+
+    let recovered = read_csv(input.as_bytes()).unwrap();
+
+    assert_eq!(recovered.len(), 1);
+    assert_eq!(recovered[0].shots, 42);
+    assert_eq!(recovered[0].errors, 3);
+    assert_eq!(recovered[0].decoder, "mwpm");
+    assert_eq!(recovered[0].strong_id, "sid-7");
+    assert_eq!(recovered[0].failure_kind, FailureKind::Timeout);
+}
+
+#[test]
 fn task_stats_addition() {
     let a = sample_stats();
     let b = TaskStats {

--- a/rsinter/tests/decode.rs
+++ b/rsinter/tests/decode.rs
@@ -5,10 +5,10 @@ use rstim::dem::DetectorErrorModel;
 fn vacuous_decoder_returns_all_zeros() {
     let dem = DetectorErrorModel::parse("error(0.1) D0").unwrap();
     let decoder = VacuousDecoder;
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
     // 2 shots, 1 detector, 1 observable → dets_bytes=1 per shot, obs_bytes=1 per shot
     let dets = vec![0b1, 0b0]; // shot0: D0 fired, shot1: nothing
-    let predictions = compiled.decode_shots_bit_packed(&dets, 2, 1, 1);
+    let predictions = compiled.decode_shots_bit_packed(&dets, 2, 1, 1).unwrap();
     // Vacuous always predicts 0
     assert_eq!(predictions, vec![0u8, 0u8]);
 }
@@ -17,8 +17,8 @@ fn vacuous_decoder_returns_all_zeros() {
 fn vacuous_decoder_multi_obs() {
     let dem = DetectorErrorModel::parse("error(0.1) D0 L0 L1").unwrap();
     let decoder = VacuousDecoder;
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
     let dets = vec![0b1]; // 1 shot
-    let predictions = compiled.decode_shots_bit_packed(&dets, 1, 1, 2);
+    let predictions = compiled.decode_shots_bit_packed(&dets, 1, 1, 2).unwrap();
     assert_eq!(predictions, vec![0u8]);
 }

--- a/rsinter/tests/decode_ilp.rs
+++ b/rsinter/tests/decode_ilp.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 
-#[cfg(feature = "gurobi")]
 use rilpqec::{BackendConfig, BackendKind, IlpDecoderConfig};
-use rsinter::collect::{CollectOptions, collect};
+use rsinter::collect::{collect, CollectOptions};
 use rsinter::decode::{Decoder, IlpDemDecoder as RsinterIlpDemDecoder};
 use rsinter::task::{CollectionOptions, Task};
 use rstim::dem::DetectorErrorModel;
@@ -13,9 +12,11 @@ use rstim::parser::parse_lines;
 fn ilp_dem_decoder_predicts_a_single_observable_flip() {
     let dem = DetectorErrorModel::parse("error(0.125) D0 L0\nerror(0.25) D1\n").unwrap();
     let decoder = RsinterIlpDemDecoder::default();
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+    let predictions = compiled
+        .decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
 }
@@ -24,9 +25,9 @@ fn ilp_dem_decoder_predicts_a_single_observable_flip() {
 fn ilp_dem_decoder_handles_observable_only_terms() {
     let dem = DetectorErrorModel::parse("error(0.75) L0\n").unwrap();
     let decoder = RsinterIlpDemDecoder::default();
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let predictions = compiled.decode_shots_bit_packed(&[], 1, 0, 1);
+    let predictions = compiled.decode_shots_bit_packed(&[], 1, 0, 1).unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
 }
@@ -86,9 +87,36 @@ fn ilp_dem_decoder_can_explicitly_use_gurobi_through_rsinter() {
             verbose: false,
         },
     });
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+    let predictions = compiled
+        .decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
+}
+
+#[cfg(not(feature = "gurobi"))]
+#[test]
+fn ilp_dem_decoder_reports_unavailable_gurobi_backend() {
+    let dem = DetectorErrorModel::parse("error(0.125) D0 L0\n").unwrap();
+    let decoder = RsinterIlpDemDecoder::new(IlpDecoderConfig {
+        backend: BackendConfig {
+            kind: BackendKind::Gurobi,
+            time_limit_seconds: None,
+            mip_gap: None,
+            threads: Some(1),
+            verbose: false,
+        },
+    });
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
+
+    let err = compiled
+        .decode_shots_bit_packed(&[0b0000_0001], 1, 1, 1)
+        .unwrap_err();
+
+    assert!(
+        err.contains("no ILP backend is available"),
+        "error was: {err}"
+    );
 }

--- a/rsinter/tests/decode_rbposd.rs
+++ b/rsinter/tests/decode_rbposd.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use rbposd::DecoderConfig;
-use rsinter::collect::{CollectOptions, collect};
+use rsinter::collect::{collect, CollectOptions};
 use rsinter::decode::{Decoder, RbposdDemDecoder};
 use rsinter::task::{CollectionOptions, Task};
 use rstim::dem::DetectorErrorModel;
@@ -12,9 +12,11 @@ use rstim::parser::parse_lines;
 fn rbposd_dem_decoder_predicts_a_single_observable_flip() {
     let dem = DetectorErrorModel::parse("error(0.125) D0 L0\nerror(0.25) D1\n").unwrap();
     let decoder = RbposdDemDecoder::new(DecoderConfig::default());
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+    let predictions = compiled
+        .decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
 }
@@ -23,11 +25,17 @@ fn rbposd_dem_decoder_predicts_a_single_observable_flip() {
 fn rbposd_dem_decoder_reuses_one_compiled_instance_across_multiple_batch_calls() {
     let dem = DetectorErrorModel::parse("error(0.125) D0 L0\nerror(0.25) D1\n").unwrap();
     let decoder = RbposdDemDecoder::new(DecoderConfig::default());
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let first = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
-    let second = compiled.decode_shots_bit_packed(&[0b0000_0000], 1, 2, 1);
-    let third = compiled.decode_shots_bit_packed(&[0b0000_0001, 0b0000_0000], 2, 2, 1);
+    let first = compiled
+        .decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap();
+    let second = compiled
+        .decode_shots_bit_packed(&[0b0000_0000], 1, 2, 1)
+        .unwrap();
+    let third = compiled
+        .decode_shots_bit_packed(&[0b0000_0001, 0b0000_0000], 2, 2, 1)
+        .unwrap();
 
     assert_eq!(first, vec![0b0000_0001]);
     assert_eq!(second, vec![0b0000_0000]);
@@ -83,9 +91,9 @@ fn collect_runs_with_the_rbposd_adapter() {
 fn rbposd_dem_decoder_handles_observable_only_terms() {
     let dem = DetectorErrorModel::parse("error(0.75) L0\n").unwrap();
     let decoder = RbposdDemDecoder::new(DecoderConfig::default());
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let predictions = compiled.decode_shots_bit_packed(&[], 1, 0, 1);
+    let predictions = compiled.decode_shots_bit_packed(&[], 1, 0, 1).unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
 }
@@ -94,9 +102,11 @@ fn rbposd_dem_decoder_handles_observable_only_terms() {
 fn rbposd_dem_decoder_handles_exact_probability_terms() {
     let dem = DetectorErrorModel::parse("error(1) D0 L0\nerror(0) D1\n").unwrap();
     let decoder = RbposdDemDecoder::new(DecoderConfig::default());
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1);
+    let predictions = compiled
+        .decode_shots_bit_packed(&[0b0000_0001], 1, 2, 1)
+        .unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
 }
@@ -105,9 +115,11 @@ fn rbposd_dem_decoder_handles_exact_probability_terms() {
 fn rbposd_dem_decoder_handles_zero_syndrome_map_cases() {
     let dem = DetectorErrorModel::parse("error(0.9) D0 L0\nerror(0.2) D0\n").unwrap();
     let decoder = RbposdDemDecoder::new(DecoderConfig::default());
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0000], 1, 1, 1);
+    let predictions = compiled
+        .decode_shots_bit_packed(&[0b0000_0000], 1, 1, 1)
+        .unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
 }
@@ -135,7 +147,7 @@ fn exact_three_error_logical_error_rate(dem: &DetectorErrorModel, osd_order: usi
     config.max_bp_iterations = 0;
     config.osd_order = osd_order;
     let decoder = RbposdDemDecoder::new(config);
-    let compiled = decoder.compile_for_dem(dem);
+    let compiled = decoder.compile_for_dem(dem).unwrap();
     let probabilities = [
         0.268_941_421_369_995_1,
         0.268_941_421_369_995_1,
@@ -155,7 +167,11 @@ fn exact_three_error_logical_error_rate(dem: &DetectorErrorModel, osd_order: usi
                 let det1 = e1 ^ e2;
                 let observed = e2;
                 let det_byte = u8::from(det0) | (u8::from(det1) << 1);
-                let predicted = compiled.decode_shots_bit_packed(&[det_byte], 1, 2, 1)[0] & 1 != 0;
+                let predicted = compiled
+                    .decode_shots_bit_packed(&[det_byte], 1, 2, 1)
+                    .unwrap()[0]
+                    & 1
+                    != 0;
                 if predicted != observed {
                     ler += probability;
                 }

--- a/rsinter/tests/decode_rmatching.rs
+++ b/rsinter/tests/decode_rmatching.rs
@@ -3,36 +3,36 @@ use rstim::dem::DetectorErrorModel;
 
 #[test]
 fn rmatching_dem_decoder_compiles_for_dem() {
-    let dem = DetectorErrorModel::parse("error(0.1) D0 D1 L0\nerror(0.05) D0\nerror(0.05) D1\n")
-        .unwrap();
+    let dem =
+        DetectorErrorModel::parse("error(0.1) D0 D1 L0\nerror(0.05) D0\nerror(0.05) D1\n").unwrap();
     let decoder = RmatchingDemDecoder;
 
-    let compiled = decoder.compile_for_dem(&dem);
-    let predictions = compiled.decode_shots_bit_packed(&[0b0000_0011], 1, 2, 1);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
+    let predictions = compiled
+        .decode_shots_bit_packed(&[0b0000_0011], 1, 2, 1)
+        .unwrap();
 
     assert_eq!(predictions, vec![0b0000_0001]);
 }
 
 #[test]
 fn rmatching_dem_decoder_handles_non_byte_aligned_widths() {
-    let dem = DetectorErrorModel::parse(
-        "error(0.1) D0 D8 L8\nerror(0.05) D0\nerror(0.05) D8\n",
-    )
-    .unwrap();
+    let dem =
+        DetectorErrorModel::parse("error(0.1) D0 D8 L8\nerror(0.05) D0\nerror(0.05) D8\n").unwrap();
     let decoder = RmatchingDemDecoder;
-    let compiled = decoder.compile_for_dem(&dem);
+    let compiled = decoder.compile_for_dem(&dem).unwrap();
 
-    let predictions = compiled.decode_shots_bit_packed(
-        &[
-            0b0000_0001,
-            0b0000_0001,
-            0b0000_0000,
-            0b1111_1110,
-        ],
-        2,
-        9,
-        9,
+    let predictions = compiled
+        .decode_shots_bit_packed(
+            &[0b0000_0001, 0b0000_0001, 0b0000_0000, 0b1111_1110],
+            2,
+            9,
+            9,
+        )
+        .unwrap();
+
+    assert_eq!(
+        predictions,
+        vec![0b0000_0000, 0b0000_0001, 0b0000_0000, 0b0000_0000]
     );
-
-    assert_eq!(predictions, vec![0b0000_0000, 0b0000_0001, 0b0000_0000, 0b0000_0000]);
 }

--- a/rsinter/tests/failure.rs
+++ b/rsinter/tests/failure.rs
@@ -1,0 +1,148 @@
+use std::str::FromStr;
+
+use rsinter::failure::{classify_completed, classify_error, combine_failure_kind, FailureKind};
+
+#[test]
+fn failure_kind_public_string_matrix_is_stable() {
+    assert_eq!(FailureKind::Ok.as_str(), "ok");
+    assert_eq!(FailureKind::LogicalFailure.as_str(), "logical_failure");
+    assert_eq!(FailureKind::Timeout.as_str(), "timeout");
+    assert_eq!(FailureKind::SolverFailure.as_str(), "solver_failure");
+    assert_eq!(FailureKind::Unsupported.as_str(), "unsupported");
+    assert_eq!(FailureKind::SamplerError.as_str(), "sampler_error");
+
+    assert_eq!(FailureKind::Ok.status(), "ok");
+    assert_eq!(FailureKind::LogicalFailure.status(), "ok");
+    assert_eq!(FailureKind::Timeout.status(), "ok");
+    assert_eq!(FailureKind::SolverFailure.status(), "error");
+    assert_eq!(FailureKind::Unsupported.status(), "error");
+    assert_eq!(FailureKind::SamplerError.status(), "error");
+
+    assert_eq!(FailureKind::default(), FailureKind::Ok);
+    assert_eq!(FailureKind::Ok.to_string(), "ok");
+    assert_eq!(FailureKind::LogicalFailure.to_string(), "logical_failure");
+    assert_eq!(FailureKind::Timeout.to_string(), "timeout");
+    assert_eq!(FailureKind::SolverFailure.to_string(), "solver_failure");
+    assert_eq!(FailureKind::Unsupported.to_string(), "unsupported");
+    assert_eq!(FailureKind::SamplerError.to_string(), "sampler_error");
+}
+
+#[test]
+fn failure_kind_json_round_trips_each_variant() {
+    let ok_json = serde_json::to_string(&FailureKind::Ok).unwrap();
+    let logical_json = serde_json::to_string(&FailureKind::LogicalFailure).unwrap();
+    let timeout_json = serde_json::to_string(&FailureKind::Timeout).unwrap();
+    let solver_json = serde_json::to_string(&FailureKind::SolverFailure).unwrap();
+    let unsupported_json = serde_json::to_string(&FailureKind::Unsupported).unwrap();
+    let sampler_json = serde_json::to_string(&FailureKind::SamplerError).unwrap();
+
+    assert_eq!(ok_json, "\"ok\"");
+    assert_eq!(logical_json, "\"logical_failure\"");
+    assert_eq!(timeout_json, "\"timeout\"");
+    assert_eq!(solver_json, "\"solver_failure\"");
+    assert_eq!(unsupported_json, "\"unsupported\"");
+    assert_eq!(sampler_json, "\"sampler_error\"");
+
+    let ok: FailureKind = serde_json::from_str(&ok_json).unwrap();
+    let logical: FailureKind = serde_json::from_str(&logical_json).unwrap();
+    let timeout: FailureKind = serde_json::from_str(&timeout_json).unwrap();
+    let solver: FailureKind = serde_json::from_str(&solver_json).unwrap();
+    let unsupported: FailureKind = serde_json::from_str(&unsupported_json).unwrap();
+    let sampler: FailureKind = serde_json::from_str(&sampler_json).unwrap();
+
+    assert_eq!(ok, FailureKind::Ok);
+    assert_eq!(logical, FailureKind::LogicalFailure);
+    assert_eq!(timeout, FailureKind::Timeout);
+    assert_eq!(solver, FailureKind::SolverFailure);
+    assert_eq!(unsupported, FailureKind::Unsupported);
+    assert_eq!(sampler, FailureKind::SamplerError);
+}
+
+#[test]
+fn failure_kind_from_str_accepts_only_snake_case_names() {
+    assert_eq!(FailureKind::from_str("ok").unwrap(), FailureKind::Ok);
+    assert_eq!(
+        FailureKind::from_str("logical_failure").unwrap(),
+        FailureKind::LogicalFailure
+    );
+    assert_eq!(
+        FailureKind::from_str("timeout").unwrap(),
+        FailureKind::Timeout
+    );
+    assert_eq!(
+        FailureKind::from_str("solver_failure").unwrap(),
+        FailureKind::SolverFailure
+    );
+    assert_eq!(
+        FailureKind::from_str("unsupported").unwrap(),
+        FailureKind::Unsupported
+    );
+    assert_eq!(
+        FailureKind::from_str("sampler_error").unwrap(),
+        FailureKind::SamplerError
+    );
+
+    assert!(FailureKind::from_str("").is_err());
+    assert!(FailureKind::from_str("logical-failure").is_err());
+    assert!(FailureKind::from_str("sampler error").is_err());
+    assert!(FailureKind::from_str("unknown")
+        .unwrap_err()
+        .contains("unknown failure_kind"));
+}
+
+#[test]
+fn failure_classifiers_cover_completion_error_and_priority_rules() {
+    assert_eq!(classify_completed(0, false), FailureKind::Ok);
+    assert_eq!(classify_completed(7, false), FailureKind::LogicalFailure);
+    assert_eq!(classify_completed(0, true), FailureKind::Timeout);
+    assert_eq!(classify_completed(7, true), FailureKind::Timeout);
+
+    assert_eq!(
+        classify_error("BackendUnavailable: gurobi", FailureKind::SolverFailure),
+        FailureKind::Unsupported
+    );
+    assert_eq!(
+        classify_error("backend unavailable: highs", FailureKind::SolverFailure),
+        FailureKind::Unsupported
+    );
+    assert_eq!(
+        classify_error("backend is unavailable", FailureKind::SolverFailure),
+        FailureKind::Unsupported
+    );
+    assert_eq!(
+        classify_error("no ILP backend is available", FailureKind::SolverFailure),
+        FailureKind::Unsupported
+    );
+    assert_eq!(
+        classify_error(
+            "unsupported detector error model",
+            FailureKind::SolverFailure
+        ),
+        FailureKind::Unsupported
+    );
+    assert_eq!(
+        classify_error("solver iteration limit reached", FailureKind::SolverFailure),
+        FailureKind::SolverFailure
+    );
+    assert_eq!(
+        classify_error("sampling failed", FailureKind::SamplerError),
+        FailureKind::SamplerError
+    );
+
+    assert_eq!(
+        combine_failure_kind(FailureKind::Ok, FailureKind::LogicalFailure),
+        FailureKind::LogicalFailure
+    );
+    assert_eq!(
+        combine_failure_kind(FailureKind::Timeout, FailureKind::SamplerError),
+        FailureKind::SamplerError
+    );
+    assert_eq!(
+        combine_failure_kind(FailureKind::SolverFailure, FailureKind::Unsupported),
+        FailureKind::Unsupported
+    );
+    assert_eq!(
+        combine_failure_kind(FailureKind::Unsupported, FailureKind::SolverFailure),
+        FailureKind::Unsupported
+    );
+}

--- a/rsinter/tests/plot.rs
+++ b/rsinter/tests/plot.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use rsinter::failure::FailureKind;
 use rsinter::plot::{plot_error_rate, plot_error_rate_per_piece};
 use rsinter::task_stats::TaskStats;
 use tempfile::tempdir;
@@ -13,6 +14,7 @@ fn make_stat(p: f64, d: u64, r: u64, shots: u64, errors: u64) -> TaskStats {
         errors,
         discards: 0,
         seconds: 0.0,
+        failure_kind: FailureKind::Ok,
         custom_counts: HashMap::new(),
     }
 }


### PR DESCRIPTION
## Summary
- Add a structured `failure_kind` taxonomy to rsinter benchmark JSONL rows, task stats, and CSV resume data while preserving legacy input compatibility.
- Convert decoder backend failures into `Result` flows and classify benchmark/collect failures as structured rows instead of panics.
- Cover unsupported gurobi backend, DEM-analysis failures, sampler failures, solver failures, timeouts, and logical failures with focused tests.

## Why
Issue #49 needs benchmark and collection outputs to distinguish failure causes instead of relying on free-form status/error strings. This makes downstream benchmark analysis and resume data more robust.

Closes #49.

## Validation
- `cargo test -p rsinter`
- `cargo test -p surface_decoder_compare_bridge`
- `git diff --check f535081..HEAD`