### PR TITLE
Add built-in CSS registry with raw Hx/Hz access

### DIFF
--- a/docs/superpowers/plans/2026-06-14-built-in-css-registry.md
+++ b/docs/superpowers/plans/2026-06-14-built-in-css-registry.md
@@ -1,0 +1,301 @@
+# Built-in CSS Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a built-in CSS registry in `qec-code` that exposes canonical raw `Hx`/`Hz` row supports by code id, rejects unknown ids, and makes `Steane::new()` lower from the same registry data.
+
+**Architecture:** Keep the built-in code catalog separate from generic CSS validation. Add one small registry module under `qec-code/src/codes/` that owns canonical row-support data and lookup, then make `Steane::new()` consume that registry and lower into the existing dense `CssCode` API. The public surface stays small: one lookup function, one result type, one dedicated unknown-id error.
+
+**Tech Stack:** Rust 2024, `qec-code`, `thiserror`, integration tests in `qec-code/tests/code.rs`, `cargo test`
+
+---
+
+### Task 1: Lock the public failure mode and registry tests
+
+**Files:**
+- Modify: `qec-code/src/error.rs`
+- Modify: `qec-code/tests/code.rs`
+
+- [ ] **Step 1: Add the dedicated unknown-id error variant**
+
+```rust
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum QecError {
+    #[error("row width mismatch: expected {expected}, got {actual}")]
+    RowWidthMismatch { expected: usize, actual: usize },
+    #[error("invalid symplectic row width: expected even width, got {width}")]
+    InvalidSymplecticRowWidth { width: usize },
+    #[error("non-binary matrix entry {value} at row {row}, column {col}")]
+    InvalidBinaryEntry { row: usize, col: usize, value: u8 },
+    #[error("invalid Pauli width: x has {x_width} bits, z has {z_width}")]
+    InvalidPauliWidth { x_width: usize, z_width: usize },
+    #[error("non-binary Pauli bit {value} in {which} support at index {index}")]
+    InvalidPauliBit {
+        which: &'static str,
+        index: usize,
+        value: u8,
+    },
+    #[error("stabilizers do not mutually commute")]
+    NonCommutingStabilizers,
+    #[error("stabilizers are linearly dependent")]
+    DependentStabilizers,
+    #[error("CSS X/Z checks are not orthogonal")]
+    InvalidCssOrthogonality,
+    #[error("unknown built-in CSS code: {code_id}")]
+    UnknownBuiltInCssCode { code_id: String },
+    #[error("logical basis extraction is unsupported for {k} logical qubits")]
+    UnsupportedLogicalBasis { k: usize },
+    #[error("exhaustive Pauli enumeration is unsupported for {n} qubits on this target")]
+    UnsupportedExhaustiveEnumeration { n: usize },
+    #[error("logical basis not found")]
+    LogicalBasisNotFound,
+    #[error("distance witness not found")]
+    DistanceWitnessNotFound,
+}
+```
+
+- [ ] **Step 2: Add the registry tests and canonical-support helper**
+
+```rust
+use qec_code::codes::built_in_css::built_in_css_checks;
+use qec_code::codes::steane::Steane;
+use qec_code::css::CssCode;
+use qec_code::{Pauli, QecError, StabilizerCode};
+
+fn assert_strictly_increasing_rows(rows: &[Vec<usize>]) {
+    for row in rows {
+        assert!(
+            row.windows(2).all(|pair| pair[0] < pair[1]),
+            "row is not canonical: {row:?}"
+        );
+    }
+}
+
+#[test]
+fn built_in_css_registry_exposes_steane_checks() {
+    let checks = built_in_css_checks("steane").unwrap();
+
+    assert_eq!(checks.code_id, "steane");
+    assert_eq!(checks.num_cols, 7);
+    assert_eq!(
+        checks.hx,
+        vec![
+            vec![0, 3, 5, 6],
+            vec![1, 3, 4, 6],
+            vec![2, 4, 5, 6],
+        ]
+    );
+    assert_eq!(checks.hz, checks.hx);
+    assert_strictly_increasing_rows(&checks.hx);
+    assert_strictly_increasing_rows(&checks.hz);
+}
+
+#[test]
+fn built_in_css_registry_rejects_unknown_code_id() {
+    assert_eq!(
+        built_in_css_checks("unknown"),
+        Err(QecError::UnknownBuiltInCssCode {
+            code_id: "unknown".to_owned(),
+        })
+    );
+}
+```
+
+- [ ] **Step 3: Run the targeted registry test command and confirm it still fails on the missing registry API**
+
+Run:
+
+```bash
+cargo test -p qec-code --test code built_in_css_registry_exposes_steane_checks built_in_css_registry_rejects_unknown_code_id
+```
+
+Expected: compile fails until the registry module exists, but the new error variant resolves cleanly and the failure is limited to the missing `built_in_css` API.
+
+- [ ] **Step 4: Commit the test-and-error change**
+
+```bash
+git add qec-code/src/error.rs qec-code/tests/code.rs
+git commit -m "test: add built-in css registry coverage"
+```
+
+### Task 2: Add the built-in CSS registry module and export it
+
+**Files:**
+- Create: `qec-code/src/codes/built_in_css.rs`
+- Modify: `qec-code/src/codes/mod.rs`
+
+- [ ] **Step 1: Add the registry module with canonical Steane row supports**
+
+```rust
+use crate::error::{QecError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuiltInCssChecks {
+    pub code_id: &'static str,
+    pub num_cols: usize,
+    pub hx: Vec<Vec<usize>>,
+    pub hz: Vec<Vec<usize>>,
+}
+
+const STEANE_ROW_SUPPORTS: &[&[usize]] = &[
+    &[0, 3, 5, 6],
+    &[1, 3, 4, 6],
+    &[2, 4, 5, 6],
+];
+
+pub fn built_in_css_checks(code_id: &str) -> Result<BuiltInCssChecks> {
+    match code_id {
+        "steane" => {
+            let hx = STEANE_ROW_SUPPORTS
+                .iter()
+                .map(|row| row.to_vec())
+                .collect::<Vec<_>>();
+
+            Ok(BuiltInCssChecks {
+                code_id: "steane",
+                num_cols: 7,
+                hx: hx.clone(),
+                hz: hx,
+            })
+        }
+        _ => Err(QecError::UnknownBuiltInCssCode {
+            code_id: code_id.to_owned(),
+        }),
+    }
+}
+```
+
+- [ ] **Step 2: Export the new registry module from `codes/mod.rs`**
+
+```rust
+pub mod built_in_css;
+pub mod steane;
+```
+
+- [ ] **Step 3: Run the focused registry tests and confirm the new API passes**
+
+Run:
+
+```bash
+cargo test -p qec-code --test code built_in_css_registry_exposes_steane_checks built_in_css_registry_rejects_unknown_code_id
+```
+
+Expected: both registry tests pass, and the existing `css` / `stabilizer` tests in `qec-code/tests/code.rs` still compile and pass.
+
+- [ ] **Step 4: Commit the registry module**
+
+```bash
+git add qec-code/src/codes/built_in_css.rs qec-code/src/codes/mod.rs
+git commit -m "feat: add built-in css registry"
+```
+
+### Task 3: Rewire `Steane::new()` to lower from the registry
+
+**Files:**
+- Modify: `qec-code/src/codes/steane.rs`
+
+- [ ] **Step 1: Replace the inline dense checks with a registry lookup and private lowering helper**
+
+```rust
+use crate::code::StabilizerCode;
+use crate::codes::built_in_css::built_in_css_checks;
+use crate::css::CssCode;
+use crate::error::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Steane {
+    code: StabilizerCode,
+}
+
+impl Steane {
+    pub fn new() -> Result<Self> {
+        let checks = built_in_css_checks("steane")?;
+        let hx = row_supports_to_dense(checks.num_cols, &checks.hx);
+        let hz = row_supports_to_dense(checks.num_cols, &checks.hz);
+        let css = CssCode::from_hx_hz(hx, hz)?;
+
+        Ok(Self {
+            code: css.code().clone(),
+        })
+    }
+
+    pub fn code(&self) -> &StabilizerCode {
+        &self.code
+    }
+}
+
+fn row_supports_to_dense(num_cols: usize, rows: &[Vec<usize>]) -> Vec<Vec<u8>> {
+    let mut matrix = vec![vec![0; num_cols]; rows.len()];
+
+    for (row_idx, row) in rows.iter().enumerate() {
+        for &col in row {
+            matrix[row_idx][col] = 1;
+        }
+    }
+
+    matrix
+}
+```
+
+- [ ] **Step 2: Run the code tests and the CLI smoke tests**
+
+Run:
+
+```bash
+cargo test -p qec-code --test code
+cargo test -p qec-code --test cli
+```
+
+Expected: all tests pass, including the new registry coverage and the existing Steane summary/distance/logicals checks.
+
+- [ ] **Step 3: Run the full crate test suite**
+
+Run:
+
+```bash
+cargo test -p qec-code
+```
+
+Expected: full `qec-code` test suite passes with no regressions.
+
+- [ ] **Step 4: Commit the Steane refactor**
+
+```bash
+git add qec-code/src/codes/steane.rs
+git commit -m "refactor: lower steane from built-in css registry"
+```
+
+### Task 4: Final verification and handoff
+
+**Files:**
+- No code changes; verify the working tree and test status
+
+- [ ] **Step 1: Confirm the final state is clean except for unrelated user work**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only unrelated pre-existing changes remain, if any.
+
+- [ ] **Step 2: Re-run the issue-specific acceptance command**
+
+Run:
+
+```bash
+cargo test -p qec-code --test code built_in_css_registry_exposes_steane_checks built_in_css_registry_rejects_unknown_code_id
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Report completion with the exact files that changed**
+
+Mention:
+
+- `qec-code/src/error.rs`
+- `qec-code/src/codes/mod.rs`
+- `qec-code/src/codes/built_in_css.rs`
+- `qec-code/src/codes/steane.rs`
+- `qec-code/tests/code.rs`

--- a/docs/superpowers/specs/2026-06-14-built-in-css-registry-design.md
+++ b/docs/superpowers/specs/2026-06-14-built-in-css-registry-design.md
@@ -1,0 +1,291 @@
+Date: 2026-06-14
+Status: Proposed
+Scope: `qec-code` built-in CSS registry for raw `Hx`/`Hz` access, with `Steane::new()` lowered from the same source data
+
+## Summary
+
+Issue #54 asks `qec-code` to expose built-in CSS parity-check data by code id
+instead of only exposing the lowered `StabilizerCode`.
+
+The change should add a small built-in CSS registry in `qec-code/src/codes/`
+that returns canonical row-support data:
+
+- lookup by built-in CSS code id such as `steane`
+- stable result shape `BuiltInCssChecks`
+- `hx` and `hz` represented as sorted, duplicate-free row supports
+- rejection of unknown ids via a dedicated error
+- `Steane::new()` rebuilt from the same registry data instead of maintaining
+  a separate copy of the parity checks
+
+This task is intentionally narrow. It does not expand the CLI, logical-basis
+APIs, distance APIs, or non-CSS built-in code support.
+
+## Goals
+
+- Add a stable library lookup for built-in CSS code checks by code id.
+- Return raw CSS check data in a reusable form before lowering to
+  `StabilizerCode`.
+- Keep the API extensible so future CSS families can be added without changing
+  the public function shape.
+- Make `Steane::new()` consume the same raw matrix source as the registry.
+- Verify that built-in row supports are canonical: sorted and duplicate-free.
+
+## Non-Goals
+
+- Do not add non-CSS built-in code registries.
+- Do not change CLI output or add CLI subcommands.
+- Do not extend `CssCode` with a new public constructor that accepts row
+  supports directly.
+- Do not add user-facing import/export formats for parity-check data.
+- Do not change logical-basis extraction or distance computation behavior.
+
+## Current State
+
+`qec-code` already has:
+
+- a general `StabilizerCode` core
+- `CssCode::from_hx_hz(hx, hz)` for dense binary check matrices
+- `Steane::new()` as the first built-in code constructor
+
+What is missing is a library path that exposes the raw built-in CSS check data
+itself. Today `Steane::new()` hard-codes the dense Hamming-style check rows
+inside `qec-code/src/codes/steane.rs`, and callers cannot reuse those checks
+without duplicating constants or extracting them from the lowered code.
+
+That is the wrong ownership boundary. Built-in code data should live with the
+built-in code registry, and the convenience constructor should lower from that
+shared source.
+
+## Alternatives Considered
+
+### 1. Built-in CSS registry under `codes/`
+
+Add a dedicated module next to `qec-code/src/codes/mod.rs` that owns built-in
+CSS metadata and lookup.
+
+Benefits:
+
+- matches the issue request directly
+- keeps built-in code lookup separate from CSS validation logic
+- gives future CSS families one obvious place to land
+- lets `Steane::new()` and downstream callers share the same source of truth
+
+Costs:
+
+- requires one small lowering helper from row supports to dense bit rows
+
+This is the recommended option.
+
+### 2. Put built-in lookup into `css.rs`
+
+Make the CSS convenience layer also own built-in code ids and registry lookup.
+
+Benefits:
+
+- slightly fewer modules in the short term
+
+Costs:
+
+- mixes built-in code catalog concerns with generic CSS construction
+- makes `css.rs` responsible for both validation semantics and built-in naming
+- blurs the separation between reusable constructors and shipped examples
+
+This is not the recommended option.
+
+### 3. Keep per-code constants and add a thin forwarding registry
+
+Leave `steane.rs` as the owner of its check constants and make a registry that
+forwards to those constants.
+
+Benefits:
+
+- smallest code diff
+
+Costs:
+
+- preserves duplicate ownership of built-in data
+- does not satisfy the design goal that `Steane::new()` and registry lookup use
+  one shared raw matrix source
+
+This is not the recommended option.
+
+## Decision
+
+Add a built-in CSS registry module under `qec-code/src/codes/`, expose a
+stable lookup function, and move built-in Steane check ownership there.
+
+The first implementation should only ship `steane`, but the API must be shaped
+so that future built-in CSS codes can be added without changing the lookup
+contract.
+
+## Module Structure
+
+The `codes` module should grow from:
+
+- `codes::steane`
+
+to:
+
+- `codes::built_in_css`
+- `codes::steane`
+
+Responsibilities:
+
+- `codes::built_in_css`
+  - defines the stable `BuiltInCssChecks` result type
+  - owns built-in CSS row-support data
+  - exposes lookup by `code_id`
+- `codes::steane`
+  - remains the ergonomic built-in constructor
+  - no longer owns its own parity-check constants
+  - lowers registry data through `CssCode::from_hx_hz(...)`
+
+`css.rs` remains a constructor/validation layer for dense `Hx`/`Hz` matrices.
+It does not become the home for built-in code ids.
+
+## Public API
+
+The registry should expose one public lookup function:
+
+```rust
+pub fn built_in_css_checks(code_id: &str) -> Result<BuiltInCssChecks>
+```
+
+The stable result shape should be:
+
+```rust
+pub struct BuiltInCssChecks {
+    pub code_id: &'static str,
+    pub num_cols: usize,
+    pub hx: Vec<Vec<usize>>,
+    pub hz: Vec<Vec<usize>>,
+}
+```
+
+Design notes:
+
+- `code_id` should be `&'static str` because built-in ids are compile-time
+  constants and do not require allocation in the returned value.
+- `hx` and `hz` should use row-support form instead of dense `Vec<Vec<u8>>`.
+- each returned support row is canonical: sorted ascending and duplicate-free.
+- the first implementation only recognizes `steane`.
+
+The registry result should be owning data. Callers should not need to care
+whether the implementation started from static slices or other internal
+storage.
+
+## Data Model and Lowering
+
+The built-in registry should store canonical row-support constants for Steane.
+
+Representative shape:
+
+- `num_cols = 7`
+- `hx = [[0, 3, 5, 6], [1, 3, 4, 6], [2, 4, 5, 6]]`
+- `hz = [[0, 3, 5, 6], [1, 3, 4, 6], [2, 4, 5, 6]]`
+
+The runtime data flow should be:
+
+1. `built_in_css_checks("steane")` returns canonical support rows.
+2. `Steane::new()` calls the registry function.
+3. `Steane::new()` lowers support rows into dense binary matrices of width
+   `num_cols`.
+4. `Steane::new()` calls `CssCode::from_hx_hz(...)`.
+5. `CssCode` lowers to the existing general `StabilizerCode`.
+
+This keeps the public surface for this issue tight:
+
+- built-in registry exposes reusable raw CSS data
+- `CssCode` continues to accept dense matrices only
+- `Steane::new()` becomes a consumer of the registry instead of a second source
+  of truth
+
+This design deliberately does not add a new public `CssCode` constructor for
+row supports. That would widen the task from "add a built-in registry" to
+"expand the CSS construction API", which issue #54 does not require.
+
+## Error Handling
+
+Unknown built-in ids should be rejected with a dedicated public error:
+
+```rust
+QecError::UnknownBuiltInCssCode { code_id: String }
+```
+
+Behavioral requirements:
+
+- preserve the original user-provided id string in the error
+- do not silently map unknown ids to a default code
+- do not return a generic formatting or parse error for this case
+
+No additional public error variant is needed for malformed built-in row
+supports. Those supports are crate-owned constants, not user input. If the
+registry constants are wrong, that is an implementation bug to be caught by
+tests, not a runtime-recovery API surface.
+
+## Canonicalization Policy
+
+The registry must return canonical data, but it should not canonicalize at
+lookup time.
+
+Chosen policy:
+
+- built-in row-support constants are authored in canonical form
+- tests assert the canonical invariants
+- lookup returns the stored canonical data unchanged
+
+Rejected policy:
+
+- sort rows on every lookup
+- deduplicate entries on every lookup
+- quietly repair malformed built-in rows at runtime
+
+Runtime repair would hide bugs in crate-maintained constants and make tests
+less meaningful.
+
+## Testing and Verification
+
+Acceptance should be anchored by the two issue-specified tests:
+
+```text
+cargo test -p qec-code --test code built_in_css_registry_exposes_steane_checks built_in_css_registry_rejects_unknown_code_id
+```
+
+The first test should verify:
+
+- `built_in_css_checks("steane")` succeeds
+- `code_id == "steane"`
+- `num_cols == 7`
+- `hx` equals the expected Steane support rows
+- `hz` equals the expected Steane support rows
+- each support row is sorted
+- each support row has no duplicates
+
+The second test should verify:
+
+- unknown ids return `QecError::UnknownBuiltInCssCode { .. }`
+- the error preserves the attempted id
+- no default built-in code is returned
+
+Existing Steane invariants should remain covered:
+
+- `Steane::new()` still produces `n = 7`
+- stabilizer rank remains `6`
+- the code still has `k = 1`
+- stabilizer rows still lower to the expected binary symplectic width
+
+This preserves confidence in both the new lookup API and the existing built-in
+constructor path.
+
+## Out of Scope Follow-Ups
+
+This design intentionally leaves these as later work:
+
+- additional built-in CSS codes beyond `steane`
+- a public helper for lowering support rows to dense matrices
+- a public `CssCode::from_supports(...)` constructor
+- non-CSS built-in code registries
+- CLI inspection commands for built-in check data
+
+Those extensions can be added later if real consumers appear, without changing
+the core lookup contract established here.

--- a/qec-code/src/codes/built_in_css.rs
+++ b/qec-code/src/codes/built_in_css.rs
@@ -1,0 +1,36 @@
+use crate::error::{QecError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuiltInCssChecks {
+    pub code_id: &'static str,
+    pub num_cols: usize,
+    pub hx: Vec<Vec<usize>>,
+    pub hz: Vec<Vec<usize>>,
+}
+
+const STEANE_ROW_SUPPORTS: &[&[usize]] = &[
+    &[0, 3, 5, 6],
+    &[1, 3, 4, 6],
+    &[2, 4, 5, 6],
+];
+
+pub fn built_in_css_checks(code_id: &str) -> Result<BuiltInCssChecks> {
+    match code_id {
+        "steane" => {
+            let hx = STEANE_ROW_SUPPORTS
+                .iter()
+                .map(|row| row.to_vec())
+                .collect::<Vec<_>>();
+
+            Ok(BuiltInCssChecks {
+                code_id: "steane",
+                num_cols: 7,
+                hx: hx.clone(),
+                hz: hx,
+            })
+        }
+        _ => Err(QecError::UnknownBuiltInCssCode {
+            code_id: code_id.to_owned(),
+        }),
+    }
+}

--- a/qec-code/src/codes/mod.rs
+++ b/qec-code/src/codes/mod.rs
@@ -1,1 +1,2 @@
+pub mod built_in_css;
 pub mod steane;

--- a/qec-code/src/codes/steane.rs
+++ b/qec-code/src/codes/steane.rs
@@ -1,4 +1,5 @@
 use crate::code::StabilizerCode;
+use crate::codes::built_in_css::built_in_css_checks;
 use crate::css::CssCode;
 use crate::error::Result;
 
@@ -9,12 +10,10 @@ pub struct Steane {
 
 impl Steane {
     pub fn new() -> Result<Self> {
-        let h = vec![
-            vec![1, 0, 0, 1, 0, 1, 1],
-            vec![0, 1, 0, 1, 1, 0, 1],
-            vec![0, 0, 1, 0, 1, 1, 1],
-        ];
-        let css = CssCode::from_hx_hz(h.clone(), h)?;
+        let checks = built_in_css_checks("steane")?;
+        let hx = row_supports_to_dense(checks.num_cols, &checks.hx);
+        let hz = row_supports_to_dense(checks.num_cols, &checks.hz);
+        let css = CssCode::from_hx_hz(hx, hz)?;
 
         Ok(Self {
             code: css.code().clone(),
@@ -24,4 +23,16 @@ impl Steane {
     pub fn code(&self) -> &StabilizerCode {
         &self.code
     }
+}
+
+fn row_supports_to_dense(num_cols: usize, rows: &[Vec<usize>]) -> Vec<Vec<u8>> {
+    let mut matrix = vec![vec![0; num_cols]; rows.len()];
+
+    for (row_idx, row) in rows.iter().enumerate() {
+        for &col in row {
+            matrix[row_idx][col] = 1;
+        }
+    }
+
+    matrix
 }

--- a/qec-code/src/error.rs
+++ b/qec-code/src/error.rs
@@ -30,6 +30,8 @@ pub enum QecError {
     LogicalBasisNotFound,
     #[error("distance witness not found")]
     DistanceWitnessNotFound,
+    #[error("unknown built-in CSS code: {code_id}")]
+    UnknownBuiltInCssCode { code_id: String },
 }
 
 pub type Result<T> = core::result::Result<T, QecError>;

--- a/qec-code/tests/code.rs
+++ b/qec-code/tests/code.rs
@@ -1,6 +1,16 @@
+use qec_code::codes::built_in_css::built_in_css_checks;
 use qec_code::codes::steane::Steane;
 use qec_code::css::CssCode;
 use qec_code::{Pauli, QecError, StabilizerCode};
+
+fn assert_strictly_increasing_rows(rows: &[Vec<usize>]) {
+    for row in rows {
+        assert!(
+            row.windows(2).all(|pair| pair[0] < pair[1]),
+            "row is not canonical: {row:?}"
+        );
+    }
+}
 
 #[test]
 fn stabilizer_code_rejects_noncommuting_generators() {
@@ -94,4 +104,33 @@ fn steane_exposes_expected_invariants() {
     assert_eq!(code.stabilizers().len(), 6);
     assert_eq!(code.stabilizer_rows().len(), 6);
     assert_eq!(code.stabilizer_rows()[0].len(), 14);
+}
+
+#[test]
+fn built_in_css_registry_exposes_steane_checks() {
+    let checks = built_in_css_checks("steane").unwrap();
+
+    assert_eq!(checks.code_id, "steane");
+    assert_eq!(checks.num_cols, 7);
+    assert_eq!(
+        checks.hx,
+        vec![
+            vec![0, 3, 5, 6],
+            vec![1, 3, 4, 6],
+            vec![2, 4, 5, 6],
+        ]
+    );
+    assert_eq!(checks.hz, checks.hx);
+    assert_strictly_increasing_rows(&checks.hx);
+    assert_strictly_increasing_rows(&checks.hz);
+}
+
+#[test]
+fn built_in_css_registry_rejects_unknown_code_id() {
+    assert_eq!(
+        built_in_css_checks("unknown"),
+        Err(QecError::UnknownBuiltInCssCode {
+            code_id: "unknown".to_owned(),
+        })
+    );
 }


### PR DESCRIPTION
## Summary
- add a built-in CSS registry in `qec-code` that returns canonical raw `Hx`/`Hz` row supports by code id
- add a dedicated `UnknownBuiltInCssCode` error and integration coverage for the registry API
- rewire `Steane::new()` to lower from the shared registry data instead of a duplicated dense matrix literal

## Test Plan
- [x] `cargo test -p qec-code`
- [x] `cargo test -p qec-code --test code`
- [x] `cargo test -p qec-code --test cli`