### PR TITLE
qec-code: export built-in CSS checks as sparse_rows JSON

### DIFF
--- a/docs/superpowers/plans/2026-06-15-built-in-css-sparse-rows-export.md
+++ b/docs/superpowers/plans/2026-06-15-built-in-css-sparse-rows-export.md
@@ -1,0 +1,335 @@
+# Built-in CSS Sparse Rows Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a validated `sparse_rows` export path in `qec-code` so built-in Steane `hx` and `hz` matrices serialize to the existing workspace JSON fixtures exactly, while malformed sparse-row supports fail with typed errors.
+
+**Architecture:** Keep sparse-row validation and JSON serialization in `qec-code/src/css.rs` as a small dedicated wrapper type instead of pushing format logic into the built-in registry. Reuse the existing `built_in_css_checks("steane")` registry data as the positive export source, add sparse-row-specific `QecError` variants in `qec-code/src/error.rs`, and verify the behavior with one focused integration test file `qec-code/tests/css_export.rs`.
+
+**Tech Stack:** Rust 2024, `qec-code`, `serde`, `serde_json`, `thiserror`, workspace fixture reads with `std::fs`, `cargo test`
+
+---
+
+### Task 1: Add the failing sparse-row export tests first
+
+**Files:**
+- Create: `qec-code/tests/css_export.rs`
+
+- [ ] **Step 1: Write the new integration test file with exact positive and negative coverage**
+
+```rust
+use std::path::PathBuf;
+
+use qec_code::codes::built_in_css::built_in_css_checks;
+use qec_code::css::SparseRowsMatrix;
+use qec_code::QecError;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn read_fixture(rel_path: &str) -> String {
+    std::fs::read_to_string(workspace_root().join(rel_path))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel_path}: {err}"))
+}
+
+#[test]
+fn steane_sparse_rows_json_matches_workspace_fixtures() {
+    let checks = built_in_css_checks("steane").unwrap();
+
+    let hx = SparseRowsMatrix::new(checks.num_cols, checks.hx.clone())
+        .unwrap()
+        .to_json_string();
+    let hz = SparseRowsMatrix::new(checks.num_cols, checks.hz.clone())
+        .unwrap()
+        .to_json_string();
+
+    let expected_hx = read_fixture("rsinter/tests/fixtures/css/steane_hx.json");
+    let expected_hz = read_fixture("rsinter/tests/fixtures/css/steane_hz.json");
+
+    assert_eq!(hx, expected_hx);
+    assert_eq!(hz, expected_hz);
+}
+
+#[test]
+fn sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports() {
+    assert_eq!(
+        SparseRowsMatrix::new(3, vec![vec![0, 0]]),
+        Err(QecError::DuplicateSparseRowSupport { row: 0, support: 0 })
+    );
+
+    assert_eq!(
+        SparseRowsMatrix::new(3, vec![vec![3]]),
+        Err(QecError::SparseRowSupportOutOfRange {
+            row: 0,
+            support: 3,
+            num_cols: 3,
+        })
+    );
+}
+```
+
+- [ ] **Step 2: Run the new test target and confirm it fails because `SparseRowsMatrix` does not exist yet**
+
+Run:
+
+```bash
+cargo test -p qec-code --test css_export
+```
+
+Expected: compile fails with unresolved import / missing type errors for `qec_code::css::SparseRowsMatrix`, while the test names and fixture paths resolve cleanly.
+
+- [ ] **Step 3: Commit the failing-test scaffold**
+
+```bash
+git add qec-code/tests/css_export.rs
+git commit -m "test: add sparse rows export coverage"
+```
+
+### Task 2: Add sparse-row-specific typed errors
+
+**Files:**
+- Modify: `qec-code/src/error.rs`
+
+- [ ] **Step 1: Extend `QecError` with duplicate and out-of-range sparse-row variants**
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum QecError {
+    #[error("row width mismatch: expected {expected}, got {actual}")]
+    RowWidthMismatch { expected: usize, actual: usize },
+    #[error("invalid symplectic row width: expected even width, got {width}")]
+    InvalidSymplecticRowWidth { width: usize },
+    #[error("non-binary matrix entry {value} at row {row}, column {col}")]
+    InvalidBinaryEntry { row: usize, col: usize, value: u8 },
+    #[error("duplicate sparse-row support {support} in row {row}")]
+    DuplicateSparseRowSupport { row: usize, support: usize },
+    #[error(
+        "out-of-range sparse-row support {support} in row {row} for width {num_cols}"
+    )]
+    SparseRowSupportOutOfRange {
+        row: usize,
+        support: usize,
+        num_cols: usize,
+    },
+    #[error("invalid Pauli width: x has {x_width} bits, z has {z_width}")]
+    InvalidPauliWidth { x_width: usize, z_width: usize },
+    #[error("non-binary Pauli bit {value} in {which} support at index {index}")]
+    InvalidPauliBit {
+        which: &'static str,
+        index: usize,
+        value: u8,
+    },
+    #[error("stabilizers do not mutually commute")]
+    NonCommutingStabilizers,
+    #[error("stabilizers are linearly dependent")]
+    DependentStabilizers,
+    #[error("CSS X/Z checks are not orthogonal")]
+    InvalidCssOrthogonality,
+    #[error("logical basis extraction is unsupported for {k} logical qubits")]
+    UnsupportedLogicalBasis { k: usize },
+    #[error("exhaustive Pauli enumeration is unsupported for {n} qubits on this target")]
+    UnsupportedExhaustiveEnumeration { n: usize },
+    #[error("logical basis not found")]
+    LogicalBasisNotFound,
+    #[error("distance witness not found")]
+    DistanceWitnessNotFound,
+    #[error("unknown built-in CSS code: {code_id}")]
+    UnknownBuiltInCssCode { code_id: String },
+}
+```
+
+- [ ] **Step 2: Run the export test again and confirm the failure has narrowed to the missing `SparseRowsMatrix` implementation**
+
+Run:
+
+```bash
+cargo test -p qec-code --test css_export
+```
+
+Expected: compile still fails, but the new `QecError` variants resolve and the only remaining unresolved symbols are the sparse-row wrapper methods/types.
+
+- [ ] **Step 3: Commit the error additions**
+
+```bash
+git add qec-code/src/error.rs
+git commit -m "feat: add sparse rows export errors"
+```
+
+### Task 3: Implement `SparseRowsMatrix` and JSON serialization in `css.rs`
+
+**Files:**
+- Modify: `qec-code/src/css.rs`
+
+- [ ] **Step 1: Add the new wrapper type and its public API near the top of `css.rs`**
+
+```rust
+use crate::Pauli;
+use crate::code::StabilizerCode;
+use crate::error::{QecError, Result};
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SparseRowsMatrix {
+    num_cols: usize,
+    rows: Vec<Vec<usize>>,
+}
+
+impl SparseRowsMatrix {
+    pub fn new(num_cols: usize, rows: Vec<Vec<usize>>) -> Result<Self> {
+        validate_sparse_rows(num_cols, &rows)?;
+        Ok(Self { num_cols, rows })
+    }
+
+    pub fn to_json_string(&self) -> String {
+        #[derive(Serialize)]
+        struct SparseRowsMatrixJson<'a> {
+            format: &'static str,
+            num_cols: usize,
+            rows: &'a [Vec<usize>],
+        }
+
+        serde_json::to_string(&SparseRowsMatrixJson {
+            format: "sparse_rows",
+            num_cols: self.num_cols,
+            rows: &self.rows,
+        })
+        .expect("validated sparse rows matrix should always serialize")
+    }
+}
+```
+
+- [ ] **Step 2: Add the sparse-row validator without mutating caller input**
+
+```rust
+fn validate_sparse_rows(num_cols: usize, rows: &[Vec<usize>]) -> Result<()> {
+    for (row_index, row) in rows.iter().enumerate() {
+        let mut seen = std::collections::BTreeSet::new();
+        for &support in row {
+            if support >= num_cols {
+                return Err(QecError::SparseRowSupportOutOfRange {
+                    row: row_index,
+                    support,
+                    num_cols,
+                });
+            }
+            if !seen.insert(support) {
+                return Err(QecError::DuplicateSparseRowSupport {
+                    row: row_index,
+                    support,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Run the export test target and confirm both issue-55 tests now pass**
+
+Run:
+
+```bash
+cargo test -p qec-code --test css_export
+```
+
+Expected: both `steane_sparse_rows_json_matches_workspace_fixtures` and `sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports` pass.
+
+- [ ] **Step 4: Commit the sparse-row wrapper implementation**
+
+```bash
+git add qec-code/src/css.rs
+git commit -m "feat: add sparse rows matrix export"
+```
+
+### Task 4: Run focused regression coverage for existing `qec-code` behavior
+
+**Files:**
+- Modify: `qec-code/tests/code.rs`
+
+- [ ] **Step 1: Add one library-level smoke test that `SparseRowsMatrix` can round-trip the built-in Steane shape without affecting existing registry tests**
+
+```rust
+use qec_code::codes::built_in_css::built_in_css_checks;
+use qec_code::codes::steane::Steane;
+use qec_code::css::{CssCode, SparseRowsMatrix};
+use qec_code::{Pauli, QecError, StabilizerCode};
+
+#[test]
+fn sparse_rows_matrix_serializes_steane_supports() {
+    let checks = built_in_css_checks("steane").unwrap();
+    let text = SparseRowsMatrix::new(checks.num_cols, checks.hx.clone())
+        .unwrap()
+        .to_json_string();
+
+    assert_eq!(
+        text,
+        r#"{"format":"sparse_rows","num_cols":7,"rows":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}"#
+    );
+}
+```
+
+- [ ] **Step 2: Run the focused code test file**
+
+Run:
+
+```bash
+cargo test -p qec-code --test code
+```
+
+Expected: the existing `code` integration tests still pass, including the new Steane sparse-row serialization smoke test.
+
+- [ ] **Step 3: Commit the regression smoke test**
+
+```bash
+git add qec-code/tests/code.rs
+git commit -m "test: cover sparse rows matrix from built-in checks"
+```
+
+### Task 5: Run the full `qec-code` verification suite and close the issue scope
+
+**Files:**
+- Modify: none
+- Test: `qec-code/tests/css_export.rs`
+- Test: `qec-code/tests/code.rs`
+- Test: `qec-code/tests/cli.rs`
+
+- [ ] **Step 1: Run the exact issue verification command**
+
+Run:
+
+```bash
+cargo test -p qec-code --test css_export steane_sparse_rows_json_matches_workspace_fixtures sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports
+```
+
+Expected: both named tests pass.
+
+- [ ] **Step 2: Run the full crate test suite**
+
+Run:
+
+```bash
+cargo test -p qec-code
+```
+
+Expected: all `qec-code` unit, integration, and CLI tests pass.
+
+- [ ] **Step 3: Inspect the final diff before shipping**
+
+Run:
+
+```bash
+git diff --stat HEAD~4..HEAD
+git status --short
+```
+
+Expected: only `qec-code/src/css.rs`, `qec-code/src/error.rs`, `qec-code/tests/code.rs`, and `qec-code/tests/css_export.rs` are changed for issue #55, with no unrelated workspace churn.
+
+- [ ] **Step 4: Commit the final verification checkpoint**
+
+```bash
+git add qec-code/src/css.rs qec-code/src/error.rs qec-code/tests/code.rs qec-code/tests/css_export.rs
+git commit -m "test: verify sparse rows export coverage"
+```

--- a/docs/superpowers/plans/2026-06-15-built-in-css-sparse-rows-export.md
+++ b/docs/superpowers/plans/2026-06-15-built-in-css-sparse-rows-export.md
@@ -47,8 +47,8 @@ fn steane_sparse_rows_json_matches_workspace_fixtures() {
     let expected_hx = read_fixture("rsinter/tests/fixtures/css/steane_hx.json");
     let expected_hz = read_fixture("rsinter/tests/fixtures/css/steane_hz.json");
 
-    assert_eq!(hx, expected_hx);
-    assert_eq!(hz, expected_hz);
+    assert_eq!(format!("{hx}\n"), expected_hx);
+    assert_eq!(format!("{hz}\n"), expected_hz);
 }
 
 #[test]
@@ -65,6 +65,14 @@ fn sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports() {
             support: 3,
             num_cols: 3,
         })
+    );
+}
+
+#[test]
+fn sparse_rows_matrix_rejects_zero_width() {
+    assert_eq!(
+        SparseRowsMatrix::new(0, vec![]),
+        Err(QecError::InvalidSparseRowsWidth { num_cols: 0 })
     );
 }
 ```
@@ -104,6 +112,8 @@ pub enum QecError {
     InvalidSymplecticRowWidth { width: usize },
     #[error("non-binary matrix entry {value} at row {row}, column {col}")]
     InvalidBinaryEntry { row: usize, col: usize, value: u8 },
+    #[error("invalid sparse-rows width: {num_cols}")]
+    InvalidSparseRowsWidth { num_cols: usize },
     #[error("duplicate sparse-row support {support} in row {row}")]
     DuplicateSparseRowSupport { row: usize, support: usize },
     #[error(
@@ -205,6 +215,10 @@ impl SparseRowsMatrix {
 
 ```rust
 fn validate_sparse_rows(num_cols: usize, rows: &[Vec<usize>]) -> Result<()> {
+    if num_cols == 0 {
+        return Err(QecError::InvalidSparseRowsWidth { num_cols });
+    }
+
     for (row_index, row) in rows.iter().enumerate() {
         let mut seen = std::collections::BTreeSet::new();
         for &support in row {
@@ -235,7 +249,7 @@ Run:
 cargo test -p qec-code --test css_export
 ```
 
-Expected: both `steane_sparse_rows_json_matches_workspace_fixtures` and `sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports` pass. Because the fixture files on disk end with `\n`, `to_json_string()` is expected to return fixture-matching text including that trailing newline.
+Expected: both `steane_sparse_rows_json_matches_workspace_fixtures` and `sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports` pass. Because the fixture files on disk end with `\n`, the fixture-parity test appends that newline at the assertion boundary; `to_json_string()` itself returns compact JSON without a line terminator.
 
 - [ ] **Step 4: Commit the sparse-row wrapper implementation**
 
@@ -266,7 +280,7 @@ fn sparse_rows_matrix_serializes_steane_supports() {
 
     assert_eq!(
         text,
-        "{\"format\":\"sparse_rows\",\"num_cols\":7,\"rows\":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}\n"
+        "{\"format\":\"sparse_rows\",\"num_cols\":7,\"rows\":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}"
     );
 }
 ```

--- a/docs/superpowers/plans/2026-06-15-built-in-css-sparse-rows-export.md
+++ b/docs/superpowers/plans/2026-06-15-built-in-css-sparse-rows-export.md
@@ -235,7 +235,7 @@ Run:
 cargo test -p qec-code --test css_export
 ```
 
-Expected: both `steane_sparse_rows_json_matches_workspace_fixtures` and `sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports` pass.
+Expected: both `steane_sparse_rows_json_matches_workspace_fixtures` and `sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports` pass. Because the fixture files on disk end with `\n`, `to_json_string()` is expected to return fixture-matching text including that trailing newline.
 
 - [ ] **Step 4: Commit the sparse-row wrapper implementation**
 
@@ -266,7 +266,7 @@ fn sparse_rows_matrix_serializes_steane_supports() {
 
     assert_eq!(
         text,
-        r#"{"format":"sparse_rows","num_cols":7,"rows":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}"#
+        "{\"format\":\"sparse_rows\",\"num_cols\":7,\"rows\":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}\n"
     );
 }
 ```

--- a/docs/superpowers/specs/2026-06-15-built-in-css-sparse-rows-export-design.md
+++ b/docs/superpowers/specs/2026-06-15-built-in-css-sparse-rows-export-design.md
@@ -185,9 +185,8 @@ API notes:
 - `new(...)` owns validation and is the only fallible step.
 - `to_json_string()` is infallible because a constructed value is already
   validated.
-- the JSON output must be canonical and compact, matching the fixture document
-  bytes used by the workspace tests. For the current Steane fixtures, that
-  includes the trailing newline present on disk.
+- the JSON output must be canonical and compact, without a trailing newline.
+  Writers that need line-oriented output should append their own newline.
 - the wrapper is intentionally narrow and does not yet expose file I/O helpers.
 
 ## Validation Rules
@@ -195,9 +194,10 @@ API notes:
 `SparseRowsMatrix::new(...)` should enforce only the invariants required by the
 workspace `sparse_rows` contract for this issue:
 
-1. Every support entry in every row must be `< num_cols`.
-2. No support entry may appear more than once within a row.
-3. Row order must be preserved exactly as provided; the wrapper must not sort,
+1. `num_cols` must be positive.
+2. Every support entry in every row must be `< num_cols`.
+3. No support entry may appear more than once within a row.
+4. Row order must be preserved exactly as provided; the wrapper must not sort,
    normalize, or otherwise repair input rows.
 
 Chosen non-rules:
@@ -213,10 +213,11 @@ quietly normalize bad inputs.
 
 ## Error Handling
 
-Sparse-row validation should stay in the existing `QecError` enum. Add two new
+Sparse-row validation should stay in the existing `QecError` enum. Add three new
 variants with enough detail for precise tests and debugging:
 
 ```rust
+QecError::InvalidSparseRowsWidth { num_cols: usize }
 QecError::DuplicateSparseRowSupport { row: usize, support: usize }
 QecError::SparseRowSupportOutOfRange {
     row: usize,
@@ -230,6 +231,7 @@ Behavioral expectations:
 - duplicate detection should report the row index and offending support
 - out-of-range detection should report the row index, offending support, and
   declared width
+- zero-width matrices should be rejected before checking rows
 - the constructor should fail fast on the first invalid row entry
 
 These errors are for user-provided or caller-provided row supports. They are
@@ -242,14 +244,15 @@ The positive path for built-in export should be:
 1. `built_in_css_checks("steane")` returns canonical row supports.
 2. The caller selects exactly one matrix: `hx` or `hz`.
 3. `SparseRowsMatrix::new(checks.num_cols, selected_rows)` validates the data.
-4. `to_json_string()` emits the fixture-matching document text:
+4. `to_json_string()` emits the compact document text:
 
 ```json
 {"format":"sparse_rows","num_cols":N,"rows":[...]}
 ```
 
-The current workspace fixtures store that JSON document with a trailing newline,
-so byte-for-byte fixture parity includes that newline.
+The current workspace fixtures store that JSON document with a trailing newline.
+Byte-for-byte fixture parity should append that newline at the test or writer
+boundary, not bake it into `to_json_string()`.
 
 This keeps the issue aligned with the required input/output contract:
 

--- a/docs/superpowers/specs/2026-06-15-built-in-css-sparse-rows-export-design.md
+++ b/docs/superpowers/specs/2026-06-15-built-in-css-sparse-rows-export-design.md
@@ -1,0 +1,308 @@
+Date: 2026-06-15
+Status: Draft accepted in-session, written for review
+Scope: GitHub issue #55, sparse-row JSON export for built-in CSS checks in `qec-code`
+
+## Summary
+
+Issue #55 asks `qec-code` to export built-in CSS parity-check matrices through
+the workspace's existing `sparse_rows` JSON contract instead of inventing a new
+format.
+
+The change should stay narrow:
+
+- add a validated `sparse_rows` wrapper in `qec-code`
+- serialize one matrix at a time (`hx` or `hz`)
+- make built-in Steane export match the existing workspace fixtures byte-for-byte
+- reject malformed sparse-row supports with dedicated typed errors
+
+This task does not add CLI output, new code families, or cross-crate plumbing.
+It is a library-only export path plus tests.
+
+## Goals
+
+- Add a reusable `sparse_rows` matrix representation in `qec-code`.
+- Keep validation and JSON serialization in the generic CSS layer instead of
+  the built-in registry layer.
+- Export built-in Steane `hx` and `hz` matrices as standalone JSON documents
+  matching the existing `rsinter` fixtures exactly.
+- Reject duplicate and out-of-range support entries with specific `QecError`
+  variants.
+- Add issue-teeth tests that prove the positive and negative paths.
+
+## Non-Goals
+
+- Do not add a new top-level `{hx, hz}` JSON shape.
+- Do not add CLI commands or CLI flags.
+- Do not change `rstim`, `rsinter`, or fixture consumers.
+- Do not add new built-in CSS code families.
+- Do not widen this work into generic CSS import/export workflows beyond the
+  one `sparse_rows` contract already used in the workspace.
+- Do not add cross-row CSS-code validation such as orthogonality checks inside
+  the sparse-row wrapper.
+
+## Current State
+
+The workspace already has a canonical sparse-row JSON format in
+`rsinter/tests/fixtures/css/steane_hx.json` and
+`rsinter/tests/fixtures/css/steane_hz.json`:
+
+```json
+{"format":"sparse_rows","num_cols":7,"rows":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}
+```
+
+`qec-code` now exposes built-in Steane checks through
+`built_in_css_checks("steane")`, returning canonical row supports:
+
+- `num_cols = 7`
+- `hx = [[0, 3, 5, 6], [1, 3, 4, 6], [2, 4, 5, 6]]`
+- `hz = [[0, 3, 5, 6], [1, 3, 4, 6], [2, 4, 5, 6]]`
+
+What is missing is a typed library boundary that says "this is a validated
+`sparse_rows` matrix" and can serialize it back to the exact JSON contract.
+Without that boundary, callers would either hand-roll JSON or push JSON logic
+down into the built-in registry, which is the wrong ownership split.
+
+## Alternatives Considered
+
+### 1. Free function in `css.rs`
+
+Add a helper such as:
+
+```rust
+pub fn serialize_sparse_rows_json(num_cols: usize, rows: Vec<Vec<usize>>) -> Result<String>
+```
+
+Benefits:
+
+- smallest API surface
+- smallest code diff
+
+Costs:
+
+- validation and serialization are only loosely coupled
+- negative-path tests must target a helper instead of a stable value type
+- future reuse becomes a pile of ad hoc helpers
+
+This is workable, but not the recommended option.
+
+### 2. Small wrapper type in `css.rs`
+
+Add a dedicated sparse-row matrix wrapper such as:
+
+```rust
+pub struct SparseRowsMatrix {
+    num_cols: usize,
+    rows: Vec<Vec<usize>>,
+}
+```
+
+Benefits:
+
+- gives the contract a clear ownership boundary
+- binds validation to construction
+- makes positive and negative tests direct and natural
+- keeps built-in registry concerns separate from JSON contract concerns
+- leaves room for future reuse without widening this issue now
+
+Costs:
+
+- one extra type to carry around
+- one small amount of owned data copying when exporting built-ins
+
+This is the recommended option.
+
+### 3. Serialize directly in `built_in_css.rs`
+
+Make the built-in registry itself return JSON strings or own the sparse-row
+serialization logic.
+
+Benefits:
+
+- minimal short-term diff
+
+Costs:
+
+- mixes built-in code catalog responsibilities with format-contract logic
+- makes malformed-input tests unnatural because built-in Steane data is already
+  valid
+- reduces reuse for non-built-in CSS matrices
+
+This is not the recommended option.
+
+## Decision
+
+Add a small `SparseRowsMatrix` type under `qec-code/src/css.rs`, make it the
+single owner of sparse-row validation and JSON serialization, and keep the
+built-in registry as a thin source of canonical row-support data.
+
+For issue #55, built-in export can stay explicit at the call site:
+
+1. fetch built-in checks with `built_in_css_checks("steane")`
+2. build `SparseRowsMatrix::new(checks.num_cols, checks.hx.clone())`
+3. call `to_json_string()`
+
+No extra convenience API on `BuiltInCssChecks` is required for this issue.
+
+## Module Structure
+
+The implementation should stay within the existing crate boundaries:
+
+- `qec-code/src/css.rs`
+  - add `SparseRowsMatrix`
+  - add sparse-row validation
+  - add JSON serialization
+- `qec-code/src/error.rs`
+  - add sparse-row-specific error variants
+- `qec-code/tests/css_export.rs`
+  - add issue-specific export tests
+
+`qec-code/src/codes/built_in_css.rs` remains the owner of built-in check data
+only. It should not become a JSON-formatting module.
+
+## Public API
+
+The wrapper type should be public so library callers can use it without going
+through built-in code lookup:
+
+```rust
+pub struct SparseRowsMatrix {
+    num_cols: usize,
+    rows: Vec<Vec<usize>>,
+}
+```
+
+Recommended constructor and serializer:
+
+```rust
+impl SparseRowsMatrix {
+    pub fn new(num_cols: usize, rows: Vec<Vec<usize>>) -> Result<Self>;
+    pub fn to_json_string(&self) -> String;
+}
+```
+
+API notes:
+
+- `new(...)` owns validation and is the only fallible step.
+- `to_json_string()` is infallible because a constructed value is already
+  validated.
+- the JSON output must be canonical and compact, matching the fixture layout
+  without extra whitespace.
+- the wrapper is intentionally narrow and does not yet expose file I/O helpers.
+
+## Validation Rules
+
+`SparseRowsMatrix::new(...)` should enforce only the invariants required by the
+workspace `sparse_rows` contract:
+
+1. Every support entry in every row must be `< num_cols`.
+2. Every row must be strictly increasing.
+3. Strictly increasing rows imply duplicate-free rows, so no separate runtime
+   deduplication step should occur.
+
+Chosen non-rules:
+
+- no cross-row uniqueness checks
+- no CSS orthogonality checks
+- no logical-basis checks
+- no runtime sorting or repair of malformed rows
+
+If input rows are malformed, construction should fail. The type should not
+quietly normalize bad inputs.
+
+## Error Handling
+
+Sparse-row validation should stay in the existing `QecError` enum. Add two new
+variants with enough detail for precise tests and debugging:
+
+```rust
+QecError::DuplicateSparseRowSupport { row: usize, support: usize }
+QecError::SparseRowSupportOutOfRange {
+    row: usize,
+    support: usize,
+    num_cols: usize,
+}
+```
+
+Behavioral expectations:
+
+- duplicate detection should report the row index and offending support
+- out-of-range detection should report the row index, offending support, and
+  declared width
+- the constructor should fail fast on the first invalid row entry
+
+These errors are for user-provided or caller-provided row supports. They are
+not specific to built-in Steane.
+
+## Data Flow
+
+The positive path for built-in export should be:
+
+1. `built_in_css_checks("steane")` returns canonical row supports.
+2. The caller selects exactly one matrix: `hx` or `hz`.
+3. `SparseRowsMatrix::new(checks.num_cols, selected_rows)` validates the data.
+4. `to_json_string()` emits:
+
+```json
+{"format":"sparse_rows","num_cols":N,"rows":[...]}
+```
+
+This keeps the issue aligned with the required input/output contract:
+
+- input: one built-in CSS matrix
+- output: one JSON document
+
+It also avoids widening the scope into an aggregate export format.
+
+## Testing And Verification
+
+Add `qec-code/tests/css_export.rs` with two top-level tests named exactly as
+the issue requests.
+
+### 1. `steane_sparse_rows_json_matches_workspace_fixtures`
+
+This test should:
+
+- call `built_in_css_checks("steane")`
+- export `hx` through `SparseRowsMatrix`
+- export `hz` through `SparseRowsMatrix`
+- read `rsinter/tests/fixtures/css/steane_hx.json`
+- read `rsinter/tests/fixtures/css/steane_hz.json`
+- compare exported strings to fixture contents byte-for-byte
+
+This is the shared baseline proving that `qec-code` matches the existing
+workspace contract exactly.
+
+### 2. `sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports`
+
+This test should construct two invalid matrices:
+
+- one with a duplicate support within a row, such as `rows = vec![vec![0, 0]]`
+- one with an out-of-range support, such as `rows = vec![vec![3]]` for
+  `num_cols = 3`
+
+It should assert the exact `QecError` variants for each case.
+
+### Verification command
+
+Acceptance is the issue-provided command:
+
+```text
+cargo test -p qec-code --test css_export steane_sparse_rows_json_matches_workspace_fixtures sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports
+```
+
+Passing this command proves:
+
+1. built-in Steane exports match the workspace fixtures exactly
+2. malformed sparse-row supports are rejected, so the positive test cannot pass
+   by accident on unchecked input
+
+## Scope Check
+
+This design is intentionally small enough for one implementation pass:
+
+- one new wrapper type
+- two new error variants
+- one focused integration test file
+
+It does not require CLI design, cross-crate API design, or a new serialization
+framework.

--- a/docs/superpowers/specs/2026-06-15-built-in-css-sparse-rows-export-design.md
+++ b/docs/superpowers/specs/2026-06-15-built-in-css-sparse-rows-export-design.md
@@ -185,8 +185,9 @@ API notes:
 - `new(...)` owns validation and is the only fallible step.
 - `to_json_string()` is infallible because a constructed value is already
   validated.
-- the JSON output must be canonical and compact, matching the fixture layout
-  without extra whitespace.
+- the JSON output must be canonical and compact, matching the fixture document
+  bytes used by the workspace tests. For the current Steane fixtures, that
+  includes the trailing newline present on disk.
 - the wrapper is intentionally narrow and does not yet expose file I/O helpers.
 
 ## Validation Rules
@@ -241,11 +242,14 @@ The positive path for built-in export should be:
 1. `built_in_css_checks("steane")` returns canonical row supports.
 2. The caller selects exactly one matrix: `hx` or `hz`.
 3. `SparseRowsMatrix::new(checks.num_cols, selected_rows)` validates the data.
-4. `to_json_string()` emits:
+4. `to_json_string()` emits the fixture-matching document text:
 
 ```json
 {"format":"sparse_rows","num_cols":N,"rows":[...]}
 ```
+
+The current workspace fixtures store that JSON document with a trailing newline,
+so byte-for-byte fixture parity includes that newline.
 
 This keeps the issue aligned with the required input/output contract:
 

--- a/docs/superpowers/specs/2026-06-15-built-in-css-sparse-rows-export-design.md
+++ b/docs/superpowers/specs/2026-06-15-built-in-css-sparse-rows-export-design.md
@@ -192,12 +192,12 @@ API notes:
 ## Validation Rules
 
 `SparseRowsMatrix::new(...)` should enforce only the invariants required by the
-workspace `sparse_rows` contract:
+workspace `sparse_rows` contract for this issue:
 
 1. Every support entry in every row must be `< num_cols`.
-2. Every row must be strictly increasing.
-3. Strictly increasing rows imply duplicate-free rows, so no separate runtime
-   deduplication step should occur.
+2. No support entry may appear more than once within a row.
+3. Row order must be preserved exactly as provided; the wrapper must not sort,
+   normalize, or otherwise repair input rows.
 
 Chosen non-rules:
 
@@ -205,6 +205,7 @@ Chosen non-rules:
 - no CSS orthogonality checks
 - no logical-basis checks
 - no runtime sorting or repair of malformed rows
+- no extra row-order canonicalization rule beyond preserving the caller's input
 
 If input rows are malformed, construction should fail. The type should not
 quietly normalize bad inputs.

--- a/qec-code/src/css.rs
+++ b/qec-code/src/css.rs
@@ -29,7 +29,7 @@ impl SparseRowsMatrix {
             rows: &self.rows,
         })
         .expect("validated sparse rows matrix should always serialize");
-        format!("{json}\n")
+        json
     }
 }
 
@@ -65,6 +65,10 @@ impl CssCode {
 }
 
 fn validate_sparse_rows(num_cols: usize, rows: &[Vec<usize>]) -> Result<()> {
+    if num_cols == 0 {
+        return Err(QecError::InvalidSparseRowsWidth { num_cols });
+    }
+
     for (row_index, row) in rows.iter().enumerate() {
         let mut seen = std::collections::BTreeSet::new();
         for &support in row {

--- a/qec-code/src/css.rs
+++ b/qec-code/src/css.rs
@@ -1,6 +1,37 @@
 use crate::Pauli;
 use crate::code::StabilizerCode;
 use crate::error::{QecError, Result};
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SparseRowsMatrix {
+    num_cols: usize,
+    rows: Vec<Vec<usize>>,
+}
+
+impl SparseRowsMatrix {
+    pub fn new(num_cols: usize, rows: Vec<Vec<usize>>) -> Result<Self> {
+        validate_sparse_rows(num_cols, &rows)?;
+        Ok(Self { num_cols, rows })
+    }
+
+    pub fn to_json_string(&self) -> String {
+        #[derive(Serialize)]
+        struct SparseRowsMatrixJson<'a> {
+            format: &'static str,
+            num_cols: usize,
+            rows: &'a [Vec<usize>],
+        }
+
+        let json = serde_json::to_string(&SparseRowsMatrixJson {
+            format: "sparse_rows",
+            num_cols: self.num_cols,
+            rows: &self.rows,
+        })
+        .expect("validated sparse rows matrix should always serialize");
+        format!("{json}\n")
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CssCode {
@@ -31,6 +62,28 @@ impl CssCode {
     pub fn code(&self) -> &StabilizerCode {
         &self.code
     }
+}
+
+fn validate_sparse_rows(num_cols: usize, rows: &[Vec<usize>]) -> Result<()> {
+    for (row_index, row) in rows.iter().enumerate() {
+        let mut seen = std::collections::BTreeSet::new();
+        for &support in row {
+            if support >= num_cols {
+                return Err(QecError::SparseRowSupportOutOfRange {
+                    row: row_index,
+                    support,
+                    num_cols,
+                });
+            }
+            if !seen.insert(support) {
+                return Err(QecError::DuplicateSparseRowSupport {
+                    row: row_index,
+                    support,
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 fn shared_width(hx: &[Vec<u8>], hz: &[Vec<u8>]) -> Result<usize> {

--- a/qec-code/src/error.rs
+++ b/qec-code/src/error.rs
@@ -8,6 +8,8 @@ pub enum QecError {
     InvalidSymplecticRowWidth { width: usize },
     #[error("non-binary matrix entry {value} at row {row}, column {col}")]
     InvalidBinaryEntry { row: usize, col: usize, value: u8 },
+    #[error("invalid sparse-rows width: {num_cols}")]
+    InvalidSparseRowsWidth { num_cols: usize },
     #[error("duplicate sparse-row support {support} in row {row}")]
     DuplicateSparseRowSupport { row: usize, support: usize },
     #[error("out-of-range sparse-row support {support} in row {row} for width {num_cols}")]

--- a/qec-code/src/error.rs
+++ b/qec-code/src/error.rs
@@ -8,6 +8,14 @@ pub enum QecError {
     InvalidSymplecticRowWidth { width: usize },
     #[error("non-binary matrix entry {value} at row {row}, column {col}")]
     InvalidBinaryEntry { row: usize, col: usize, value: u8 },
+    #[error("duplicate sparse-row support {support} in row {row}")]
+    DuplicateSparseRowSupport { row: usize, support: usize },
+    #[error("out-of-range sparse-row support {support} in row {row} for width {num_cols}")]
+    SparseRowSupportOutOfRange {
+        row: usize,
+        support: usize,
+        num_cols: usize,
+    },
     #[error("invalid Pauli width: x has {x_width} bits, z has {z_width}")]
     InvalidPauliWidth { x_width: usize, z_width: usize },
     #[error("non-binary Pauli bit {value} in {which} support at index {index}")]

--- a/qec-code/tests/code.rs
+++ b/qec-code/tests/code.rs
@@ -1,6 +1,6 @@
 use qec_code::codes::built_in_css::built_in_css_checks;
 use qec_code::codes::steane::Steane;
-use qec_code::css::CssCode;
+use qec_code::css::{CssCode, SparseRowsMatrix};
 use qec_code::{Pauli, QecError, StabilizerCode};
 
 fn assert_strictly_increasing_rows(rows: &[Vec<usize>]) {
@@ -123,6 +123,19 @@ fn built_in_css_registry_exposes_steane_checks() {
     assert_eq!(checks.hz, checks.hx);
     assert_strictly_increasing_rows(&checks.hx);
     assert_strictly_increasing_rows(&checks.hz);
+}
+
+#[test]
+fn sparse_rows_matrix_serializes_steane_supports() {
+    let checks = built_in_css_checks("steane").unwrap();
+    let text = SparseRowsMatrix::new(checks.num_cols, checks.hx.clone())
+        .unwrap()
+        .to_json_string();
+
+    assert_eq!(
+        text,
+        "{\"format\":\"sparse_rows\",\"num_cols\":7,\"rows\":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}\n"
+    );
 }
 
 #[test]

--- a/qec-code/tests/code.rs
+++ b/qec-code/tests/code.rs
@@ -134,7 +134,7 @@ fn sparse_rows_matrix_serializes_steane_supports() {
 
     assert_eq!(
         text,
-        "{\"format\":\"sparse_rows\",\"num_cols\":7,\"rows\":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}\n"
+        "{\"format\":\"sparse_rows\",\"num_cols\":7,\"rows\":[[0,3,5,6],[1,3,4,6],[2,4,5,6]]}"
     );
 }
 

--- a/qec-code/tests/css_export.rs
+++ b/qec-code/tests/css_export.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+
+use qec_code::codes::built_in_css::built_in_css_checks;
+use qec_code::css::SparseRowsMatrix;
+use qec_code::QecError;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn read_fixture(rel_path: &str) -> String {
+    std::fs::read_to_string(workspace_root().join(rel_path))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel_path}: {err}"))
+}
+
+#[test]
+fn steane_sparse_rows_json_matches_workspace_fixtures() {
+    let checks = built_in_css_checks("steane").unwrap();
+
+    let hx = SparseRowsMatrix::new(checks.num_cols, checks.hx.clone())
+        .unwrap()
+        .to_json_string();
+    let hz = SparseRowsMatrix::new(checks.num_cols, checks.hz.clone())
+        .unwrap()
+        .to_json_string();
+
+    let expected_hx = read_fixture("rsinter/tests/fixtures/css/steane_hx.json");
+    let expected_hz = read_fixture("rsinter/tests/fixtures/css/steane_hz.json");
+
+    assert_eq!(hx, expected_hx);
+    assert_eq!(hz, expected_hz);
+}
+
+#[test]
+fn sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports() {
+    assert_eq!(
+        SparseRowsMatrix::new(3, vec![vec![0, 0]]),
+        Err(QecError::DuplicateSparseRowSupport { row: 0, support: 0 })
+    );
+
+    assert_eq!(
+        SparseRowsMatrix::new(3, vec![vec![3]]),
+        Err(QecError::SparseRowSupportOutOfRange {
+            row: 0,
+            support: 3,
+            num_cols: 3,
+        })
+    );
+}

--- a/qec-code/tests/css_export.rs
+++ b/qec-code/tests/css_export.rs
@@ -47,3 +47,15 @@ fn sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports() {
         })
     );
 }
+
+#[test]
+fn sparse_rows_matrix_preserves_row_order_without_normalizing() {
+    let text = SparseRowsMatrix::new(5, vec![vec![3, 1], vec![4, 0]])
+        .unwrap()
+        .to_json_string();
+
+    assert_eq!(
+        text,
+        "{\"format\":\"sparse_rows\",\"num_cols\":5,\"rows\":[[3,1],[4,0]]}\n"
+    );
+}

--- a/qec-code/tests/css_export.rs
+++ b/qec-code/tests/css_export.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
+use qec_code::QecError;
 use qec_code::codes::built_in_css::built_in_css_checks;
 use qec_code::css::SparseRowsMatrix;
-use qec_code::QecError;
 
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
@@ -27,8 +27,8 @@ fn steane_sparse_rows_json_matches_workspace_fixtures() {
     let expected_hx = read_fixture("rsinter/tests/fixtures/css/steane_hx.json");
     let expected_hz = read_fixture("rsinter/tests/fixtures/css/steane_hz.json");
 
-    assert_eq!(hx, expected_hx);
-    assert_eq!(hz, expected_hz);
+    assert_eq!(format!("{hx}\n"), expected_hx);
+    assert_eq!(format!("{hz}\n"), expected_hz);
 }
 
 #[test]
@@ -49,6 +49,14 @@ fn sparse_rows_matrix_rejects_duplicate_or_out_of_range_supports() {
 }
 
 #[test]
+fn sparse_rows_matrix_rejects_zero_width() {
+    assert_eq!(
+        SparseRowsMatrix::new(0, vec![]),
+        Err(QecError::InvalidSparseRowsWidth { num_cols: 0 })
+    );
+}
+
+#[test]
 fn sparse_rows_matrix_preserves_row_order_without_normalizing() {
     let text = SparseRowsMatrix::new(5, vec![vec![3, 1], vec![4, 0]])
         .unwrap()
@@ -56,6 +64,6 @@ fn sparse_rows_matrix_preserves_row_order_without_normalizing() {
 
     assert_eq!(
         text,
-        "{\"format\":\"sparse_rows\",\"num_cols\":5,\"rows\":[[3,1],[4,0]]}\n"
+        "{\"format\":\"sparse_rows\",\"num_cols\":5,\"rows\":[[3,1],[4,0]]}"
     );
 }


### PR DESCRIPTION
## Summary
- add `SparseRowsMatrix` in `qec-code` for validated sparse-row JSON export
- add typed sparse-row support errors and focused `qec-code` coverage for Steane fixture parity
- document the issue-55 design/plan and lock in the current fixture newline + no-normalization contract

## Test Plan
- [x] `cargo test -p qec-code`
- [x] `cargo test -p qec-code --test css_export`
- [x] `cargo test -p qec-code --test code`